### PR TITLE
Add BookList widget with sorted DataTable and row count (#26)

### DIFF
--- a/src/bookery/tui/app.py
+++ b/src/bookery/tui/app.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Header, Static
 
 from bookery import __version__
 from bookery.db.catalog import LibraryCatalog
+from bookery.tui.widgets.book_list import BookList
 
 
 class BookeryApp(App):
@@ -32,8 +33,11 @@ class BookeryApp(App):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         with Horizontal():
-            with VerticalScroll(id="book-list", can_focus=True):
-                yield Static("No books loaded")
+            yield BookList(id="book-list")
             with VerticalScroll(id="book-detail", can_focus=True):
                 yield Static("Select a book to view details")
         yield Footer()
+
+    def on_mount(self) -> None:
+        records = self.catalog.list_all()
+        self.query_one(BookList).load(records)

--- a/src/bookery/tui/styles/app.tcss
+++ b/src/bookery/tui/styles/app.tcss
@@ -8,11 +8,21 @@ Horizontal {
 #book-list {
     width: 2fr;
     border: solid $panel;
-    padding: 1 2;
 }
 
-#book-list:focus {
+#book-list:focus-within {
     border: solid $accent;
+}
+
+#book-table {
+    height: 1fr;
+}
+
+#row-count {
+    height: 1;
+    dock: bottom;
+    text-style: dim;
+    padding: 0 2;
 }
 
 #book-detail {

--- a/src/bookery/tui/widgets/__init__.py
+++ b/src/bookery/tui/widgets/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Package for Bookery TUI custom widgets.
+# ABOUTME: Houses reusable Textual widgets for the library browser interface.

--- a/src/bookery/tui/widgets/book_list.py
+++ b/src/bookery/tui/widgets/book_list.py
@@ -1,0 +1,62 @@
+# ABOUTME: BookList widget for the TUI left pane.
+# ABOUTME: Displays a sorted DataTable of books with a row count footer.
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import DataTable, Static
+
+from bookery.core.pathformat import derive_author_sort
+from bookery.db.mapping import BookRecord
+
+
+def format_row_label(record: BookRecord) -> str:
+    """Format a BookRecord as 'Author Last, First \u2014 Title' for display."""
+    author_sort = derive_author_sort(record.metadata)
+    if author_sort == "Unknown":
+        author_sort = "Unknown Author"
+
+    title = record.metadata.title if record.metadata.title else "(Untitled)"
+
+    return f"{author_sort} \u2014 {title}"
+
+
+def author_sort_key(record: BookRecord) -> tuple[int, str]:
+    """Return a sort key that orders known authors first, case-insensitive.
+
+    Unknown authors sort last via the leading tuple element:
+    (0, "calvino, italo") < (1, "unknown").
+    """
+    author_sort = derive_author_sort(record.metadata)
+    if author_sort == "Unknown":
+        return (1, "unknown")
+    return (0, author_sort.lower())
+
+
+class BookList(Widget):
+    """A widget composing a DataTable of books and a row count label."""
+
+    can_focus_children = True
+
+    def compose(self) -> ComposeResult:
+        yield DataTable(id="book-table")
+        yield Static("0 books", id="row-count")
+
+    def on_mount(self) -> None:
+        table = self.query_one("#book-table", DataTable)
+        table.add_column("Library", key="library")
+        table.cursor_type = "row"
+
+    def load(self, records: list[BookRecord]) -> None:
+        """Sort records by author, populate the DataTable, and update count."""
+        sorted_records = sorted(records, key=author_sort_key)
+
+        table = self.query_one("#book-table", DataTable)
+        table.clear()
+
+        for record in sorted_records:
+            label = format_row_label(record)
+            table.add_row(label, key=str(record.id))
+
+        count = len(sorted_records)
+        noun = "book" if count == 1 else "books"
+        self.query_one("#row-count", Static).update(f"{count} {noun}")

--- a/tests/e2e/test_tui_e2e.py
+++ b/tests/e2e/test_tui_e2e.py
@@ -1,6 +1,7 @@
 # ABOUTME: End-to-end tests for the `bookery tui` command.
 # ABOUTME: Verifies --help output, missing DB error, headless app launch, and two-pane layout.
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,6 +10,7 @@ from click.testing import CliRunner
 from bookery.cli import cli
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
 from bookery.tui.app import BookeryApp
 
 
@@ -82,6 +84,56 @@ class TestTuiE2E:
             book_detail = app.query_one("#book-detail")
             assert book_list is not None
             assert book_detail is not None
