### PR TITLE
Add two-pane layout with TCSS styling to TUI (#25)

### DIFF
--- a/src/bookery/tui/app.py
+++ b/src/bookery/tui/app.py
@@ -1,12 +1,15 @@
 # ABOUTME: The main Textual application for Bookery's TUI.
 # ABOUTME: Provides an interactive terminal interface for browsing the library catalog.
 
+from pathlib import Path
 from typing import ClassVar
 
-from textual.app import App
+from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
-from textual.widgets import Static
+from textual.containers import Horizontal, VerticalScroll
+from textual.widgets import Footer, Header, Static
 
+from bookery import __version__
 from bookery.db.catalog import LibraryCatalog
 
 
@@ -14,6 +17,9 @@ class BookeryApp(App):
     """Bookery's interactive terminal UI."""
 
     TITLE = "Bookery"
+    SUB_TITLE = f"v{__version__}"
+
+    CSS_PATH = Path("styles/app.tcss")
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "quit", "Quit"),
@@ -23,5 +29,11 @@ class BookeryApp(App):
         super().__init__(**kwargs)
         self.catalog = catalog
 
-    def compose(self):
-        yield Static("Bookery")
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        with Horizontal():
+            with VerticalScroll(id="book-list", can_focus=True):
+                yield Static("No books loaded")
+            with VerticalScroll(id="book-detail", can_focus=True):
+                yield Static("Select a book to view details")
+        yield Footer()

--- a/src/bookery/tui/styles/__init__.py
+++ b/src/bookery/tui/styles/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Package marker for TUI stylesheets.
+# ABOUTME: Contains TCSS files for the Textual app layout.

--- a/src/bookery/tui/styles/app.tcss
+++ b/src/bookery/tui/styles/app.tcss
@@ -1,0 +1,26 @@
+/* Two-pane layout for Bookery TUI */
+/* Left pane: book list, Right pane: book detail */
+
+Horizontal {
+    height: 1fr;
+}
+
+#book-list {
+    width: 2fr;
+    border: solid $panel;
+    padding: 1 2;
+}
+
+#book-list:focus {
+    border: solid $accent;
+}
+
+#book-detail {
+    width: 3fr;
+    border: solid $panel;
+    padding: 1 2;
+}
+
+#book-detail:focus {
+    border: solid $accent;
+}

--- a/tests/e2e/test_tui_e2e.py
+++ b/tests/e2e/test_tui_e2e.py
@@ -1,5 +1,5 @@
 # ABOUTME: End-to-end tests for the `bookery tui` command.
-# ABOUTME: Verifies --help output, missing DB error, and headless app launch.
+# ABOUTME: Verifies --help output, missing DB error, headless app launch, and two-pane layout.
 
 from unittest.mock import patch
 
@@ -57,6 +57,32 @@ class TestTuiE2E:
 
         app = BookeryApp(catalog=catalog)
         async with app.run_test() as pilot:
+            await pilot.press("q")
+
+        conn.close()
+
+    @pytest.mark.asyncio
+    async def test_app_mounts_with_both_panes(self, tmp_path) -> None:
+        """The Textual app mounts with both book-list and book-detail panes."""
+        from textual.containers import Horizontal
+        from textual.widgets import Footer, Header
+
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            # Verify full layout structure
+            assert len(app.query(Header)) == 1
+            assert len(app.query(Footer)) == 1
+            assert len(app.query(Horizontal)) == 1
+
+            book_list = app.query_one("#book-list")
+            book_detail = app.query_one("#book-detail")
+            assert book_list is not None
+            assert book_detail is not None
+
             await pilot.press("q")
 
         conn.close()

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1,5 +1,5 @@
 # ABOUTME: Unit tests for the BookeryApp Textual application.
-# ABOUTME: Verifies app instantiation, quit bindings, and clean launch/exit.
+# ABOUTME: Verifies app instantiation, quit bindings, layout composition, and focus cycling.
 
 import sqlite3
 
@@ -34,9 +34,120 @@ class TestBookeryAppUnit:
         binding_keys = [b.key for b in app.BINDINGS]
         assert "q" in binding_keys
 
