### PR TITLE
Skip MOBI conversion when EPUB exists in directory (#36)

### DIFF
--- a/src/bookery/cli/commands/import_cmd.py
+++ b/src/bookery/cli/commands/import_cmd.py
@@ -7,6 +7,7 @@ import click
 from rich.console import Console
 
 from bookery.cli.options import db_option
+from bookery.core.dedup import filter_redundant_mobis
 from bookery.core.importer import MatchResult, import_books
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import DEFAULT_DB_PATH, open_library
@@ -183,6 +184,15 @@ def import_command(
 
     if do_convert:
         mobi_files = _find_mobis(directory)
+        if mobi_files:
+            mobi_files, dedup_skipped = filter_redundant_mobis(
+                mobi_files, epub_files,
+            )
+            if dedup_skipped:
+                console.print(
+                    f"Skipped {len(dedup_skipped)} MOBI file(s) "
+                    f"— EPUB exists in directory\n",
+                )
         if mobi_files:
             epub_files = _convert_mobis(mobi_files, epub_files, output_dir)
 

--- a/src/bookery/core/dedup.py
+++ b/src/bookery/core/dedup.py
@@ -1,0 +1,27 @@
+# ABOUTME: Deduplication logic for filtering redundant MOBI files.
+# ABOUTME: Skips MOBIs when an EPUB already exists in the same directory.
+
+from pathlib import Path
+
+
+def filter_redundant_mobis(
+    mobi_files: list[Path],
+    epub_files: list[Path],
+) -> tuple[list[Path], list[Path]]:
+    """Partition MOBIs into (to_convert, skipped) based on EPUB presence.
+
+    A MOBI is considered redundant if its parent directory already contains
+    an EPUB file (Calibre convention: one book per directory).
+    """
+    epub_dirs: set[Path] = {epub.parent for epub in epub_files}
+
+    to_convert: list[Path] = []
+    skipped: list[Path] = []
+
+    for mobi in mobi_files:
+        if mobi.parent in epub_dirs:
+            skipped.append(mobi)
+        else:
+            to_convert.append(mobi)
+
+    return to_convert, skipped

--- a/tests/e2e/test_import_cli.py
+++ b/tests/e2e/test_import_cli.py
@@ -212,3 +212,63 @@ class TestImportCommand:
         assert result.exit_code == 0, result.output
         assert "skipped" in result.output
         assert "rose.mobi" in result.output
+
+    def test_import_convert_skips_mobi_when_epub_exists(
+        self, sample_epub: Path, tmp_path: Path,
+    ) -> None:
+        """MOBI + EPUB in same dir + --convert → MOBI not converted, skip reported."""
+        scan_dir = tmp_path / "scan"
+        book_dir = scan_dir / "Author" / "Title"
+        book_dir.mkdir(parents=True)
+        shutil.copy(sample_epub, book_dir / "book.epub")
+        (book_dir / "book.mobi").write_bytes(b"fake mobi")
+
+        db_path = tmp_path / "test.db"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["import", str(scan_dir), "--convert", "--db", str(db_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Skipped 1 MOBI" in result.output
+        assert "EPUB exists" in result.output
+        # The EPUB should still be cataloged
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        records = catalog.list_all()
+        assert len(records) == 1
+        conn.close()
+
+    def test_import_convert_processes_mobi_without_epub(
+        self, sample_epub: Path, tmp_path: Path,
+    ) -> None:
+        """MOBI alone in dir + --convert → MOBI converted normally."""
+        scan_dir = tmp_path / "scan"
+        mobi_dir = scan_dir / "Author" / "MobiOnly"
+        mobi_dir.mkdir(parents=True)
+        mobi_file = mobi_dir / "book.mobi"
+        mobi_file.write_bytes(b"fake mobi")
+
+        fake_result = ConvertResult(
+            source=mobi_file,
+            epub_path=sample_epub,
+            success=True,
+        )
+
+        db_path = tmp_path / "test.db"
+        runner = CliRunner()
+        with patch(
+            "bookery.core.converter.convert_one",
+            return_value=fake_result,
+        ):
+            result = runner.invoke(
+                cli,
+                ["import", str(scan_dir), "--convert", "--db", str(db_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Converting" in result.output
+        assert "book.mobi" in result.output
+        # Should NOT show dedup skip message
+        assert "EPUB exists" not in result.output

--- a/tests/unit/test_dedup.py
+++ b/tests/unit/test_dedup.py
@@ -1,0 +1,118 @@
+# ABOUTME: Unit tests for filter_redundant_mobis() deduplication logic.
+# ABOUTME: Verifies MOBIs are skipped when an EPUB exists in the same directory.
+
+from pathlib import Path
+
+from bookery.core.dedup import filter_redundant_mobis
+
+
+class TestFilterRedundantMobis:
+    """Tests for MOBI deduplication based on EPUB co-location."""
+
+    def test_mobi_skipped_when_epub_in_same_dir(self, tmp_path: Path) -> None:
+        """MOBI + EPUB in same directory → MOBI is skipped."""
+        book_dir = tmp_path / "Author" / "Title"
+        book_dir.mkdir(parents=True)
+        mobi = book_dir / "book.mobi"
+        epub = book_dir / "book.epub"
+        mobi.touch()
+        epub.touch()
+
+        to_convert, skipped = filter_redundant_mobis([mobi], [epub])
+
+        assert to_convert == []
+        assert skipped == [mobi]
+
+    def test_mobi_kept_when_alone_in_dir(self, tmp_path: Path) -> None:
+        """MOBI alone in directory → kept for conversion."""
+        mobi_dir = tmp_path / "Author" / "Title"
+        mobi_dir.mkdir(parents=True)
+        mobi = mobi_dir / "book.mobi"
+        mobi.touch()
+
+        # EPUB is in a different directory
+        other_dir = tmp_path / "Other" / "Book"
+        other_dir.mkdir(parents=True)
+        epub = other_dir / "other.epub"
+        epub.touch()
+
+        to_convert, skipped = filter_redundant_mobis([mobi], [epub])
+
+        assert to_convert == [mobi]
+        assert skipped == []
+
+    def test_mobi_skipped_with_multiple_epubs_in_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """Multiple EPUBs + MOBI in same dir → MOBI is skipped."""
+        book_dir = tmp_path / "Author" / "Title"
+        book_dir.mkdir(parents=True)
+        mobi = book_dir / "book.mobi"
+        epub1 = book_dir / "book.epub"
+        epub2 = book_dir / "book_v2.epub"
+        mobi.touch()
+        epub1.touch()
+        epub2.touch()
+
+        to_convert, skipped = filter_redundant_mobis([mobi], [epub1, epub2])
+
+        assert to_convert == []
+        assert skipped == [mobi]
+
+    def test_mobi_skipped_even_with_different_filename(
+        self, tmp_path: Path,
+    ) -> None:
+        """MOBI filename doesn't match EPUB → still skipped (same dir)."""
+        book_dir = tmp_path / "Author" / "Title"
+        book_dir.mkdir(parents=True)
+        mobi = book_dir / "converted.mobi"
+        epub = book_dir / "original.epub"
+        mobi.touch()
+        epub.touch()
+
+        to_convert, skipped = filter_redundant_mobis([mobi], [epub])
+
+        assert to_convert == []
+        assert skipped == [mobi]
+
+    def test_mixed_dirs_correct_split(self, tmp_path: Path) -> None:
+        """Some dirs have EPUBs, some don't → correct partition."""
+        # Dir with both formats
+        dir_both = tmp_path / "A" / "Both"
+        dir_both.mkdir(parents=True)
+        mobi_skip = dir_both / "book.mobi"
+        epub = dir_both / "book.epub"
+        mobi_skip.touch()
+        epub.touch()
+
+        # Dir with only MOBI
+        dir_mobi = tmp_path / "B" / "MobiOnly"
+        dir_mobi.mkdir(parents=True)
+        mobi_keep = dir_mobi / "another.mobi"
+        mobi_keep.touch()
+
+        to_convert, skipped = filter_redundant_mobis(
+            [mobi_skip, mobi_keep], [epub],
+        )
+
+        assert to_convert == [mobi_keep]
+        assert skipped == [mobi_skip]
+
+    def test_empty_inputs(self) -> None:
+        """Empty lists → empty results."""
+        to_convert, skipped = filter_redundant_mobis([], [])
+
+        assert to_convert == []
+        assert skipped == []
+
+    def test_no_epubs_all_mobis_kept(self, tmp_path: Path) -> None:
+        """No EPUBs at all → all MOBIs kept."""
+        dir_a = tmp_path / "A"
+        dir_a.mkdir()
+        mobi = dir_a / "book.mobi"
+        mobi.touch()
+
+        to_convert, skipped = filter_redundant_mobis([mobi], [])
+
+        assert to_convert == [mobi]
+        assert skipped == []


### PR DESCRIPTION
## Summary
- Adds `filter_redundant_mobis()` in `core/dedup.py` to skip MOBIs when an EPUB already exists in the same directory
- Wired into `import --convert` pipeline before conversion step, with skip count reported in output
- Tested against full Calibre library (158 MOBIs correctly skipped)

## Test plan
- [x] 7 unit tests for `filter_redundant_mobis()` edge cases
- [x] 2 new e2e tests for CLI skip behavior and normal conversion
- [x] All 10 e2e import tests pass
- [x] Full suite green (714 passed, 2 pre-existing failures unrelated)
- [x] Ruff clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)