### PR TITLE
Add BookDetail widget with metadata display (#27)

### DIFF
--- a/src/bookery/tui/app.py
+++ b/src/bookery/tui/app.py
@@ -6,11 +6,12 @@ from typing import ClassVar
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Horizontal, VerticalScroll
-from textual.widgets import Footer, Header, Static
+from textual.containers import Horizontal
+from textual.widgets import DataTable, Footer, Header
 
 from bookery import __version__
 from bookery.db.catalog import LibraryCatalog
+from bookery.tui.widgets.book_detail import BookDetail
 from bookery.tui.widgets.book_list import BookList
 
 
@@ -34,10 +35,22 @@ class BookeryApp(App):
         yield Header(show_clock=False)
         with Horizontal():
             yield BookList(id="book-list")
-            with VerticalScroll(id="book-detail", can_focus=True):
-                yield Static("Select a book to view details")
+            yield BookDetail(id="book-detail")
         yield Footer()
 
     def on_mount(self) -> None:
         records = self.catalog.list_all()
         self.query_one(BookList).load(records)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """When a row is highlighted in the book list, update the detail pane."""
+        if event.row_key is None or event.row_key.value is None:
+            return
+
+        book_id = int(event.row_key.value)
+        record = self.catalog.get_by_id(book_id)
+        if record is None:
+            return
+
+        tags = self.catalog.get_tags_for_book(book_id)
+        self.query_one(BookDetail).update_detail(record, tags)

--- a/src/bookery/tui/styles/app.tcss
+++ b/src/bookery/tui/styles/app.tcss
@@ -31,6 +31,19 @@ Horizontal {
     padding: 1 2;
 }
 
-#book-detail:focus {
+#book-detail:focus-within {
     border: solid $accent;
+}
+
+#detail-header {
+    text-style: bold;
+    padding: 0 0 1 0;
+}
+
+#detail-metadata {
+    padding: 0 0 1 0;
+}
+
+#detail-scroll {
+    height: 1fr;
 }

--- a/src/bookery/tui/widgets/book_detail.py
+++ b/src/bookery/tui/widgets/book_detail.py
@@ -1,0 +1,107 @@
+# ABOUTME: BookDetail widget for the TUI right pane.
+# ABOUTME: Displays full metadata for the selected book with a scrollable description.
+
+from html.parser import HTMLParser
+from io import StringIO
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Static
+
+from bookery.db.mapping import BookRecord
+
+_PLACEHOLDER = "Select a book to view details"
+_EM_DASH = "\u2014"
+
+
+class _HTMLStripper(HTMLParser):
+    """Strips HTML tags and decodes entities, returning plain text."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._text = StringIO()
+
+    def handle_data(self, data: str) -> None:
+        self._text.write(data)
+
+    def get_text(self) -> str:
+        return self._text.getvalue()
+
+
+def strip_html(value: str | None) -> str:
+    """Strip HTML tags and decode entities from a string.
+
+    Returns empty string for None or empty input.
+    """
+    if not value:
+        return ""
+    stripper = _HTMLStripper()
+    stripper.feed(value)
+    return stripper.get_text()
+
+
+def _format_field(label: str, value: str | None) -> str:
+    """Format a single metadata field with a fixed-width label column."""
+    display = value if value else _EM_DASH
+    return f"{label:>11}  {display}"
+
+
+class BookDetail(Widget):
+    """Displays full metadata for a selected book."""
+
+    can_focus = True
+
+    def compose(self) -> ComposeResult:
+        yield Static(_PLACEHOLDER, id="detail-header")
+        yield Static("", id="detail-metadata")
+        with VerticalScroll(id="detail-scroll"):
+            yield Static("", id="detail-description")
+
+    def update_detail(self, record: BookRecord, tags: list[str]) -> None:
+        """Populate the detail pane with a book's metadata."""
+        meta = record.metadata
+
+        # Header: bold title
+        self.query_one("#detail-header", Static).update(
+            f"[bold]{meta.title}[/bold]"
+        )
+
+        # Build metadata lines
+        lines: list[str] = []
+        lines.append(_format_field("Author", f"[dim]{meta.author}[/dim]" if meta.author else None))
+        lines.append(f"{'':>11}  {'─' * 30}")
+        lines.append(_format_field("Publisher", meta.publisher))
+        lines.append(_format_field("ISBN", meta.isbn))
+        lines.append(_format_field("Language", meta.language))
+
+        # Series with position
+        if meta.series:
+            series_display = meta.series
+            if meta.series_index is not None:
+                series_display += f" #{int(meta.series_index)}"
+            lines.append(_format_field("Series", series_display))
+        else:
+            lines.append(_format_field("Series", None))
+
+        # Tags
+        if tags:
+            lines.append(_format_field("Tags", ", ".join(tags)))
+        else:
+            lines.append(_format_field("Tags", None))
+
+        # Filename
+        filename = record.source_path.name if record.source_path else None
+        lines.append(_format_field("File", filename))
+
+        self.query_one("#detail-metadata", Static).update("\n".join(lines))
+
+        # Description (strip HTML, show in scrollable area)
+        desc = strip_html(meta.description) if meta.description else _EM_DASH
+        self.query_one("#detail-description", Static).update(desc)
+
+    def clear_detail(self) -> None:
+        """Reset to placeholder state."""
+        self.query_one("#detail-header", Static).update(_PLACEHOLDER)
+        self.query_one("#detail-metadata", Static).update("")
+        self.query_one("#detail-description", Static).update("")

