### PR TITLE
Fix None uid crash on Calibre-exported EPUBs

### DIFF
--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -153,6 +153,9 @@ def _scrub_none_metadata(book: epub.EpubBook) -> None:
 
     ebooklib preserves OPF meta tags like <meta name="cover" content="..."/>
     as (None, {attrs}) tuples. lxml rejects None when serializing to XML.
+
+    If scrubbing removes the book's uid identifier, a new UUID is generated
+    to prevent ebooklib from crashing when writing the NCX.
     """
     for ns in book.metadata:
         for name in list(book.metadata[ns]):
@@ -164,6 +167,14 @@ def _scrub_none_metadata(book: epub.EpubBook) -> None:
                     len(entries) - len(cleaned), ns, name,
                 )
                 book.metadata[ns][name] = cleaned
+
+    # If scrubbing removed the uid identifier, generate a replacement
+    if book.uid is None:
+        import uuid
+        new_uid = str(uuid.uuid4())
+        book.set_unique_metadata("DC", "identifier", new_uid, {"id": "bookery-uid"})
+        book.uid = new_uid
+        logger.debug("Generated replacement uid: %s", new_uid)
 
 
 def _scrub_none_guide(book: epub.EpubBook) -> None:

--- a/tests/unit/test_epub_writer.py
+++ b/tests/unit/test_epub_writer.py
@@ -87,6 +87,28 @@ class TestWriteEpubMetadata:
         with pytest.raises(EpubReadError):
             write_epub_metadata(corrupt_epub, meta)
 
+    def test_write_survives_none_uid_identifier(self, sample_epub: Path) -> None:
+        """EPUBs where the uid identifier has a None value get a replacement uid."""
+        from unittest.mock import patch
+        from ebooklib import epub
+
+        original_read = epub.read_epub
+
+        def read_and_poison(*args, **kwargs):
+            book = original_read(*args, **kwargs)
+            # Simulate a Calibre EPUB with None uid identifier
+            dc_ns = "http://purl.org/dc/elements/1.1/"
+            book.metadata[dc_ns]["identifier"] = [(None, {"id": "uuid_id"})]
+            book.uid = None
+            return book
+
+        with patch("bookery.formats.epub.epub.read_epub", side_effect=read_and_poison):
+            updated = BookMetadata(title="Survives None UID")
+            write_epub_metadata(sample_epub, updated)
+
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.title == "Survives None UID"
+
     def test_write_survives_none_opf_metadata(self, sample_epub: Path) -> None:
         """EPUBs with None values in OPF metadata (e.g. cover meta) don't crash on write.
 


### PR DESCRIPTION
## Summary
Calibre-exported EPUBs can have a DC identifier with `value=None` that serves as the book uid. Our `_scrub_none_metadata` correctly removes the None entry, but this left `book.uid` as `None`, crashing ebooklib when writing the NCX header.

## Fix
After scrubbing None metadata, check if `book.uid` was lost. If so, generate a UUID replacement and set it as the new uid identifier.

## Remaining known issue
The "Document is empty" error (e.g. Hank Green's EPUB) is a corrupt EPUB with empty HTML items inside the archive. This is unfixable without content repair and is already handled gracefully by the pipeline error path.

## Testing
- [x] 644 tests pass
- [x] New test for None uid replacement
- [x] Verified against real Start With Why EPUB

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)