### PR TITLE
Wire up bookery tui command with minimal Textual app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "rich>=13.0",
+    "textual>=0.89",
     "wordninja>=2.0",
 ]
 
@@ -29,6 +30,7 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "pytest-asyncio>=1.3.0",
     "ruff>=0.8",
 ]
 

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -16,6 +16,7 @@ from bookery.cli.commands import (
     rematch_cmd,
     search_cmd,
     tag_cmd,
+    tui_cmd,
     verify_cmd,
 )
 
@@ -47,4 +48,5 @@ cli.add_command(match_cmd.match)
 cli.add_command(rematch_cmd.rematch)
 cli.add_command(search_cmd.search)
 cli.add_command(tag_cmd.tag)
+cli.add_command(tui_cmd.tui)
 cli.add_command(verify_cmd.verify)

--- a/src/bookery/cli/commands/tui_cmd.py
+++ b/src/bookery/cli/commands/tui_cmd.py
@@ -1,0 +1,30 @@
+# ABOUTME: The `bookery tui` command for launching the interactive terminal UI.
+# ABOUTME: Checks that a library database exists, then starts the Textual app.
+
+from pathlib import Path
+
+import click
+
+from bookery.cli.options import db_option
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import DEFAULT_DB_PATH, open_library
+from bookery.tui.app import BookeryApp
+
+
+@click.command("tui")
+@db_option
+def tui(db_path: Path | None) -> None:
+    """Launch the interactive terminal UI for browsing the library."""
+    resolved = db_path or DEFAULT_DB_PATH
+
+    if not resolved.exists():
+        click.echo(f"No library found at {resolved}. Run 'bookery import' first.")
+        raise SystemExit(1)
+
+    conn = open_library(resolved)
+    catalog = LibraryCatalog(conn)
+
+    try:
+        BookeryApp(catalog=catalog).run()
+    finally:
+        conn.close()

--- a/src/bookery/tui/__init__.py
+++ b/src/bookery/tui/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: TUI package for Bookery, built on Textual.
+# ABOUTME: Provides the interactive terminal interface for browsing and managing the library.

--- a/src/bookery/tui/app.py
+++ b/src/bookery/tui/app.py
@@ -1,0 +1,27 @@
+# ABOUTME: The main Textual application for Bookery's TUI.
+# ABOUTME: Provides an interactive terminal interface for browsing the library catalog.
+
+from typing import ClassVar
+
+from textual.app import App
+from textual.binding import Binding, BindingType
+from textual.widgets import Static
+
+from bookery.db.catalog import LibraryCatalog
+
+
+class BookeryApp(App):
+    """Bookery's interactive terminal UI."""
+
+    TITLE = "Bookery"
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, catalog: LibraryCatalog, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.catalog = catalog
+
+    def compose(self):
+        yield Static("Bookery")