+    def test_title_is_bookery(self, catalog: LibraryCatalog) -> None:
+        """App TITLE is 'Bookery'."""
+        app = BookeryApp(catalog=catalog)
+        assert app.TITLE == "Bookery"
+
+    def test_subtitle_contains_version(self, catalog: LibraryCatalog) -> None:
+        """App SUB_TITLE contains the package version."""
+        from bookery import __version__
+
+        app = BookeryApp(catalog=catalog)
+        assert __version__ in app.SUB_TITLE
+
     @pytest.mark.asyncio
     async def test_launches_and_exits_cleanly(self, catalog: LibraryCatalog) -> None:
         """App launches in headless mode and exits cleanly."""
         app = BookeryApp(catalog=catalog)
         async with app.run_test() as pilot:
             await pilot.press("q")
+
+    @pytest.mark.asyncio
+    async def test_compose_yields_header(self, catalog: LibraryCatalog) -> None:
+        """compose() yields a Header widget."""
+        from textual.widgets import Header
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            headers = app.query(Header)
+            assert len(headers) == 1
+
+    @pytest.mark.asyncio
+    async def test_compose_yields_footer(self, catalog: LibraryCatalog) -> None:
+        """compose() yields a Footer widget."""
+        from textual.widgets import Footer
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            footers = app.query(Footer)
+            assert len(footers) == 1
+
+    @pytest.mark.asyncio
+    async def test_compose_has_book_list_pane(self, catalog: LibraryCatalog) -> None:
+        """compose() includes a widget with id 'book-list'."""
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            book_list = app.query_one("#book-list")
+            assert book_list is not None
+
+    @pytest.mark.asyncio
+    async def test_compose_has_book_detail_pane(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        """compose() includes a widget with id 'book-detail'."""
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            book_detail = app.query_one("#book-detail")
+            assert book_detail is not None
+
+    @pytest.mark.asyncio
+    async def test_book_list_placeholder_text(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        """Left pane shows placeholder text when no books loaded."""
+        from textual.widgets import Static
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            book_list = app.query_one("#book-list")
+            # The Static inside the pane should have placeholder text
+            static = book_list.query_one(Static)
+            assert "No books loaded" in str(static.render())
+
+    @pytest.mark.asyncio
+    async def test_book_detail_placeholder_text(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        """Right pane shows placeholder text."""
+        from textual.widgets import Static
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            book_detail = app.query_one("#book-detail")
+            static = book_detail.query_one(Static)
+            assert "Select a book" in str(static.render())
+
+    @pytest.mark.asyncio
+    async def test_two_panes_inside_horizontal(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        """Both panes are children of a Horizontal container."""
+        from textual.containers import Horizontal
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test():
+            horizontal = app.query_one(Horizontal)
+            children_ids = [child.id for child in horizontal.children]
+            assert "book-list" in children_ids
+            assert "book-detail" in children_ids
+
+    @pytest.mark.asyncio
+    async def test_tab_cycles_focus_between_panes(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        """Pressing Tab cycles focus between the two panes."""
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            # Focus the left pane first
+            book_list = app.query_one("#book-list")
+            book_list.focus()
+            assert app.focused.id == "book-list"
+
+            # Tab should move to the right pane
+            await pilot.press("tab")
+            assert app.focused.id == "book-detail"
+
+            # Tab again should cycle back to the left pane
+            await pilot.press("tab")
+            assert app.focused.id == "book-list"


### PR DESCRIPTION
## Summary
- Replace placeholder `Static("Bookery")` with proper two-pane layout: Header, Horizontal(book-list, book-detail), Footer
- Add TCSS stylesheet with 2fr/3fr split, accent borders on focus
- Tab key cycles focus between panes; version displayed in subtitle

## Test plan
- [x] 9 new unit tests for layout composition, placeholder text, focus cycling
- [x] 1 new e2e test verifying both panes mount
- [x] All 675 tests pass
- [x] ruff clean on all changed files
- [ ] Manual: `bookery tui --db <path>` renders two-pane layout at 80x24

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)