--- a/tests/e2e/test_tui_e2e.py
+++ b/tests/e2e/test_tui_e2e.py
@@ -138,3 +138,77 @@ class TestTuiE2E:
             await pilot.press("q")
 
         conn.close()
+
+    @pytest.mark.asyncio
+    async def test_select_book_shows_detail(self, tmp_path) -> None:
+        """Full flow: launch app, highlight row, detail pane shows metadata."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        catalog.add_book(
+            BookMetadata(
+                title="If on a winter's night a traveler",
+                authors=["Italo Calvino"],
+                publisher="Einaudi",
+                language="it",
+                description="<p>A novel about reading novels.</p>",
+                source_path=Path("/books/winter.epub"),
+            ),
+            file_hash="hash_winter",
+        )
+        catalog.add_book(
+            BookMetadata(
+                title="The Name of the Rose",
+                authors=["Umberto Eco"],
+                isbn="978-0-15-144647-6",
+                series="Medieval Mysteries",
+                series_index=1.0,
+                source_path=Path("/books/rose.epub"),
+            ),
+            file_hash="hash_rose",
+        )
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Focus the table; cursor starts at row 0 (Calvino),
+            # pressing down moves to row 1 (Eco).
+            table = app.query_one("#book-table")
+            table.focus()
+            await pilot.pause()
+            await pilot.press("down")
+            await pilot.pause()
+
+            # Verify the detail pane shows Eco's book (row 1)
+            header = app.query_one("#detail-header")
+            header_text = str(header.render())
+            assert "Rose" in header_text
+
+            metadata = app.query_one("#detail-metadata")
+            meta_text = str(metadata.render())
+            assert "Eco" in meta_text
+            assert "978-0-15-144647-6" in meta_text
+            assert "Medieval Mysteries" in meta_text
+            assert "#1" in meta_text
+
+            # Now press up to go back to Calvino (row 0)
+            await pilot.press("up")
+            await pilot.pause()
+
+            header_text = str(app.query_one("#detail-header").render())
+            assert "winter" in header_text.lower()
+
+            meta_text = str(app.query_one("#detail-metadata").render())
+            assert "Calvino" in meta_text
+            assert "Einaudi" in meta_text
+
+            # Description should have HTML stripped
+            desc_text = str(app.query_one("#detail-description").render())
+            assert "A novel about reading novels." in desc_text
+            assert "<p>" not in desc_text
+
+            await pilot.press("q")
+
+        conn.close()

--- a/tests/integration/test_tui_cli.py
+++ b/tests/integration/test_tui_cli.py
@@ -1,12 +1,17 @@
 # ABOUTME: Integration tests for the `bookery tui` CLI command.
-# ABOUTME: Tests command invocation with a real database file.
+# ABOUTME: Tests command invocation, and selection→detail flow with a real database.
 
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+from bookery.tui.app import BookeryApp
 
 
 class TestTuiIntegration:
@@ -28,3 +33,50 @@ class TestTuiIntegration:
         assert result.exit_code == 0
         mock_app_cls.assert_called_once()
         mock_app_cls.return_value.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_row_highlight_updates_detail_pane(self, tmp_path) -> None:
+        """Highlighting a row in the DataTable populates the detail pane."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        catalog.add_book(
+            BookMetadata(
+                title="The Name of the Rose",
+                authors=["Umberto Eco"],
+                publisher="Harcourt",
+                isbn="978-0-15-144647-6",
+                source_path=Path("/books/rose.epub"),
+            ),
+            file_hash="hash1",
+        )
+
+        app = BookeryApp(catalog=catalog)
+        async with app.run_test() as pilot:
+            # Give the app time to mount and load
+            await pilot.pause()
+
+            # The table should have one row; move cursor to highlight it
+            table = app.query_one("#book-table")
+            assert table.row_count == 1
+
+            # Press down to trigger RowHighlighted on the first row
+            table.focus()
+            await pilot.pause()
+            await pilot.press("down")
+            await pilot.pause()
+
+            # Verify detail pane updated
+            header = app.query_one("#detail-header")
+            rendered = str(header.render())
+            assert "The Name of the Rose" in rendered
+
+            metadata = app.query_one("#detail-metadata")
+            meta_rendered = str(metadata.render())
+            assert "Umberto Eco" in meta_rendered
+            assert "Harcourt" in meta_rendered
+
+            await pilot.press("q")
+
+        conn.close()

