### PR TITLE
Fix write crashes on EPUBs with None metadata, guide, and deep TOC

### DIFF
--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -130,19 +130,55 @@ def _fix_toc_uids(book: epub.EpubBook) -> None:
     """Assign uids to TOC Link items that are missing them.
 
     ebooklib sometimes reads TOC entries without preserving the uid attribute,
-    which causes lxml to fail when writing the NCX. This assigns a stable uid
-    based on the link's href.
+    which causes lxml to fail when writing the NCX. This walks the TOC tree
+    at arbitrary depth and assigns stable uids to any Link missing one.
     """
-    for i, item in enumerate(book.toc):
+    _fix_toc_items(book.toc, prefix="navpoint")
+
+
+def _fix_toc_items(items: list, prefix: str) -> None:
+    """Recursively fix uids on TOC items at any nesting depth."""
+    for i, item in enumerate(items):
         if isinstance(item, epub.Link) and not item.uid:
-            item.uid = f"navpoint-{i}"
+            item.uid = f"{prefix}-{i}"
         elif isinstance(item, tuple) and len(item) == 2:
             section, children = item
             if isinstance(section, epub.Link) and not section.uid:
-                section.uid = f"navpoint-section-{i}"
-            for j, child in enumerate(children):
-                if isinstance(child, epub.Link) and not child.uid:
-                    child.uid = f"navpoint-{i}-{j}"
+                section.uid = f"{prefix}-section-{i}"
+            _fix_toc_items(children, prefix=f"{prefix}-{i}")
+
+
+def _scrub_none_metadata(book: epub.EpubBook) -> None:
+    """Remove metadata entries with None values that would crash lxml.
+
+    ebooklib preserves OPF meta tags like <meta name="cover" content="..."/>
+    as (None, {attrs}) tuples. lxml rejects None when serializing to XML.
+    """
+    for ns in book.metadata:
+        for name in list(book.metadata[ns]):
+            entries = book.metadata[ns][name]
+            cleaned = [(v, a) for v, a in entries if v is not None]
+            if len(cleaned) < len(entries):
+                logger.debug(
+                    "Scrubbed %d None metadata entries from %s/%s",
+                    len(entries) - len(cleaned), ns, name,
+                )
+                book.metadata[ns][name] = cleaned
+
+
+def _scrub_none_guide(book: epub.EpubBook) -> None:
+    """Remove guide entries with None href/type that would crash lxml.
+
+    Some EPUBs contain empty guide references with all-None fields.
+    """
+    original_len = len(book.guide)
+    book.guide = [
+        entry for entry in book.guide
+        if entry.get("href") is not None and entry.get("type") is not None
+    ]
+    removed = original_len - len(book.guide)
+    if removed:
+        logger.debug("Scrubbed %d empty guide entries", removed)
 
 
 def _clear_dc_metadata(book: epub.EpubBook, name: str) -> None:
@@ -196,6 +232,8 @@ def write_epub_metadata(path: Path, metadata: BookMetadata) -> None:
         _set_dc_metadata(book, "description", metadata.description)
 
     _fix_toc_uids(book)
+    _scrub_none_metadata(book)
+    _scrub_none_guide(book)
 
     try:
         epub.write_epub(str(path), book)

--- a/tests/unit/test_epub_writer.py
+++ b/tests/unit/test_epub_writer.py
@@ -87,6 +87,76 @@ class TestWriteEpubMetadata:
         with pytest.raises(EpubReadError):
             write_epub_metadata(corrupt_epub, meta)
 
+    def test_write_survives_none_opf_metadata(self, sample_epub: Path) -> None:
+        """EPUBs with None values in OPF metadata (e.g. cover meta) don't crash on write.
+
+        ebooklib reads <meta name="cover" content="cover-image"/> as
+        (None, {'content': 'cover-image', 'name': 'cover'}). The None value
+        causes lxml to crash during serialization.
+        """
+        from ebooklib import epub
+
+        # Inject a None-valued OPF meta entry (mimics the cover meta tag)
+        book = epub.read_epub(str(sample_epub))
+        opf_ns = "http://www.idpf.org/2007/opf"
+        book.metadata.setdefault(opf_ns, {})
+        book.metadata[opf_ns]["meta"] = [(None, {"name": "cover", "content": "cover-image"})]
+
+        # Write a temp copy with the poisoned metadata
+        from bookery.formats.epub import _fix_toc_uids
+        _fix_toc_uids(book)
+        epub.write_epub(str(sample_epub), book)
+
+        # Our write should scrub the None and succeed
+        updated = BookMetadata(title="Survives None")
+        write_epub_metadata(sample_epub, updated)
+
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.title == "Survives None"
+
+    def test_write_survives_deeply_nested_toc(self, sample_epub: Path) -> None:
+        """EPUBs with 3+ levels of TOC nesting don't crash on write."""
+        from unittest.mock import patch
+        from ebooklib import epub
+
+        # Read the EPUB, then monkey-patch its TOC with deep nesting
+        # so write_epub_metadata encounters it during our write path
+        original_read = epub.read_epub
+
+        def read_and_poison(*args, **kwargs):
+            book = original_read(*args, **kwargs)
+            inner_link = epub.Link("ch1.html", "Chapter 1", None)
+            inner_section = (epub.Section("Part A"), [inner_link])
+            outer_section = (epub.Section("Book I"), [inner_section])
+            book.toc = [outer_section]
+            return book
+
+        with patch("bookery.formats.epub.epub.read_epub", side_effect=read_and_poison):
+            updated = BookMetadata(title="Deep TOC")
+            write_epub_metadata(sample_epub, updated)
+
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.title == "Deep TOC"
+
+    def test_write_survives_none_guide_entries(self, sample_epub: Path) -> None:
+        """EPUBs with None-valued guide entries don't crash on write."""
+        from unittest.mock import patch
+        from ebooklib import epub
+
+        original_read = epub.read_epub
+
+        def read_and_poison(*args, **kwargs):
+            book = original_read(*args, **kwargs)
+            book.guide.append({"href": None, "title": None, "type": None})
+            return book
+
+        with patch("bookery.formats.epub.epub.read_epub", side_effect=read_and_poison):
+            updated = BookMetadata(title="Survives Guide None")
+            write_epub_metadata(sample_epub, updated)
+
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.title == "Survives Guide None"
+
     def test_round_trip_preserves_unmodified_fields(self, sample_epub: Path) -> None:
         """Fields not in the update are preserved from the original EPUB."""
         original = read_epub_metadata(sample_epub)


### PR DESCRIPTION
## Summary
Fixes three variants of `Argument must be bytes or unicode, got 'NoneType'` that caused 19 write failures in a 265-book batch run.

## Root Causes
1. **Deep TOC nesting** — `_fix_toc_uids` only handled 2 levels; some EPUBs (e.g. Fluent Forever) have 3+
2. **OPF meta None values** — `<meta name="cover" content="..."/>` stored as `(None, {attrs})` by ebooklib
3. **Empty guide entries** — `{'href': None, 'title': None, 'type': None}` in the guide reference list

## Changes
- **`src/bookery/formats/epub.py`**: Recursive `_fix_toc_items`, `_scrub_none_metadata`, `_scrub_none_guide`
- **`tests/unit/test_epub_writer.py`**: 3 new tests for each crash variant
- Verified against the actual Fluent Forever EPUB that triggered the bug

## Testing
- [x] 641 tests pass
- [x] Real EPUB that previously crashed now writes successfully

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)