+
+            await pilot.press("q")
+
+        conn.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_catalog_shows_zero_books(self, tmp_path) -> None:
+        """An empty catalog shows '0 books' in the row count."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            label = app.query_one("#row-count")
+            assert "0 books" in str(label.render())
+            await pilot.press("q")
+
+        conn.close()
+
+    @pytest.mark.asyncio
+    async def test_populated_catalog_renders_book_list(self, tmp_path) -> None:
+        """A catalog with books renders them in the DataTable sorted by author."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        catalog.add_book(
+            BookMetadata(title="The Name of the Rose", authors=["Umberto Eco"],
+                         source_path=Path("/books/rose.epub")),
+            file_hash="hash1",
+        )
+        catalog.add_book(
+            BookMetadata(title="If on a winter's night a traveler",
+                         authors=["Italo Calvino"],
+                         source_path=Path("/books/winter.epub")),
+            file_hash="hash2",
+        )
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            table = app.query_one("#book-table")
+            assert table.row_count == 2
+
+            # Calvino sorts before Eco
+            first_row = table.get_row_at(0)
+            assert "Calvino" in str(first_row[0])
+
+            label = app.query_one("#row-count")
+            assert "2 books" in str(label.render())
 
             await pilot.press("q")
 

--- a/tests/unit/test_book_list_widget.py
+++ b/tests/unit/test_book_list_widget.py
@@ -1,0 +1,229 @@
+# ABOUTME: Unit tests for the BookList TUI widget.
+# ABOUTME: Tests format_row_label(), author_sort_key(), and BookList.load() behavior.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.mapping import BookRecord
+from bookery.metadata.types import BookMetadata
+
+
+def _make_record(
+    title: str = "The Name of the Rose",
+    authors: list[str] | None = None,
+    record_id: int = 1,
+) -> BookRecord:
+    """Helper to create a BookRecord with sensible defaults."""
+    if authors is None:
+        authors = ["Umberto Eco"]
+    return BookRecord(
+        id=record_id,
+        metadata=BookMetadata(title=title, authors=authors),
+        file_hash="abc123",
+        source_path=Path("/books/test.epub"),
+        output_path=None,
+        date_added="2025-01-01T00:00:00",
+        date_modified="2025-01-01T00:00:00",
+    )
+
+
+class TestFormatRowLabel:
+    """Tests for format_row_label()."""
+
+    def test_normal_author_and_title(self) -> None:
+        """Standard author/title produces 'Last, First \u2014 Title'."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record(title="The Name of the Rose", authors=["Umberto Eco"])
+        assert format_row_label(record) == "Eco, Umberto \u2014 The Name of the Rose"
+
+    def test_empty_authors_list(self) -> None:
+        """Empty authors list produces 'Unknown Author'."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record(authors=[])
+        assert format_row_label(record) == "Unknown Author \u2014 The Name of the Rose"
+
+    def test_none_title(self) -> None:
+        """None-ish title (empty string) produces '(Untitled)'."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record(title="", authors=["Umberto Eco"])
+        assert format_row_label(record) == "Eco, Umberto \u2014 (Untitled)"
+
+    def test_single_name_author(self) -> None:
+        """Single-word author name is used as-is (no inversion)."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record(authors=["Colette"])
+        assert format_row_label(record) == "Colette \u2014 The Name of the Rose"
+
+    def test_author_with_comma_kept_as_is(self) -> None:
+        """Author already containing a comma is kept as-is."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record(authors=["Eco, Umberto"])
+        assert format_row_label(record) == "Eco, Umberto \u2014 The Name of the Rose"
+
+    def test_whitespace_only_author(self) -> None:
+        """Whitespace-only author treated as unknown."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record(authors=["   "])
+        assert format_row_label(record) == "Unknown Author \u2014 The Name of the Rose"
+
+
+class TestAuthorSortKey:
+    """Tests for author_sort_key()."""
+
+    def test_case_insensitive(self) -> None:
+        """Sort keys are case-insensitive."""
+        from bookery.tui.widgets.book_list import author_sort_key
+
+        upper = _make_record(authors=["Umberto Eco"])
+        lower = _make_record(authors=["umberto eco"])
+        assert author_sort_key(upper) == author_sort_key(lower)
+
+    def test_unknown_sorts_last(self) -> None:
+        """Records with unknown authors sort after known authors."""
+        from bookery.tui.widgets.book_list import author_sort_key
+
+        known = _make_record(authors=["Umberto Eco"])
+        unknown = _make_record(authors=[])
+        assert author_sort_key(known) < author_sort_key(unknown)
+
+    def test_ordering_by_last_name(self) -> None:
+        """Records sort by author last name."""
+        from bookery.tui.widgets.book_list import author_sort_key
+
+        eco = _make_record(authors=["Umberto Eco"])
+        calvino = _make_record(authors=["Italo Calvino"])
+        assert author_sort_key(calvino) < author_sort_key(eco)
+
+
+class TestBookListLoad:
+    """Tests for BookList.load() via Textual's async test harness."""
+
+    @pytest.mark.asyncio
+    async def test_load_populates_table(self) -> None:
+        """load() populates the DataTable with sorted records."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_list import BookList
+
+        records = [
+            _make_record(title="The Name of the Rose", authors=["Umberto Eco"], record_id=1),
+            _make_record(title="If on a winter's night", authors=["Italo Calvino"], record_id=2),
+            _make_record(title="Unknown Work", authors=[], record_id=3),
+        ]
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookList(id="book-list")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            book_list = app.query_one(BookList)
+            book_list.load(records)
+            await pilot.pause()
+
+            table = app.query_one("#book-table")
+            assert table.row_count == 3
+
+            # Calvino should be first, Eco second, Unknown last
+            first_row = table.get_row_at(0)
+            assert "Calvino" in str(first_row[0])
+
+            last_row = table.get_row_at(2)
+            assert "Unknown Author" in str(last_row[0])
+
+    @pytest.mark.asyncio
+    async def test_load_updates_row_count_label(self) -> None:
+        """load() updates the row count label."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_list import BookList
+
+        records = [
+            _make_record(record_id=1),
+            _make_record(record_id=2),
+        ]
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookList(id="book-list")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            book_list = app.query_one(BookList)
+            book_list.load(records)
+            await pilot.pause()
+
+            label = app.query_one("#row-count")
+            assert "2 books" in str(label.render())
+
+    @pytest.mark.asyncio
+    async def test_load_singular_count(self) -> None:
+        """load() with one record shows '1 book' (singular)."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_list import BookList
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookList(id="book-list")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            book_list = app.query_one(BookList)
+            book_list.load([_make_record()])
+            await pilot.pause()
+
+            label = app.query_one("#row-count")
+            assert "1 book" in str(label.render())
+
+    @pytest.mark.asyncio
+    async def test_load_empty(self) -> None:
+        """load() with no records shows '0 books'."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_list import BookList
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookList(id="book-list")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            book_list = app.query_one(BookList)
+            book_list.load([])
+            await pilot.pause()
+
+            label = app.query_one("#row-count")
+            assert "0 books" in str(label.render())
+
+    @pytest.mark.asyncio
+    async def test_row_keys_are_record_ids(self) -> None:
+        """DataTable row keys match BookRecord.id values."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_list import BookList
+
+        records = [
+            _make_record(title="Book A", authors=["Author A"], record_id=42),
+        ]
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookList(id="book-list")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            book_list = app.query_one(BookList)
+            book_list.load(records)
+            await pilot.pause()
+
+            table = app.query_one("#book-table")
+            row_key = next(iter(table.rows.keys()))
+            assert row_key.value == "42"

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -95,15 +95,11 @@ class TestBookeryAppUnit:
     async def test_book_list_placeholder_text(
         self, catalog: LibraryCatalog
     ) -> None:
-        """Left pane shows placeholder text when no books loaded."""
-        from textual.widgets import Static
-
+        """Left pane shows '0 books' when catalog is empty."""
         app = BookeryApp(catalog=catalog)
         async with app.run_test():
-            book_list = app.query_one("#book-list")
-            # The Static inside the pane should have placeholder text
-            static = book_list.query_one(Static)
-            assert "No books loaded" in str(static.render())
+            row_count = app.query_one("#row-count")
+            assert "0 books" in str(row_count.render())
 
     @pytest.mark.asyncio
     async def test_book_detail_placeholder_text(
@@ -136,18 +132,18 @@ class TestBookeryAppUnit:
     async def test_tab_cycles_focus_between_panes(
         self, catalog: LibraryCatalog
     ) -> None:
-        """Pressing Tab cycles focus between the two panes."""
+        """Pressing Tab cycles focus between the book table and detail pane."""
         app = BookeryApp(catalog=catalog)
         async with app.run_test() as pilot:
-            # Focus the left pane first
-            book_list = app.query_one("#book-list")
-            book_list.focus()
-            assert app.focused.id == "book-list"
+            # Focus starts on the book table inside #book-list
+            book_table = app.query_one("#book-table")
+            book_table.focus()
+            assert app.focused.id == "book-table"
 
             # Tab should move to the right pane
             await pilot.press("tab")
             assert app.focused.id == "book-detail"
 
-            # Tab again should cycle back to the left pane
+            # Tab again should cycle back to the book table
             await pilot.press("tab")
-            assert app.focused.id == "book-list"
+            assert app.focused.id == "book-table"


### PR DESCRIPTION
## Summary
- Replace left pane placeholder with a `BookList` widget composing a `DataTable` + row count `Static`
- Sort books by author last name (case-insensitive, unknown authors last) using `derive_author_sort()`
- Store `BookRecord.id` as row keys for future selection events (#27)
- Row count footer: "312 books" / "1 book" / "0 books"

## Test plan
- [x] 14 unit tests: `format_row_label()`, `author_sort_key()`, `BookList.load()`
- [x] 2 new e2e tests: empty catalog, populated catalog with sort verification
- [x] Updated 2 existing unit tests for new widget structure
- [x] 691 tests passing, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)