--- a/tests/unit/test_book_detail_widget.py
+++ b/tests/unit/test_book_detail_widget.py
@@ -1,0 +1,279 @@
+# ABOUTME: Unit tests for the BookDetail TUI widget.
+# ABOUTME: Tests strip_html(), update_detail(), clear_detail(), and field rendering.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.mapping import BookRecord
+from bookery.metadata.types import BookMetadata
+
+
+def _make_record(
+    title: str = "The Name of the Rose",
+    authors: list[str] | None = None,
+    record_id: int = 1,
+    publisher: str | None = None,
+    isbn: str | None = None,
+    language: str | None = None,
+    series: str | None = None,
+    series_index: float | None = None,
+    description: str | None = None,
+) -> BookRecord:
+    """Helper to create a BookRecord with sensible defaults."""
+    if authors is None:
+        authors = ["Umberto Eco"]
+    return BookRecord(
+        id=record_id,
+        metadata=BookMetadata(
+            title=title,
+            authors=authors,
+            publisher=publisher,
+            isbn=isbn,
+            language=language,
+            series=series,
+            series_index=series_index,
+            description=description,
+        ),
+        file_hash="abc123",
+        source_path=Path("/books/test.epub"),
+        output_path=None,
+        date_added="2025-01-01T00:00:00",
+        date_modified="2025-01-01T00:00:00",
+    )
+
+
+class TestStripHtml:
+    """Tests for strip_html()."""
+
+    def test_plain_text_passthrough(self) -> None:
+        """Plain text without HTML tags passes through unchanged."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html("Hello, world!") == "Hello, world!"
+
+    def test_strips_p_tags(self) -> None:
+        """Paragraph tags are stripped."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html("<p>Hello</p>") == "Hello"
+
+    def test_strips_br_tags(self) -> None:
+        """Break tags are stripped."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html("Line one<br>Line two") == "Line oneLine two"
+
+    def test_strips_bold_tags(self) -> None:
+        """Bold tags are stripped."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html("<b>Bold text</b>") == "Bold text"
+
+    def test_decodes_html_entities(self) -> None:
+        """HTML entities are decoded to their characters."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html("Tom &amp; Jerry") == "Tom & Jerry"
+
+    def test_none_returns_empty_string(self) -> None:
+        """None input returns empty string."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html(None) == ""
+
+    def test_empty_string_returns_empty(self) -> None:
+        """Empty string returns empty string."""
+        from bookery.tui.widgets.book_detail import strip_html
+
+        assert strip_html("") == ""
+
+
+class TestBookDetailUpdateDetail:
+    """Tests for BookDetail.update_detail() rendering."""
+
+    @pytest.mark.asyncio
+    async def test_title_rendered_bold(self) -> None:
+        """update_detail() renders the title as bold markup."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        record = _make_record(title="The Name of the Rose")
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            detail = app.query_one(BookDetail)
+            detail.update_detail(record, [])
+            await pilot.pause()
+
+            header = app.query_one("#detail-header")
+            rendered = str(header.render())
+            assert "The Name of the Rose" in rendered
+
+    @pytest.mark.asyncio
+    async def test_author_rendered(self) -> None:
+        """update_detail() renders the author."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        record = _make_record(authors=["Umberto Eco"])
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            detail = app.query_one(BookDetail)
+            detail.update_detail(record, [])
+            await pilot.pause()
+
+            metadata = app.query_one("#detail-metadata")
+            rendered = str(metadata.render())
+            assert "Umberto Eco" in rendered
+
+    @pytest.mark.asyncio
+    async def test_all_fields_displayed(self) -> None:
+        """update_detail() renders Publisher, ISBN, Language, Series, Tags, Description."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        record = _make_record(
+            publisher="Harcourt",
+            isbn="978-0-15-144647-6",
+            language="en",
+            series="Medieval Mysteries",
+            series_index=1.0,
+            description="A mystery novel set in a monastery.",
+        )
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            detail = app.query_one(BookDetail)
+            detail.update_detail(record, ["fiction", "mystery"])
+            await pilot.pause()
+
+            metadata = app.query_one("#detail-metadata")
+            rendered = str(metadata.render())
+            assert "Harcourt" in rendered
+            assert "978-0-15-144647-6" in rendered
+            assert "en" in rendered
+            assert "Medieval Mysteries" in rendered
+            assert "#1" in rendered
+            assert "fiction" in rendered
+            assert "mystery" in rendered
+            assert "test.epub" in rendered
+
+            desc = app.query_one("#detail-description")
+            desc_rendered = str(desc.render())
+            assert "A mystery novel set in a monastery." in desc_rendered
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_show_em_dash(self) -> None:
+        """Missing fields display em dash."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        record = _make_record()  # All optional fields are None
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            detail = app.query_one(BookDetail)
+            detail.update_detail(record, [])
+            await pilot.pause()
+
+            metadata = app.query_one("#detail-metadata")
+            rendered = str(metadata.render())
+            assert "\u2014" in rendered  # em dash for missing fields
+
+
+class TestBookDetailClear:
+    """Tests for BookDetail.clear_detail()."""
+
+    @pytest.mark.asyncio
+    async def test_clear_shows_placeholder(self) -> None:
+        """clear_detail() restores the placeholder message."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        record = _make_record()
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            detail = app.query_one(BookDetail)
+            detail.update_detail(record, [])
+            await pilot.pause()
+
+            detail.clear_detail()
+            await pilot.pause()
+
+            header = app.query_one("#detail-header")
+            rendered = str(header.render())
+            assert "Select a book to view details" in rendered
+
+    @pytest.mark.asyncio
+    async def test_initial_state_shows_placeholder(self) -> None:
+        """Widget starts with placeholder text before any update."""
+        from textual.app import App, ComposeResult
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test():
+            header = app.query_one("#detail-header")
+            rendered = str(header.render())
+            assert "Select a book to view details" in rendered
+
+
+class TestBookDetailDescription:
+    """Tests for description rendering and scrollability."""
+
+    @pytest.mark.asyncio
+    async def test_description_in_scrollable_container(self) -> None:
+        """Description is rendered inside a VerticalScroll container."""
+        from textual.app import App, ComposeResult
+        from textual.containers import VerticalScroll
+
+        from bookery.tui.widgets.book_detail import BookDetail
+
+        record = _make_record(description="A long description here.")
+
+        class Harness(App):
+            def compose(self) -> ComposeResult:
+                yield BookDetail(id="book-detail")
+
+        app = Harness()
+        async with app.run_test() as pilot:
+            detail = app.query_one(BookDetail)
+            detail.update_detail(record, [])
+            await pilot.pause()
+
+            scroll = app.query_one("#detail-scroll", VerticalScroll)
+            assert scroll is not None
+            desc = app.query_one("#detail-description")
+            assert desc is not None


### PR DESCRIPTION
## Summary
- Add `BookDetail` widget showing full metadata (title, author, publisher, ISBN, language, series, tags, filename, description) when a book is highlighted
- Wire `DataTable.RowHighlighted` event to populate detail pane from catalog
- Strip HTML from descriptions using lightweight `HTMLParser` subclass
- Add TCSS styling for detail header, metadata block, and scrollable description

## Test plan
- [x] 7 unit tests for `strip_html()` utility
- [x] 7 unit tests for `BookDetail` widget (update, clear, placeholder, scrollable description)
- [x] 1 integration test for row highlight → detail pane update
- [x] 1 E2E test for full navigation flow with metadata verification
- [x] All 24 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)