### PR TITLE
Fix verification failures: whitespace tolerance and read-back resilience

### DIFF
--- a/src/bookery/core/pipeline.py
+++ b/src/bookery/core/pipeline.py
@@ -52,10 +52,10 @@ def _verify_write(dest: Path, metadata: BookMetadata) -> list[FieldVerification]
         passed=metadata.title == read_back.title,
     ))
 
-    # Authors — sorted comparison for order independence
+    # Authors — sorted comparison for order independence, stripped for whitespace tolerance
     if metadata.authors:
-        expected_sorted = ", ".join(sorted(metadata.authors))
-        actual_sorted = ", ".join(sorted(read_back.authors))
+        expected_sorted = ", ".join(sorted(a.strip() for a in metadata.authors))
+        actual_sorted = ", ".join(sorted(a.strip() for a in read_back.authors))
         verifications.append(FieldVerification(
             field="authors",
             expected=expected_sorted,
@@ -141,9 +141,11 @@ def apply_metadata_safely(
     try:
         verifications = _verify_write(dest, metadata)
     except (OSError, EpubReadError) as exc:
-        logger.error("apply_metadata_safely: verify read-back failed %s: %s", dest, exc)
-        _cleanup_dest(dest)
-        return WriteResult(path=None, success=False, error=str(exc))
+        # Read-back failed (e.g. missing archive entry from Kobo-modified EPUBs).
+        # The write itself succeeded, so keep the file and skip verification.
+        logger.warning("apply_metadata_safely: verify read-back failed %s: %s", dest, exc)
+        record_processed(output_dir, source.name)
+        return WriteResult(path=dest, success=True, verified_fields=[])
 
     # Check if all fields passed
     if not all(v.passed for v in verifications):

--- a/tests/unit/test_safe_write.py
+++ b/tests/unit/test_safe_write.py
@@ -186,10 +186,10 @@ class TestWriteBackVerification:
         assert result.success is False
         assert not list(output_dir.rglob("*.epub"))
 
-    def test_verification_readback_failure_cleans_up(
+    def test_verification_readback_failure_keeps_file(
         self, sample_epub: Path, tmp_path: Path
     ) -> None:
-        """If read-back raises, the copy is deleted."""
+        """If read-back raises, the file is kept (write succeeded, verify skipped)."""
         output_dir = tmp_path / "output"
         output_dir.mkdir()
         metadata = BookMetadata(title="Test")
@@ -200,9 +200,10 @@ class TestWriteBackVerification:
         ):
             result = apply_metadata_safely(sample_epub, metadata, output_dir)
 
-        assert result.success is False
-        assert result.error is not None
-        assert not list(output_dir.rglob("*.epub"))
+        assert result.success is True
+        assert result.path is not None
+        assert result.path.exists()
+        assert result.verified_fields == []
 
     def test_only_written_fields_are_verified(
         self, sample_epub: Path, tmp_path: Path
@@ -252,3 +253,35 @@ class TestWriteBackVerification:
 
         lang_field = next(v for v in result.verified_fields if v.field == "language")
         assert lang_field.passed is True
+
+    def test_author_whitespace_tolerance(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        """Author verification strips whitespace before comparing."""
+        output_dir = tmp_path / "output"
+        metadata = BookMetadata(
+            title="Test",
+            authors=["Neil Rackham       "],
+        )
+
+        result = apply_metadata_safely(sample_epub, metadata, output_dir)
+
+        authors_field = next(v for v in result.verified_fields if v.field == "authors")
+        assert authors_field.passed is True
+
+    def test_verify_readback_failure_keeps_file(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        """If read-back fails (e.g. missing archive entry), keep the file and warn."""
+        output_dir = tmp_path / "output"
+        metadata = BookMetadata(title="Test", authors=["Author"])
+
+        with patch(
+            "bookery.core.pipeline.read_epub_metadata",
+            side_effect=EpubReadError("There is no item named 'js/kobo.js' in the archive"),
+        ):
+            result = apply_metadata_safely(sample_epub, metadata, output_dir)
+
+        assert result.success is True
+        assert result.path is not None
+        assert result.path.exists()


### PR DESCRIPTION
## Summary
Two fixes for write verification that caused files to be deleted even though the write succeeded.

## Bug 1: Author whitespace mismatch
Open Library sometimes returns author names with trailing spaces (e.g. `"Neil Rackham       "`). After writing to EPUB and reading back, the whitespace is stripped. Verification did exact comparison and failed.

**Fix**: Strip whitespace on both sides before comparing.

## Bug 2: Read-back failure deletes written file
Some EPUBs (Kobo-modified) reference files like `js/kobo.js` that don't exist in the archive. The write succeeds, but read-back for verification crashes. Previously this deleted the output file.

**Fix**: Read-back failures now keep the file and skip verification with a warning. The metadata was written successfully — no reason to discard the work.

## Testing
- [x] 643 tests pass
- [x] 2 new tests for whitespace tolerance and read-back resilience
- [x] Updated existing test to match new keep-on-readback-failure behavior

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)