--- a/tests/e2e/test_tui_e2e.py
+++ b/tests/e2e/test_tui_e2e.py
@@ -1,0 +1,62 @@
+# ABOUTME: End-to-end tests for the `bookery tui` command.
+# ABOUTME: Verifies --help output, missing DB error, and headless app launch.
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.tui.app import BookeryApp
+
+
+class TestTuiE2E:
+    """End-to-end tests for the tui command."""
+
+    def test_help_shows_tui_command(self) -> None:
+        """bookery tui --help shows command documentation."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["tui", "--help"])
+        assert result.exit_code == 0
+        assert "Launch the interactive terminal UI" in result.output
+
+    def test_no_db_gives_clean_error(self, tmp_path) -> None:
+        """bookery tui with no DB gives a user-friendly error, no traceback."""
+        nonexistent = tmp_path / "missing" / "library.db"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["tui", "--db", str(nonexistent)])
+        assert result.exit_code == 1
+        assert "No library found" in result.output
+        # No Python traceback in output
+        assert "Traceback" not in result.output
+
+    def test_with_db_launches_app(self, tmp_path) -> None:
+        """bookery tui with a valid DB launches the Textual app."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        conn.close()
+
+        runner = CliRunner()
+        with patch("bookery.cli.commands.tui_cmd.BookeryApp") as mock_app_cls:
+            mock_app_cls.return_value.run.return_value = None
+            result = runner.invoke(cli, ["tui", "--db", str(db_path)])
+
+        assert result.exit_code == 0
+        # Verify the app was instantiated with a LibraryCatalog
+        call_kwargs = mock_app_cls.call_args
+        assert isinstance(call_kwargs.kwargs["catalog"], LibraryCatalog)
+
+    @pytest.mark.asyncio
+    async def test_app_starts_headless_and_quits(self, tmp_path) -> None:
+        """The Textual app starts in headless mode and quits with 'q'."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            await pilot.press("q")
+
+        conn.close()

--- a/tests/integration/test_tui_cli.py
+++ b/tests/integration/test_tui_cli.py
@@ -1,0 +1,30 @@
+# ABOUTME: Integration tests for the `bookery tui` CLI command.
+# ABOUTME: Tests command invocation with a real database file.
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.connection import open_library
+
+
+class TestTuiIntegration:
+    """Integration tests for tui command with real DB."""
+
+    def test_with_existing_db_does_not_crash(self, tmp_path) -> None:
+        """With a real DB file, the command invokes the app without crashing."""
+        db_path = tmp_path / "library.db"
+        # Create the DB so it exists
+        conn = open_library(db_path)
+        conn.close()
+
+        runner = CliRunner()
+        # Mock BookeryApp.run() to avoid actually launching the TUI
+        with patch("bookery.cli.commands.tui_cmd.BookeryApp") as mock_app_cls:
+            mock_app_cls.return_value.run.return_value = None
+            result = runner.invoke(cli, ["tui", "--db", str(db_path)])
+
+        assert result.exit_code == 0
+        mock_app_cls.assert_called_once()
+        mock_app_cls.return_value.run.assert_called_once()

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1,0 +1,42 @@
+# ABOUTME: Unit tests for the BookeryApp Textual application.
+# ABOUTME: Verifies app instantiation, quit bindings, and clean launch/exit.
+
+import sqlite3
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.tui.app import BookeryApp
+
+
+@pytest.fixture
+def catalog() -> LibraryCatalog:
+    """Create a LibraryCatalog with an in-memory database."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    from bookery.db.schema import SCHEMA_V1
+
+    conn.executescript(SCHEMA_V1)
+    return LibraryCatalog(conn)
+
+
+class TestBookeryAppUnit:
+    """Unit tests for BookeryApp."""
+
+    def test_instantiates_with_catalog(self, catalog: LibraryCatalog) -> None:
+        """App can be created with a LibraryCatalog instance."""
+        app = BookeryApp(catalog=catalog)
+        assert app.catalog is catalog
+
+    def test_has_quit_binding(self, catalog: LibraryCatalog) -> None:
+        """App declares a 'q' key binding for quitting."""
+        app = BookeryApp(catalog=catalog)
+        binding_keys = [b.key for b in app.BINDINGS]
+        assert "q" in binding_keys
+
+    @pytest.mark.asyncio
+    async def test_launches_and_exits_cleanly(self, catalog: LibraryCatalog) -> None:
+        """App launches in headless mode and exits cleanly."""
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            await pilot.press("q")

--- a/tests/unit/test_tui_cmd.py
+++ b/tests/unit/test_tui_cmd.py
@@ -1,0 +1,25 @@
+# ABOUTME: Unit tests for the `bookery tui` CLI command.
+# ABOUTME: Verifies command registration and error handling for missing database.
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+
+
+class TestTuiCommand:
+    """Unit tests for the tui CLI command."""
+
+    def test_tui_registered_in_cli(self) -> None:
+        """The tui command appears in the CLI group."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "tui" in result.output
+
+    def test_missing_db_shows_error(self, tmp_path) -> None:
+        """When no library DB exists, show a friendly error and exit 1."""
+        nonexistent_db = tmp_path / "nope" / "library.db"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["tui", "--db", str(nonexistent_db)])
+        assert result.exit_code == 1
+        assert "No library found" in result.output


### PR DESCRIPTION
## Summary
- Adds `bookery tui` CLI command that checks for an existing library DB and launches a minimal Textual app
- `BookeryApp` receives a `LibraryCatalog` instance, has `q` quit binding, shows empty screen with title
- Friendly error message when no library DB exists

## Changes
- **New**: `src/bookery/tui/` package with `BookeryApp(App)`
- **New**: `src/bookery/cli/commands/tui_cmd.py` — Click command with DB existence check
- **Modified**: `pyproject.toml` — added `textual>=0.89`, `pytest-asyncio` (dev)
- **Modified**: `src/bookery/cli/__init__.py` — registered `tui` command

## Test plan
- [x] Unit tests: app instantiation, quit binding, headless launch/exit (3 tests)
- [x] Unit tests: command registration, missing DB error (2 tests)
- [x] Integration test: real DB with mocked app run (1 test)
- [x] E2E tests: --help, no-DB error, app launch, headless pilot (4 tests)
- [x] 664 tests pass, ruff clean on all new files

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)