### PR TITLE
Fix HTTP client to follow redirects for ISBN lookups

### DIFF
--- a/src/bookery/cli/commands/tui_cmd.py
+++ b/src/bookery/cli/commands/tui_cmd.py
@@ -13,7 +13,14 @@ from bookery.tui.app import BookeryApp
 
 @click.command("tui")
 @db_option
-def tui(db_path: Path | None) -> None:
+@click.option(
+    "-o",
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory for enriched copies (default: ./bookery-output).",
+)
+def tui(db_path: Path | None, output_dir: Path | None) -> None:
     """Launch the interactive terminal UI for browsing the library."""
     resolved = db_path or DEFAULT_DB_PATH
 
@@ -25,6 +32,6 @@ def tui(db_path: Path | None) -> None:
     catalog = LibraryCatalog(conn)
 
     try:
-        BookeryApp(catalog=catalog).run()
+        BookeryApp(catalog=catalog, output_dir=output_dir).run()
     finally:
         conn.close()

--- a/src/bookery/core/enrichment.py
+++ b/src/bookery/core/enrichment.py
@@ -1,0 +1,81 @@
+# ABOUTME: Enrichment service facade for TUI metadata search and apply.
+# ABOUTME: Thin wrapper over existing providers, normalizer, and write pipeline.
+
+import logging
+from pathlib import Path
+
+from bookery.core.pipeline import WriteResult, apply_metadata_safely
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.normalizer import normalize_metadata
+from bookery.metadata.provider import MetadataProvider
+from bookery.metadata.types import BookMetadata
+
+logger = logging.getLogger(__name__)
+
+
+class EnrichmentService:
+    """Facade for metadata enrichment operations.
+
+    Provides search and apply methods that the TUI calls via background
+    workers. All methods are synchronous — the TUI wraps them in
+    run_worker(thread=True) for non-blocking operation.
+    """
+
+    def __init__(self, provider: MetadataProvider, output_dir: Path) -> None:
+        self._provider = provider
+        self._output_dir = output_dir
+
+    def search(self, metadata: BookMetadata) -> list[MetadataCandidate]:
+        """Search for metadata candidates using ISBN-first, title/author fallback.
+
+        Normalizes mangled metadata before searching for better query quality.
+        """
+        norm_result = normalize_metadata(metadata)
+        search_meta = norm_result.normalized
+
+        if norm_result.was_modified:
+            logger.debug(
+                "enrichment search: normalized title=%r author=%r",
+                search_meta.title,
+                search_meta.author,
+            )
+
+        # ISBN lookup first
+        candidates: list[MetadataCandidate] = []
+        if search_meta.isbn:
+            candidates = self._provider.search_by_isbn(search_meta.isbn)
+            logger.debug("enrichment search: ISBN returned %d candidates", len(candidates))
+
+        # Fall back to title/author
+        if not candidates:
+            author = search_meta.author or None
+            candidates = self._provider.search_by_title_author(search_meta.title, author)
+            logger.debug(
+                "enrichment search: title/author returned %d candidates", len(candidates)
+            )
+
+        return candidates
+
+    def search_manual(self, query: str) -> list[MetadataCandidate]:
+        """Search by free text or auto-detected Open Library URL.
+
+        URLs (starting with http:// or https://) are dispatched to
+        lookup_by_url. Plain text queries search by title/author.
+        """
+        if query.startswith(("http://", "https://")):
+            candidate = self._provider.lookup_by_url(query)
+            return [candidate] if candidate else []
+
+        return self._provider.search_by_title_author(query, None)
+
+    def lookup_url(self, url: str) -> MetadataCandidate | None:
+        """Look up metadata from an Open Library URL."""
+        return self._provider.lookup_by_url(url)
+
+    def apply(self, source: Path, metadata: BookMetadata) -> WriteResult:
+        """Write enriched metadata to a non-destructive copy.
+
+        Delegates to apply_metadata_safely. Catalog DB updates should
+        be performed by the caller on the main thread.
+        """
+        return apply_metadata_safely(source, metadata, self._output_dir)

--- a/src/bookery/metadata/http.py
+++ b/src/bookery/metadata/http.py
@@ -41,6 +41,7 @@ class BookeryHttpClient:
         client_kwargs: dict[str, Any] = {
             "headers": {"User-Agent": "bookery/0.1.0"},
             "timeout": 30.0,
+            "follow_redirects": True,
         }
         if transport is not None:
             client_kwargs["transport"] = transport

--- a/src/bookery/tui/app.py
+++ b/src/bookery/tui/app.py
@@ -1,18 +1,34 @@
 # ABOUTME: The main Textual application for Bookery's TUI.
 # ABOUTME: Provides an interactive terminal interface for browsing the library catalog.
 
+import logging
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal
 from textual.widgets import DataTable, Footer, Header
+from textual.worker import Worker, WorkerState
 
 from bookery import __version__
+from bookery.core.enrichment import EnrichmentService
+from bookery.core.pipeline import WriteResult
 from bookery.db.catalog import LibraryCatalog
+from bookery.db.mapping import BookRecord
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.http import BookeryHttpClient
+from bookery.metadata.openlibrary import OpenLibraryProvider
+from bookery.metadata.provider import MetadataProvider
+from bookery.metadata.types import BookMetadata
+from bookery.tui.screens.candidates import CandidateSelectScreen
+from bookery.tui.screens.confirm import ConfirmScreen
+from bookery.tui.screens.loading import LoadingOverlay
+from bookery.tui.screens.reenrich import ReEnrichConfirmModal
 from bookery.tui.widgets.book_detail import BookDetail
 from bookery.tui.widgets.book_list import BookList
+
+logger = logging.getLogger(__name__)
 
 
 class BookeryApp(App):
@@ -21,15 +37,46 @@ class BookeryApp(App):
     TITLE = "Bookery"
     SUB_TITLE = f"v{__version__}"
 
-    CSS_PATH = Path("styles/app.tcss")
+    CSS_PATH: ClassVar[list[str | Path]] = [  # type: ignore[assignment]
+        Path("styles/app.tcss"),
+        Path("styles/enrichment.tcss"),
+    ]
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "quit", "Quit"),
+        Binding("e", "enrich", "Enrich"),
     ]
 
-    def __init__(self, catalog: LibraryCatalog, **kwargs) -> None:
+    def __init__(
+        self,
+        catalog: LibraryCatalog,
+        *,
+        output_dir: Path | None = None,
+        provider: MetadataProvider | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.catalog = catalog
+        self._output_dir = output_dir or Path("bookery-output")
+        self._provider = provider
+        self._enrichment_service: EnrichmentService | None = None
+        self._current_record: BookRecord | None = None
+
+    @property
+    def enrichment_service(self) -> EnrichmentService:
+        """Lazily create the enrichment service on first use."""
+        if self._enrichment_service is None:
+            provider = self._provider or self._create_provider()
+            self._enrichment_service = EnrichmentService(
+                provider=provider, output_dir=self._output_dir
+            )
+        return self._enrichment_service
+
+    @staticmethod
+    def _create_provider() -> MetadataProvider:
+        """Create the default metadata provider (Open Library)."""
+        http_client = BookeryHttpClient()
+        return OpenLibraryProvider(http_client=http_client)
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -55,3 +102,178 @@ class BookeryApp(App):
         tags = self.catalog.get_tags_for_book(book_id)
         genres = self.catalog.get_genres_for_book(book_id)
         self.query_one(BookDetail).update_detail(record, tags, genres=genres)
+
+    def _get_selected_record(self) -> BookRecord | None:
+        """Get the currently selected book record from the DataTable."""
+        table = self.query_one("#book-table", DataTable)
+        if table.row_count == 0:
+            return None
+        row_key = table.cursor_row
+        if row_key < 0:
+            return None
+        # Get the row key value (book ID) from the cursor position
+        keys = list(table.rows.keys())
+        if row_key >= len(keys):
+            return None
+        key_value = keys[row_key].value
+        if key_value is None:
+            return None
+        book_id = int(key_value)
+        return self.catalog.get_by_id(book_id)
+
+    # --- Enrichment flow ---
+
+    def action_enrich(self) -> None:
+        """Start the enrichment flow for the selected book."""
+        record = self._get_selected_record()
+        if record is None:
+            return
+
+        self._current_record = record
+
+        # Check if already enriched
+        if record.output_path is not None:
+            self.push_screen(
+                ReEnrichConfirmModal(),
+                callback=self._on_reenrich_decision,
+            )
+        else:
+            self._start_search(record)
+
+    def _on_reenrich_decision(self, proceed: bool | None) -> None:
+        """Handle re-enrich confirmation result."""
+        if proceed and self._current_record is not None:
+            self._start_search(self._current_record)
+
+    def _start_search(self, record: BookRecord) -> None:
+        """Push loading overlay and start background search."""
+        self.push_screen(LoadingOverlay("Searching Open Library..."))
+        self.run_worker(
+            self._search_worker(record.metadata),
+            name="enrichment_search",
+            thread=True,
+        )
+
+    async def _search_worker(self, metadata: BookMetadata) -> list[MetadataCandidate]:
+        """Run metadata search in a background thread."""
+        return self.enrichment_service.search(metadata)
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        """Handle worker completion for search and apply operations."""
+        if event.state != WorkerState.SUCCESS:
+            if event.state == WorkerState.ERROR:
+                # Dismiss loading overlay on error
+                if self.screen.__class__.__name__ == "LoadingOverlay":
+                    self.screen.dismiss(None)
+                self.notify(
+                    f"Error: {event.worker.error}",
+                    severity="error",
+                    timeout=5,
+                )
+            return
+
+        if event.worker.name == "enrichment_search":
+            candidates = event.worker.result
+            if candidates is not None:
+                self._on_search_complete(candidates)
+        elif event.worker.name == "enrichment_apply":
+            result = event.worker.result
+            if result is not None:
+                self._on_apply_complete(result)
+
+    def _on_search_complete(self, candidates: list[MetadataCandidate]) -> None:
+        """Handle search worker completion — dismiss loading, show candidates."""
+        # Dismiss loading overlay
+        if self.screen.__class__.__name__ == "LoadingOverlay":
+            self.screen.dismiss(None)
+
+        if self._current_record is None:
+            return
+
+        self.push_screen(
+            CandidateSelectScreen(self._current_record.metadata, candidates),
+            callback=self._on_candidate_selected,
+        )
+
+    def _on_candidate_selected(self, candidate: MetadataCandidate | None) -> None:
+        """Handle candidate selection — show confirm screen or cancel."""
+        if candidate is None or self._current_record is None:
+            return
+
+        self.push_screen(
+            ConfirmScreen(self._current_record.metadata, candidate.metadata),
+            callback=lambda result: self._on_confirm_decision(result, candidate),
+        )
+
+    def _on_confirm_decision(
+        self, result: bool | None, candidate: MetadataCandidate
+    ) -> None:
+        """Handle confirm screen result."""
+        if result is True and self._current_record is not None:
+            self._start_apply(self._current_record, candidate.metadata)
+        elif result is False and self._current_record is not None:
+            # Back to candidates — re-run search
+            self._start_search(self._current_record)
+
+    def _start_apply(self, record: BookRecord, metadata: BookMetadata) -> None:
+        """Push loading overlay and start background apply."""
+        self.push_screen(LoadingOverlay("Writing metadata..."))
+        self.run_worker(
+            self._apply_worker(record.source_path, metadata),
+            name="enrichment_apply",
+            thread=True,
+        )
+
+    async def _apply_worker(self, source_path: Path, metadata: BookMetadata) -> WriteResult:
+        """Run metadata apply in a background thread."""
+        return self.enrichment_service.apply(source_path, metadata)
+
+    def _on_apply_complete(self, write_result: WriteResult) -> None:
+        """Handle apply worker completion — update catalog, show toast."""
+        # Dismiss loading overlay
+        if self.screen.__class__.__name__ == "LoadingOverlay":
+            self.screen.dismiss(None)
+
+        if write_result.success and self._current_record is not None:
+            # Update catalog on main thread (thread-safe)
+            if write_result.path is not None:
+                self.catalog.set_output_path(
+                    self._current_record.id, write_result.path
+                )
+                self.notify(
+                    f"Written to {write_result.path.name}",
+                    title="Enrichment complete",
+                    timeout=5,
+                )
+            # Refresh book list to show badge
+            self._refresh_book_list()
+        else:
+            error_msg = write_result.error or "Unknown error"
+            self.notify(
+                f"Write failed: {error_msg}",
+                severity="error",
+                timeout=5,
+            )
+
+    def _refresh_book_list(self) -> None:
+        """Reload the book list from the catalog."""
+        records = self.catalog.list_all()
+        self.query_one(BookList).load(records)
+
+    # --- Manual search (via candidate screen 'm' key) ---
+
+    def on_manual_search_modal_dismissed(self, query: str | None) -> None:
+        """Handle manual search modal result."""
+        if query is None or self._current_record is None:
+            return
+
+        self.push_screen(LoadingOverlay("Searching..."))
+        self.run_worker(
+            self._manual_search_worker(query),
+            name="enrichment_search",
+            thread=True,
+        )
+
+    async def _manual_search_worker(self, query: str) -> list[MetadataCandidate]:
+        """Run manual search in a background thread."""
+        return self.enrichment_service.search_manual(query)

--- a/src/bookery/tui/screens/__init__.py
+++ b/src/bookery/tui/screens/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: TUI screens package for enrichment workflow modals and screens.
+# ABOUTME: Provides candidate selection, confirmation, manual search, and re-enrich screens.

--- a/src/bookery/tui/screens/candidates.py
+++ b/src/bookery/tui/screens/candidates.py
@@ -1,0 +1,95 @@
+# ABOUTME: Candidate selection screen with split pane layout.
+# ABOUTME: Shows ranked candidates on top and a live diff preview below.
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Static
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+from bookery.tui.widgets.candidate_table import CandidateTable
+from bookery.tui.widgets.metadata_diff import MetadataDiff
+
+
+class CandidateSelectScreen(Screen[MetadataCandidate | None]):
+    """Split-pane screen for selecting a metadata candidate.
+
+    Top pane: ranked candidate table.
+    Bottom pane: diff preview of highlighted candidate vs current metadata.
+
+    Dismisses with the selected MetadataCandidate, or None on cancel.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("m", "manual_search", "Manual search"),
+    ]
+
+    def __init__(
+        self,
+        current: BookMetadata,
+        candidates: list[MetadataCandidate],
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._current = current
+        self._candidates = candidates
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(
+                "[bold]Select a candidate[/bold]  "
+                "[dim]Enter: select  m: manual search  Esc: cancel[/dim]",
+                id="candidate-header",
+            )
+            yield CandidateTable(id="candidate-list")
+            yield MetadataDiff(
+                self._current,
+                self._candidates[0].metadata if self._candidates else self._current,
+                mode="compact",
+                id="candidate-diff",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one(CandidateTable).load(self._candidates)
+        # Focus the candidate table
+        table = self.query_one("#candidate-table", DataTable)
+        table.focus()
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Update the diff preview when a candidate row is highlighted."""
+        if event.row_key is None or event.row_key.value is None:
+            return
+
+        index = int(event.row_key.value)
+        candidate_table = self.query_one(CandidateTable)
+        candidate = candidate_table.get_candidate_at(index)
+        if candidate is None:
+            return
+
+        self.query_one(MetadataDiff).update_diff(self._current, candidate.metadata)
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Handle Enter on a candidate row — select and dismiss."""
+        if event.row_key is None or event.row_key.value is None:
+            return
+
+        index = int(event.row_key.value)
+        candidate_table = self.query_one(CandidateTable)
+        candidate = candidate_table.get_candidate_at(index)
+        if candidate is not None:
+            self.dismiss(candidate)
+
+    def action_cancel(self) -> None:
+        """Cancel and return to the book list."""
+        self.dismiss(None)
+
+    def action_manual_search(self) -> None:
+        """Open the manual search modal."""
+        from bookery.tui.screens.manual import ManualSearchModal
+
+        self.app.push_screen(ManualSearchModal())

--- a/src/bookery/tui/screens/confirm.py
+++ b/src/bookery/tui/screens/confirm.py
@@ -1,0 +1,72 @@
+# ABOUTME: Confirmation screen for metadata enrichment write-back.
+# ABOUTME: Shows full field-by-field diff with accept, back, and cancel actions.
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from bookery.metadata.types import BookMetadata
+from bookery.tui.widgets.metadata_diff import MetadataDiff, compute_field_diffs
+
+
+class ConfirmScreen(Screen[bool | None]):
+    """Full field-by-field diff confirmation before writing.
+
+    Dismisses with:
+    - True: user accepts, proceed to write
+    - False: user wants to go back to candidate selection
+    - None: user cancels entirely
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("y", "accept", "Accept"),
+        Binding("enter", "accept", "Accept"),
+        Binding("b", "back", "Back"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        current: BookMetadata,
+        proposed: BookMetadata,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._current = current
+        self._proposed = proposed
+
+    def compose(self) -> ComposeResult:
+        diffs = compute_field_diffs(self._current, self._proposed)
+        has_data_loss = any(d.change == "removed" for d in diffs)
+
+        with Vertical():
+            yield Static(
+                "[bold]Confirm metadata changes[/bold]  "
+                "[dim]y/Enter: accept  b: back  Esc: cancel[/dim]",
+                id="confirm-header",
+            )
+            if has_data_loss:
+                yield Static(
+                    "[bold red]Warning:[/bold red] Some existing fields "
+                    "will be cleared (marked [-])",
+                    id="data-loss-warning",
+                )
+            yield MetadataDiff(
+                self._current, self._proposed, mode="full", id="confirm-diff"
+            )
+
+    def action_accept(self) -> None:
+        """Accept the proposed changes."""
+        self.dismiss(True)
+
+    def action_back(self) -> None:
+        """Go back to candidate selection."""
+        self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        """Cancel the entire enrichment flow."""
+        self.dismiss(None)

--- a/src/bookery/tui/screens/loading.py
+++ b/src/bookery/tui/screens/loading.py
@@ -1,0 +1,31 @@
+# ABOUTME: Loading overlay modal shown during async operations.
+# ABOUTME: Displays a spinner and message while metadata search or write is in progress.
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Center, Middle
+from textual.screen import ModalScreen
+from textual.widgets import LoadingIndicator, Static
+
+
+class LoadingOverlay(ModalScreen[None]):
+    """Translucent modal overlay with spinner shown during async operations."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, message: str = "Loading...", **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._message = message
+
+    def compose(self) -> ComposeResult:
+        with Center(), Middle():
+            yield LoadingIndicator()
+            yield Static(self._message, id="loading-message")
+
+    def action_cancel(self) -> None:
+        """Cancel the loading operation."""
+        self.dismiss(None)

--- a/src/bookery/tui/screens/manual.py
+++ b/src/bookery/tui/screens/manual.py
@@ -1,0 +1,47 @@
+# ABOUTME: Manual search modal for free-text query or Open Library URL input.
+# ABOUTME: Dismisses with the search query string or None on cancel.
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Center, Middle
+from textual.screen import ModalScreen
+from textual.widgets import Input, Static
+
+
+class ManualSearchModal(ModalScreen[str | None]):
+    """Modal with a text input for manual search query or Open Library URL.
+
+    Dismisses with the query string, or None on cancel.
+    URLs (http/https) are auto-detected by the caller.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Center(), Middle():
+            yield Static(
+                "[bold]Manual Search[/bold]\n"
+                "[dim]Enter a title, author, or Open Library URL[/dim]",
+                id="manual-search-label",
+            )
+            yield Input(
+                placeholder="Search query or URL...",
+                id="manual-search-input",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle Enter key in the input field."""
+        query = event.value.strip()
+        if query:
+            self.dismiss(query)
+
+    def action_cancel(self) -> None:
+        """Cancel manual search."""
+        self.dismiss(None)

--- a/src/bookery/tui/screens/reenrich.py
+++ b/src/bookery/tui/screens/reenrich.py
@@ -1,0 +1,41 @@
+# ABOUTME: Re-enrichment confirmation modal for already-enriched books.
+# ABOUTME: Asks user to confirm before re-enriching a book that has an existing output.
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Center, Middle
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class ReEnrichConfirmModal(ModalScreen[bool]):
+    """Confirmation dialog when a book has already been enriched.
+
+    Dismisses with True (proceed) or False (cancel).
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("y", "confirm", "Yes"),
+        Binding("n", "decline", "No"),
+        Binding("escape", "decline", "Cancel"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Center(), Middle():
+            yield Static(
+                "[bold]This book has already been enriched.[/bold]\n\n"
+                "Re-enriching will create a new copy.\n"
+                "The previous enriched copy will not be overwritten.\n\n"
+                "[dim]y: proceed  n/Esc: cancel[/dim]",
+                id="reenrich-message",
+            )
+
+    def action_confirm(self) -> None:
+        """Proceed with re-enrichment."""
+        self.dismiss(True)
+
+    def action_decline(self) -> None:
+        """Cancel re-enrichment."""
+        self.dismiss(False)

--- a/src/bookery/tui/styles/enrichment.tcss
+++ b/src/bookery/tui/styles/enrichment.tcss
@@ -1,0 +1,96 @@
+/* Styles for the metadata enrichment workflow screens */
+
+/* Loading overlay */
+LoadingOverlay {
+    align: center middle;
+    background: $surface 80%;
+}
+
+LoadingOverlay Center {
+    width: auto;
+    height: auto;
+}
+
+#loading-message {
+    text-align: center;
+    padding: 1 2;
+    text-style: dim;
+}
+
+/* Candidate selection screen */
+CandidateSelectScreen {
+    layout: vertical;
+}
+
+#candidate-header {
+    height: 1;
+    padding: 0 1;
+}
+
+#candidate-list {
+    height: 2fr;
+    border: solid $panel;
+}
+
+#candidate-diff {
+    height: 1fr;
+    border: solid $panel;
+    padding: 0 1;
+}
+
+/* Confirm screen */
+ConfirmScreen {
+    layout: vertical;
+}
+
+#confirm-header {
+    height: 1;
+    padding: 0 1;
+}
+
+#data-loss-warning {
+    height: 1;
+    padding: 0 1;
+    background: $error 20%;
+}
+
+#confirm-diff {
+    height: 1fr;
+    padding: 0 1;
+}
+
+/* Manual search modal */
+ManualSearchModal {
+    align: center middle;
+    background: $surface 80%;
+}
+
+ManualSearchModal Center {
+    width: 60;
+    height: auto;
+}
+
+#manual-search-label {
+    text-align: center;
+    padding: 1 2;
+}
+
+#manual-search-input {
+    margin: 1 2;
+}
+
+/* Re-enrich confirmation modal */
+ReEnrichConfirmModal {
+    align: center middle;
+    background: $surface 80%;
+}
+
+ReEnrichConfirmModal Center {
+    width: 60;
+    height: auto;
+}
+
+#reenrich-message {
+    text-align: center;
+    padding: 1 2;
+}

--- a/src/bookery/tui/widgets/book_list.py
+++ b/src/bookery/tui/widgets/book_list.py
@@ -10,14 +10,18 @@ from bookery.db.mapping import BookRecord
 
 
 def format_row_label(record: BookRecord) -> str:
-    """Format a BookRecord as 'Author Last, First \u2014 Title' for display."""
+    """Format a BookRecord as 'Author Last, First \u2014 Title' for display.
+
+    Books with an output_path (already enriched) get a checkmark badge.
+    """
     author_sort = derive_author_sort(record.metadata)
     if author_sort == "Unknown":
         author_sort = "Unknown Author"
 
     title = record.metadata.title if record.metadata.title else "(Untitled)"
 
-    return f"{author_sort} \u2014 {title}"
+    badge = "\u2713 " if record.output_path is not None else ""
+    return f"{badge}{author_sort} \u2014 {title}"
 
 
 def author_sort_key(record: BookRecord) -> tuple[int, str]:

--- a/src/bookery/tui/widgets/candidate_table.py
+++ b/src/bookery/tui/widgets/candidate_table.py
@@ -1,0 +1,75 @@
+# ABOUTME: CandidateTable widget displaying ranked metadata candidates.
+# ABOUTME: Shows confidence scores, tier labels, and source info in a DataTable.
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import DataTable
+
+from bookery.metadata.candidate import MetadataCandidate
+
+_HIGH_THRESHOLD = 0.8
+_MEDIUM_THRESHOLD = 0.5
+
+
+def confidence_tier(confidence: float) -> str:
+    """Map a confidence score to a tier label (HIGH/MED/LOW)."""
+    if confidence >= _HIGH_THRESHOLD:
+        return "HIGH"
+    if confidence >= _MEDIUM_THRESHOLD:
+        return "MED"
+    return "LOW"
+
+
+class CandidateTable(Widget):
+    """A DataTable of ranked MetadataCandidates with confidence scores."""
+
+    can_focus_children = True
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._candidates: list[MetadataCandidate] = []
+
+    def compose(self) -> ComposeResult:
+        yield DataTable(id="candidate-table")
+
+    def on_mount(self) -> None:
+        table = self.query_one("#candidate-table", DataTable)
+        table.add_column("#", key="index", width=3)
+        table.add_column("Title", key="title")
+        table.add_column("Author", key="author")
+        table.add_column("ISBN", key="isbn", width=16)
+        table.add_column("Lang", key="language", width=5)
+        table.add_column("Confidence", key="confidence", width=12)
+        table.add_column("Source", key="source", width=12)
+        table.cursor_type = "row"
+
+    def load(self, candidates: list[MetadataCandidate]) -> None:
+        """Populate the table with candidates."""
+        self._candidates = list(candidates)
+        table = self.query_one("#candidate-table", DataTable)
+        table.clear()
+
+        for i, candidate in enumerate(candidates, start=1):
+            conf_pct = f"{candidate.confidence:.0%}"
+            tier = confidence_tier(candidate.confidence)
+            table.add_row(
+                str(i),
+                candidate.metadata.title,
+                candidate.metadata.author,
+                candidate.metadata.isbn or "\u2014",
+                candidate.metadata.language or "\u2014",
+                f"{conf_pct} {tier}",
+                candidate.source,
+                key=str(i - 1),
+            )
+
+    def get_candidate_at(self, index: int) -> MetadataCandidate | None:
+        """Get the candidate at the given index."""
+        if 0 <= index < len(self._candidates):
+            return self._candidates[index]
+        return None
+
+    @property
+    def candidates(self) -> list[MetadataCandidate]:
+        """The currently loaded candidates."""
+        return self._candidates

--- a/src/bookery/tui/widgets/metadata_diff.py
+++ b/src/bookery/tui/widgets/metadata_diff.py
@@ -1,0 +1,150 @@
+# ABOUTME: Shared metadata diff widget for comparing current vs proposed metadata.
+# ABOUTME: Supports compact mode (changed fields only) and full mode (all fields with markers).
+
+from dataclasses import dataclass
+
+from textual.widget import Widget
+
+from bookery.metadata.types import BookMetadata
+
+_MARKERS = {
+    "added": "[+]",
+    "changed": "[~]",
+    "removed": "[-]",
+    "unchanged": "",
+}
+
+
+@dataclass
+class FieldDiff:
+    """A single field comparison between current and proposed metadata."""
+
+    field: str
+    current: str
+    proposed: str
+    change: str  # "added" | "changed" | "removed" | "unchanged"
+
+    @property
+    def marker(self) -> str:
+        """Change indicator symbol for display."""
+        return _MARKERS.get(self.change, "")
+
+
+def _field_value(value: str | None) -> str:
+    """Convert a metadata field value to a display string."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _format_series(series: str | None, index: float | None) -> str:
+    """Format series name with optional index."""
+    if not series:
+        return ""
+    if index is not None:
+        return f"{series} #{int(index)}"
+    return series
+
+
+def compute_field_diffs(
+    current: BookMetadata, proposed: BookMetadata
+) -> list[FieldDiff]:
+    """Compare two BookMetadata instances field by field.
+
+    Returns a list of FieldDiff objects for each comparable metadata field.
+    """
+    fields: list[tuple[str, str, str]] = [
+        ("Title", _field_value(current.title), _field_value(proposed.title)),
+        (
+            "Authors",
+            ", ".join(current.authors) if current.authors else "",
+            ", ".join(proposed.authors) if proposed.authors else "",
+        ),
+        ("Publisher", _field_value(current.publisher), _field_value(proposed.publisher)),
+        ("ISBN", _field_value(current.isbn), _field_value(proposed.isbn)),
+        ("Language", _field_value(current.language), _field_value(proposed.language)),
+        (
+            "Description",
+            _field_value(current.description),
+            _field_value(proposed.description),
+        ),
+        (
+            "Series",
+            _format_series(current.series, current.series_index),
+            _format_series(proposed.series, proposed.series_index),
+        ),
+        (
+            "Subjects",
+            ", ".join(current.subjects) if current.subjects else "",
+            ", ".join(proposed.subjects) if proposed.subjects else "",
+        ),
+    ]
+
+    diffs: list[FieldDiff] = []
+    for field_name, cur, prop in fields:
+        if cur == prop:
+            change = "unchanged"
+        elif not cur and prop:
+            change = "added"
+        elif cur and not prop:
+            change = "removed"
+        else:
+            change = "changed"
+
+        diffs.append(FieldDiff(field=field_name, current=cur, proposed=prop, change=change))
+
+    return diffs
+
+
+def _render_diff_lines(diffs: list[FieldDiff], mode: str) -> str:
+    """Render field diffs as formatted text lines."""
+    lines: list[str] = []
+    for diff in diffs:
+        if mode == "compact" and diff.change == "unchanged":
+            continue
+
+        marker = f" {diff.marker}" if diff.marker else "    "
+        current_display = diff.current or "\u2014"
+        proposed_display = diff.proposed or "\u2014"
+
+        if diff.change == "unchanged":
+            lines.append(f"    {diff.field:>12}  {current_display}")
+        else:
+            lines.append(
+                f"{marker} {diff.field:>12}  {current_display} \u2192 {proposed_display}"
+            )
+
+    return "\n".join(lines)
+
+
+class MetadataDiff(Widget):
+    """Side-by-side metadata comparison widget.
+
+    Modes:
+    - "compact": only changed fields, for candidate list preview
+    - "full": all fields with change indicators, for confirmation screen
+    """
+
+    def __init__(
+        self,
+        current: BookMetadata,
+        proposed: BookMetadata,
+        *,
+        mode: str = "compact",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._current = current
+        self._proposed = proposed
+        self._mode = mode
+
+    def update_diff(self, current: BookMetadata, proposed: BookMetadata) -> None:
+        """Update the diff with new metadata pair and refresh display."""
+        self._current = current
+        self._proposed = proposed
+        self.refresh()
+
+    def render(self) -> str:
+        """Render the metadata diff as formatted text."""
+        diffs = compute_field_diffs(self._current, self._proposed)
+        return _render_diff_lines(diffs, self._mode)

--- a/tests/e2e/test_enrichment_e2e.py
+++ b/tests/e2e/test_enrichment_e2e.py
@@ -1,0 +1,180 @@
+# ABOUTME: End-to-end tests for TUI metadata enrichment.
+# ABOUTME: Tests the complete enrichment workflow in a headless Textual app.
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+from bookery.tui.app import BookeryApp
+
+
+def _make_candidate(
+    title: str = "The Name of the Rose",
+    authors: list[str] | None = None,
+    confidence: float = 0.95,
+) -> MetadataCandidate:
+    return MetadataCandidate(
+        metadata=BookMetadata(
+            title=title,
+            authors=authors or ["Umberto Eco"],
+            isbn="978-0-15-144647-6",
+            language="en",
+            publisher="Harcourt",
+        ),
+        confidence=confidence,
+        source="openlibrary",
+        source_id="/works/OL123W",
+    )
+
+
+@pytest.mark.asyncio
+class TestEnrichmentE2E:
+    """End-to-end tests for the enrichment feature."""
+
+    async def test_enrichment_badge_appears_after_apply(
+        self, tmp_path, sample_epub
+    ) -> None:
+        """After enrichment, the book list row shows a checkmark badge."""
+        from textual.widgets import DataTable
+
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        catalog.add_book(
+            BookMetadata(
+                title="The Name of the Rose",
+                authors=["Umberto Eco"],
+                source_path=sample_epub,
+            ),
+            file_hash="hash1",
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.name = "mock"
+        mock_provider.search_by_isbn.return_value = []
+        mock_provider.search_by_title_author.return_value = [_make_candidate()]
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        app = BookeryApp(
+            catalog=catalog,
+            output_dir=output_dir,
+            provider=mock_provider,
+        )
+
+        try:
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                # Focus table and check initial state (no checkmark)
+                table = app.query_one("#book-table", DataTable)
+                table.focus()
+                await pilot.pause()
+
+                initial_row = str(table.get_row_at(0)[0])
+                assert "\u2713" not in initial_row
+
+                # Start enrichment
+                await pilot.press("e")
+
+                # Wait for candidate screen
+                for _ in range(20):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ == "CandidateSelectScreen":
+                        break
+
+                # Select and confirm
+                screen = app.screen
+                ct_table = screen.query_one("#candidate-table", DataTable)
+                ct_table.focus()
+                await pilot.pause()
+                await pilot.press("enter")
+
+                for _ in range(10):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ == "ConfirmScreen":
+                        break
+
+                await pilot.press("y")
+
+                # Wait for apply to complete
+                for _ in range(30):
+                    await pilot.pause()
+
+                # Check the row now has a checkmark
+                table = app.query_one("#book-table", DataTable)
+                if table.row_count > 0:
+                    updated_row = str(table.get_row_at(0)[0])
+                    assert "\u2713" in updated_row
+
+                await pilot.press("q")
+        finally:
+            conn.close()
+
+    async def test_escape_cancels_enrichment_at_candidate_screen(
+        self, tmp_path
+    ) -> None:
+        """Pressing Escape at candidate screen returns to main screen."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        catalog.add_book(
+            BookMetadata(
+                title="Test Book",
+                authors=["Test Author"],
+                source_path=Path("/books/test.epub"),
+            ),
+            file_hash="hash1",
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.name = "mock"
+        mock_provider.search_by_isbn.return_value = []
+        mock_provider.search_by_title_author.return_value = [_make_candidate()]
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        app = BookeryApp(
+            catalog=catalog,
+            output_dir=output_dir,
+            provider=mock_provider,
+        )
+
+        try:
+            async with app.run_test() as pilot:
+                from textual.widgets import DataTable
+                await pilot.pause()
+
+                table = app.query_one("#book-table", DataTable)
+                table.focus()
+                await pilot.pause()
+
+                await pilot.press("e")
+
+                # Wait for candidate screen
+                for _ in range(20):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ == "CandidateSelectScreen":
+                        break
+
+                assert app.screen.__class__.__name__ == "CandidateSelectScreen"
+
+                # Cancel
+                await pilot.press("escape")
+                await pilot.pause()
+
+                # Back to default screen
+                assert app.screen.__class__.__name__ != "CandidateSelectScreen"
+
+                await pilot.press("q")
+        finally:
+            conn.close()

--- a/tests/integration/test_enrichment_tui.py
+++ b/tests/integration/test_enrichment_tui.py
@@ -1,0 +1,236 @@
+# ABOUTME: Integration tests for the TUI metadata enrichment workflow.
+# ABOUTME: Tests the full flow with mock provider: search, select, confirm, write.
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+from bookery.tui.app import BookeryApp
+
+
+def _make_candidate(
+    title: str = "Enriched Title",
+    authors: list[str] | None = None,
+    confidence: float = 0.9,
+) -> MetadataCandidate:
+    return MetadataCandidate(
+        metadata=BookMetadata(
+            title=title,
+            authors=authors or ["Enriched Author"],
+            isbn="978-0-999999-99-9",
+            language="en",
+        ),
+        confidence=confidence,
+        source="openlibrary",
+        source_id="/works/OL123W",
+    )
+
+
+@pytest.fixture
+def db_and_catalog(tmp_path):
+    """Create a DB with one book and return (conn, catalog, book_id)."""
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+
+    book_id = catalog.add_book(
+        BookMetadata(
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
+            source_path=Path("/books/rose.epub"),
+        ),
+        file_hash="hash1",
+    )
+    return conn, catalog, book_id
+
+
+@pytest.fixture
+def mock_provider():
+    """Create a mock MetadataProvider returning one candidate."""
+    provider = MagicMock()
+    provider.name = "mock"
+    provider.search_by_isbn.return_value = []
+    provider.search_by_title_author.return_value = [_make_candidate()]
+    provider.lookup_by_url.return_value = None
+    return provider
+
+
+@pytest.mark.asyncio
+class TestEnrichmentTuiIntegration:
+    """Integration tests for the enrichment TUI workflow."""
+
+    async def test_e_key_shows_loading_then_candidates(
+        self, db_and_catalog, mock_provider, tmp_path
+    ) -> None:
+        """Pressing 'e' triggers search and shows candidate screen."""
+        conn, catalog, _book_id = db_and_catalog
+        from textual.widgets import DataTable
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        app = BookeryApp(
+            catalog=catalog,
+            output_dir=output_dir,
+            provider=mock_provider,
+        )
+
+        try:
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                # Focus the book table
+                table = app.query_one("#book-table", DataTable)
+                table.focus()
+                await pilot.pause()
+
+                # Press 'e' to start enrichment
+                await pilot.press("e")
+                await pilot.pause()
+
+                # Loading overlay should appear briefly, then candidate screen
+                # Give the worker time to complete
+                for _ in range(20):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ == "CandidateSelectScreen":
+                        break
+
+                assert app.screen.__class__.__name__ == "CandidateSelectScreen"
+
+                # Verify candidates are loaded
+                from bookery.tui.widgets.candidate_table import CandidateTable
+                screen = app.screen
+                ct = screen.query_one(CandidateTable)
+                assert len(ct.candidates) == 1
+
+                await pilot.press("escape")
+                await pilot.pause()
+                await pilot.press("q")
+        finally:
+            conn.close()
+
+    async def test_e_on_enriched_book_shows_reenrich_modal(
+        self, db_and_catalog, mock_provider, tmp_path
+    ) -> None:
+        """Pressing 'e' on an already-enriched book shows re-enrich confirmation."""
+        conn, catalog, book_id = db_and_catalog
+        from textual.widgets import DataTable
+
+        # Mark the book as enriched
+        catalog.set_output_path(book_id, Path("/output/rose.epub"))
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        app = BookeryApp(
+            catalog=catalog,
+            output_dir=output_dir,
+            provider=mock_provider,
+        )
+
+        try:
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                table = app.query_one("#book-table", DataTable)
+                table.focus()
+                await pilot.pause()
+
+                await pilot.press("e")
+                await pilot.pause()
+
+                # Re-enrich modal should appear
+                assert app.screen.__class__.__name__ == "ReEnrichConfirmModal"
+
+                # Cancel
+                await pilot.press("escape")
+                await pilot.pause()
+                await pilot.press("q")
+        finally:
+            conn.close()
+
+    async def test_full_enrich_flow_with_mock_provider(
+        self, db_and_catalog, mock_provider, tmp_path, sample_epub
+    ) -> None:
+        """Full flow: e -> select candidate -> confirm -> apply succeeds."""
+        conn, catalog, _book_id = db_and_catalog
+        from textual.widgets import DataTable
+
+        # Re-add with real epub path for apply to work
+        catalog.delete_book(_book_id)
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="The Name of the Rose",
+                authors=["Umberto Eco"],
+                source_path=sample_epub,
+            ),
+            file_hash="hash_real",
+        )
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        app = BookeryApp(
+            catalog=catalog,
+            output_dir=output_dir,
+            provider=mock_provider,
+        )
+
+        try:
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+
+                # Focus and press 'e'
+                table = app.query_one("#book-table", DataTable)
+                table.focus()
+                await pilot.pause()
+                await pilot.press("e")
+
+                # Wait for candidate screen
+                for _ in range(20):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ == "CandidateSelectScreen":
+                        break
+
+                assert app.screen.__class__.__name__ == "CandidateSelectScreen"
+
+                # Select the candidate (Enter)
+                screen = app.screen
+                ct_table = screen.query_one("#candidate-table", DataTable)
+                ct_table.focus()
+                await pilot.pause()
+                await pilot.press("enter")
+
+                # Wait for confirm screen
+                for _ in range(10):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ == "ConfirmScreen":
+                        break
+
+                assert app.screen.__class__.__name__ == "ConfirmScreen"
+
+                # Accept (y)
+                await pilot.press("y")
+
+                # Wait for apply to complete
+                for _ in range(30):
+                    await pilot.pause()
+                    if app.screen.__class__.__name__ != "LoadingOverlay":
+                        break
+
+                # Should be back at the main screen
+                await pilot.pause()
+
+                # Verify the catalog was updated
+                updated = catalog.get_by_id(book_id)
+                assert updated is not None
+                assert updated.output_path is not None
+
+                await pilot.press("q")
+        finally:
+            conn.close()

--- a/tests/unit/test_book_list_widget.py
+++ b/tests/unit/test_book_list_widget.py
@@ -102,6 +102,34 @@ class TestAuthorSortKey:
         assert author_sort_key(calvino) < author_sort_key(eco)
 
 
+class TestEnrichedBadge:
+    """Tests for the enrichment badge in row labels."""
+
+    def test_enriched_book_shows_checkmark(self) -> None:
+        """BookRecord with output_path shows checkmark in row label."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = BookRecord(
+            id=1,
+            metadata=BookMetadata(title="Test", authors=["Author"]),
+            file_hash="abc",
+            source_path=Path("/books/test.epub"),
+            output_path=Path("/output/test.epub"),
+            date_added="2025-01-01T00:00:00",
+            date_modified="2025-01-01T00:00:00",
+        )
+        label = format_row_label(record)
+        assert "\u2713" in label  # checkmark character
+
+    def test_unenriched_book_has_no_checkmark(self) -> None:
+        """BookRecord with output_path=None has no checkmark."""
+        from bookery.tui.widgets.book_list import format_row_label
+
+        record = _make_record()
+        label = format_row_label(record)
+        assert "\u2713" not in label
+
+
 class TestBookListLoad:
     """Tests for BookList.load() via Textual's async test harness."""
 
@@ -109,6 +137,7 @@ class TestBookListLoad:
     async def test_load_populates_table(self) -> None:
         """load() populates the DataTable with sorted records."""
         from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
 
         from bookery.tui.widgets.book_list import BookList
 
@@ -128,7 +157,7 @@ class TestBookListLoad:
             book_list.load(records)
             await pilot.pause()
 
-            table = app.query_one("#book-table")
+            table = app.query_one("#book-table", DataTable)
             assert table.row_count == 3
 
             # Calvino should be first, Eco second, Unknown last
@@ -207,6 +236,7 @@ class TestBookListLoad:
     async def test_row_keys_are_record_ids(self) -> None:
         """DataTable row keys match BookRecord.id values."""
         from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
 
         from bookery.tui.widgets.book_list import BookList
 
@@ -224,6 +254,6 @@ class TestBookListLoad:
             book_list.load(records)
             await pilot.pause()
 
-            table = app.query_one("#book-table")
+            table = app.query_one("#book-table", DataTable)
             row_key = next(iter(table.rows.keys()))
             assert row_key.value == "42"

--- a/tests/unit/test_candidate_screen.py
+++ b/tests/unit/test_candidate_screen.py
@@ -1,0 +1,130 @@
+# ABOUTME: Unit tests for the CandidateSelectScreen.
+# ABOUTME: Verifies split-pane layout, candidate selection, and dismiss behavior.
+
+import pytest
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+from bookery.tui.screens.candidates import CandidateSelectScreen
+from bookery.tui.widgets.candidate_table import CandidateTable
+from bookery.tui.widgets.metadata_diff import MetadataDiff
+
+
+def _make_candidate(
+    title: str = "Test Book",
+    confidence: float = 0.9,
+) -> MetadataCandidate:
+    return MetadataCandidate(
+        metadata=BookMetadata(title=title, authors=["Test Author"]),
+        confidence=confidence,
+        source="openlibrary",
+        source_id="test-id",
+    )
+
+
+@pytest.mark.asyncio
+class TestCandidateSelectScreen:
+    """Tests for the CandidateSelectScreen."""
+
+    async def test_screen_has_candidate_table_and_diff(self) -> None:
+        """Screen contains both CandidateTable and MetadataDiff widgets."""
+        from textual.app import App
+
+        current = BookMetadata(title="Original")
+        candidates = [_make_candidate()]
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    CandidateSelectScreen(current, candidates)
+                )
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert len(screen.query(CandidateTable)) == 1
+            assert len(screen.query(MetadataDiff)) == 1
+
+    async def test_escape_dismisses_with_none(self) -> None:
+        """Pressing Escape dismisses the screen with None."""
+        from textual.app import App
+
+        current = BookMetadata(title="Original")
+        candidates = [_make_candidate()]
+        result = None
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    CandidateSelectScreen(current, candidates),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: MetadataCandidate | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert result is None
+
+    async def test_enter_selects_highlighted_candidate(self) -> None:
+        """Pressing Enter on a highlighted candidate dismisses with that candidate."""
+        from textual.app import App
+        from textual.widgets import DataTable
+
+        current = BookMetadata(title="Original")
+        candidate = _make_candidate(title="Selected Book")
+        candidates = [candidate]
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    CandidateSelectScreen(current, candidates),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: MetadataCandidate | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Focus the candidate table and press enter
+            screen = app.screen
+            table = screen.query_one("#candidate-table", DataTable)
+            table.focus()
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+        assert result is not None
+        assert result != "not_set"
+        assert result.metadata.title == "Selected Book"
+
+    async def test_no_candidates_shows_empty_table(self) -> None:
+        """Empty candidate list produces zero table rows."""
+        from textual.app import App
+        from textual.widgets import DataTable
+
+        current = BookMetadata(title="Original")
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    CandidateSelectScreen(current, [])
+                )
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            table = screen.query_one("#candidate-table", DataTable)
+            assert table.row_count == 0

--- a/tests/unit/test_candidate_table_widget.py
+++ b/tests/unit/test_candidate_table_widget.py
@@ -1,0 +1,158 @@
+# ABOUTME: Unit tests for the CandidateTable widget.
+# ABOUTME: Verifies candidate rendering, confidence display, and row ordering.
+
+import pytest
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+from bookery.tui.widgets.candidate_table import CandidateTable, confidence_tier
+
+
+def _make_candidate(
+    title: str = "Test Book",
+    authors: list[str] | None = None,
+    confidence: float = 0.9,
+    source: str = "openlibrary",
+    isbn: str | None = None,
+    language: str | None = None,
+) -> MetadataCandidate:
+    """Create a test MetadataCandidate."""
+    return MetadataCandidate(
+        metadata=BookMetadata(
+            title=title,
+            authors=authors or ["Test Author"],
+            isbn=isbn,
+            language=language,
+        ),
+        confidence=confidence,
+        source=source,
+        source_id="test-id",
+    )
+
+
+class TestConfidenceTier:
+    """Tests for the confidence_tier helper."""
+
+    def test_high_confidence(self) -> None:
+        assert confidence_tier(0.85) == "HIGH"
+
+    def test_medium_confidence(self) -> None:
+        assert confidence_tier(0.65) == "MED"
+
+    def test_low_confidence(self) -> None:
+        assert confidence_tier(0.3) == "LOW"
+
+    def test_boundary_high(self) -> None:
+        assert confidence_tier(0.8) == "HIGH"
+
+    def test_boundary_medium(self) -> None:
+        assert confidence_tier(0.5) == "MED"
+
+
+@pytest.mark.asyncio
+class TestCandidateTableWidget:
+    """Tests for the CandidateTable Textual widget."""
+
+    async def test_renders_candidates_with_correct_columns(self) -> None:
+        """CandidateTable shows all expected columns."""
+        from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
+
+        candidates = [_make_candidate()]
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield CandidateTable(id="ct")
+
+            def on_mount(self) -> None:
+                self.query_one(CandidateTable).load(candidates)
+
+        app = TestApp()
+        async with app.run_test():
+            table = app.query_one("#candidate-table", DataTable)
+            assert table.row_count == 1
+
+    async def test_confidence_shown_as_percentage(self) -> None:
+        """Confidence 0.85 renders as '85% HIGH'."""
+        from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
+
+        candidates = [_make_candidate(confidence=0.85)]
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield CandidateTable(id="ct")
+
+            def on_mount(self) -> None:
+                self.query_one(CandidateTable).load(candidates)
+
+        app = TestApp()
+        async with app.run_test():
+            table = app.query_one("#candidate-table", DataTable)
+            row = table.get_row_at(0)
+            row_text = " ".join(str(cell) for cell in row)
+            assert "85%" in row_text
+            assert "HIGH" in row_text
+
+    async def test_shows_title_and_author(self) -> None:
+        """Candidate title and author are visible in the table."""
+        from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
+
+        candidates = [_make_candidate(title="Dune", authors=["Frank Herbert"])]
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield CandidateTable(id="ct")
+
+            def on_mount(self) -> None:
+                self.query_one(CandidateTable).load(candidates)
+
+        app = TestApp()
+        async with app.run_test():
+            table = app.query_one("#candidate-table", DataTable)
+            row = table.get_row_at(0)
+            row_text = " ".join(str(cell) for cell in row)
+            assert "Dune" in row_text
+            assert "Frank Herbert" in row_text
+
+    async def test_empty_candidates_shows_no_rows(self) -> None:
+        """Empty candidate list produces zero table rows."""
+        from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield CandidateTable(id="ct")
+
+            def on_mount(self) -> None:
+                self.query_one(CandidateTable).load([])
+
+        app = TestApp()
+        async with app.run_test():
+            table = app.query_one("#candidate-table", DataTable)
+            assert table.row_count == 0
+
+    async def test_multiple_candidates_ordered_by_index(self) -> None:
+        """Multiple candidates render in the order they are provided."""
+        from textual.app import App, ComposeResult
+        from textual.widgets import DataTable
+
+        candidates = [
+            _make_candidate(title="Best Match", confidence=0.95),
+            _make_candidate(title="Okay Match", confidence=0.60),
+        ]
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield CandidateTable(id="ct")
+
+            def on_mount(self) -> None:
+                self.query_one(CandidateTable).load(candidates)
+
+        app = TestApp()
+        async with app.run_test():
+            table = app.query_one("#candidate-table", DataTable)
+            assert table.row_count == 2
+            first_row = " ".join(str(cell) for cell in table.get_row_at(0))
+            assert "Best Match" in first_row

--- a/tests/unit/test_confirm_screen.py
+++ b/tests/unit/test_confirm_screen.py
@@ -1,0 +1,134 @@
+# ABOUTME: Unit tests for the ConfirmScreen.
+# ABOUTME: Verifies full diff display, accept/back/cancel behavior, and data loss warnings.
+
+import pytest
+
+from bookery.metadata.types import BookMetadata
+from bookery.tui.screens.confirm import ConfirmScreen
+from bookery.tui.widgets.metadata_diff import MetadataDiff
+
+
+@pytest.mark.asyncio
+class TestConfirmScreen:
+    """Tests for the ConfirmScreen."""
+
+    async def test_shows_full_diff(self) -> None:
+        """Screen contains a MetadataDiff widget in full mode."""
+        from textual.app import App
+
+        current = BookMetadata(title="Original", isbn="111")
+        proposed = BookMetadata(title="Updated", isbn="222")
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(ConfirmScreen(current, proposed))
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            diff = screen.query_one(MetadataDiff)
+            assert diff is not None
+            rendered = str(diff.render())
+            # Full mode should show all fields including unchanged
+            assert "Title" in rendered
+
+    async def test_accept_dismisses_with_true(self) -> None:
+        """Pressing 'y' dismisses the screen with True."""
+        from textual.app import App
+
+        current = BookMetadata(title="Original")
+        proposed = BookMetadata(title="Updated")
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ConfirmScreen(current, proposed),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: bool | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("y")
+            await pilot.pause()
+
+        assert result is True
+
+    async def test_back_dismisses_with_false(self) -> None:
+        """Pressing 'b' dismisses the screen with False (back to candidates)."""
+        from textual.app import App
+
+        current = BookMetadata(title="Original")
+        proposed = BookMetadata(title="Updated")
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ConfirmScreen(current, proposed),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: bool | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("b")
+            await pilot.pause()
+
+        assert result is False
+
+    async def test_escape_dismisses_with_none(self) -> None:
+        """Pressing Escape dismisses with None (cancel entirely)."""
+        from textual.app import App
+
+        current = BookMetadata(title="Original")
+        proposed = BookMetadata(title="Updated")
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ConfirmScreen(current, proposed),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: bool | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert result is None
+
+    async def test_data_loss_warning_visible(self) -> None:
+        """When proposed clears an existing field, warning marker is shown."""
+        from textual.app import App
+
+        current = BookMetadata(title="Test", publisher="Einaudi")
+        proposed = BookMetadata(title="Test", publisher=None)
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(ConfirmScreen(current, proposed))
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            diff = screen.query_one(MetadataDiff)
+            rendered = str(diff.render())
+            assert "[-]" in rendered

--- a/tests/unit/test_enrichment_service.py
+++ b/tests/unit/test_enrichment_service.py
@@ -1,0 +1,247 @@
+# ABOUTME: Unit tests for the EnrichmentService core facade.
+# ABOUTME: Verifies search delegation, normalization, manual search, URL lookup, and apply.
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bookery.core.enrichment import EnrichmentService
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture
+def provider() -> MagicMock:
+    """Create a mock MetadataProvider."""
+    mock = MagicMock()
+    mock.name = "mock_provider"
+    mock.search_by_isbn.return_value = []
+    mock.search_by_title_author.return_value = []
+    mock.lookup_by_url.return_value = None
+    return mock
+
+
+@pytest.fixture
+def output_dir(tmp_path: Path) -> Path:
+    """Create a temporary output directory."""
+    d = tmp_path / "output"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def service(provider: MagicMock, output_dir: Path) -> EnrichmentService:
+    """Create an EnrichmentService with mock provider."""
+    return EnrichmentService(provider=provider, output_dir=output_dir)
+
+
+def _make_candidate(
+    title: str = "Test Book",
+    confidence: float = 0.9,
+    source: str = "test",
+) -> MetadataCandidate:
+    """Create a test MetadataCandidate."""
+    return MetadataCandidate(
+        metadata=BookMetadata(title=title, authors=["Test Author"]),
+        confidence=confidence,
+        source=source,
+        source_id="test-id",
+    )
+
+
+class TestEnrichmentServiceSearch:
+    """Tests for EnrichmentService.search()."""
+
+    def test_search_by_isbn_when_isbn_present(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search() delegates to search_by_isbn when metadata has ISBN."""
+        candidate = _make_candidate()
+        provider.search_by_isbn.return_value = [candidate]
+
+        metadata = BookMetadata(title="Test", isbn="978-0-123456-47-2")
+        result = service.search(metadata)
+
+        provider.search_by_isbn.assert_called_once_with("978-0-123456-47-2")
+        assert result == [candidate]
+
+    def test_search_falls_back_to_title_author(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search() falls back to title/author when ISBN search returns nothing."""
+        candidate = _make_candidate()
+        provider.search_by_isbn.return_value = []
+        provider.search_by_title_author.return_value = [candidate]
+
+        metadata = BookMetadata(
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
+            isbn="978-0-123456-47-2",
+        )
+        result = service.search(metadata)
+
+        provider.search_by_title_author.assert_called_once()
+        assert result == [candidate]
+
+    def test_search_title_author_when_no_isbn(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search() goes straight to title/author when no ISBN present."""
+        candidate = _make_candidate()
+        provider.search_by_title_author.return_value = [candidate]
+
+        metadata = BookMetadata(title="Dune", authors=["Frank Herbert"])
+        result = service.search(metadata)
+
+        provider.search_by_isbn.assert_not_called()
+        provider.search_by_title_author.assert_called_once_with("Dune", "Frank Herbert")
+        assert result == [candidate]
+
+    def test_search_normalizes_metadata(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search() normalizes mangled metadata before searching."""
+        provider.search_by_title_author.return_value = []
+
+        # CamelCase title that needs normalization
+        metadata = BookMetadata(title="TheNameOfTheRose", authors=[])
+        service.search(metadata)
+
+        # The provider should receive normalized (split) title, not the raw one
+        call_args = provider.search_by_title_author.call_args
+        title_arg = call_args[0][0]
+        assert " " in title_arg  # Normalized title should have spaces
+
+    def test_search_returns_empty_when_no_candidates(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search() returns empty list when no candidates found."""
+        metadata = BookMetadata(title="Nonexistent Book")
+        result = service.search(metadata)
+        assert result == []
+
+    def test_search_author_none_when_no_authors(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search() passes None as author when metadata has no authors."""
+        provider.search_by_title_author.return_value = []
+
+        metadata = BookMetadata(title="Mystery Book", authors=[])
+        service.search(metadata)
+
+        provider.search_by_title_author.assert_called_once_with("Mystery Book", None)
+
+
+class TestEnrichmentServiceManualSearch:
+    """Tests for EnrichmentService.search_manual()."""
+
+    def test_manual_text_search(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search_manual() with plain text delegates to search_by_title_author."""
+        candidate = _make_candidate()
+        provider.search_by_title_author.return_value = [candidate]
+
+        result = service.search_manual("Italo Calvino")
+
+        provider.search_by_title_author.assert_called_once_with("Italo Calvino", None)
+        assert result == [candidate]
+
+    def test_manual_url_detected(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search_manual() auto-detects URLs and delegates to lookup_by_url."""
+        candidate = _make_candidate()
+        provider.lookup_by_url.return_value = candidate
+
+        url = "https://openlibrary.org/works/OL123W"
+        result = service.search_manual(url)
+
+        provider.lookup_by_url.assert_called_once_with(url)
+        assert result == [candidate]
+
+    def test_manual_url_returns_empty_on_failure(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search_manual() with URL returns empty list when lookup fails."""
+        provider.lookup_by_url.return_value = None
+
+        result = service.search_manual("https://openlibrary.org/works/OL999W")
+
+        assert result == []
+
+    def test_manual_http_url_detected(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """search_manual() detects http:// URLs (not just https://)."""
+        candidate = _make_candidate()
+        provider.lookup_by_url.return_value = candidate
+
+        url = "http://openlibrary.org/works/OL123W"
+        service.search_manual(url)
+
+        provider.lookup_by_url.assert_called_once_with(url)
+
+
+class TestEnrichmentServiceLookupUrl:
+    """Tests for EnrichmentService.lookup_url()."""
+
+    def test_delegates_to_provider(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """lookup_url() delegates to provider.lookup_by_url."""
+        candidate = _make_candidate()
+        provider.lookup_by_url.return_value = candidate
+
+        result = service.lookup_url("https://openlibrary.org/works/OL123W")
+
+        provider.lookup_by_url.assert_called_once_with(
+            "https://openlibrary.org/works/OL123W"
+        )
+        assert result == candidate
+
+    def test_returns_none_on_failure(
+        self, service: EnrichmentService, provider: MagicMock
+    ) -> None:
+        """lookup_url() returns None when provider lookup fails."""
+        provider.lookup_by_url.return_value = None
+
+        result = service.lookup_url("https://openlibrary.org/works/OL999W")
+        assert result is None
+
+
+class TestEnrichmentServiceApply:
+    """Tests for EnrichmentService.apply()."""
+
+    def test_delegates_to_apply_metadata_safely(
+        self, service: EnrichmentService, output_dir: Path
+    ) -> None:
+        """apply() delegates to apply_metadata_safely with correct args."""
+        source = Path("/books/test.epub")
+        metadata = BookMetadata(title="Test Book")
+
+        with patch("bookery.core.enrichment.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = MagicMock(
+                success=True, path=output_dir / "test.epub"
+            )
+            result = service.apply(source, metadata)
+
+        mock_apply.assert_called_once_with(source, metadata, output_dir)
+        assert result.success is True
+
+    def test_apply_returns_write_result(
+        self, service: EnrichmentService, output_dir: Path
+    ) -> None:
+        """apply() returns the WriteResult from apply_metadata_safely."""
+        source = Path("/books/test.epub")
+        metadata = BookMetadata(title="Test Book")
+
+        with patch("bookery.core.enrichment.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = MagicMock(
+                success=False, error="Write failed", path=None
+            )
+            result = service.apply(source, metadata)
+
+        assert result.success is False
+        assert result.error == "Write failed"

--- a/tests/unit/test_loading_screen.py
+++ b/tests/unit/test_loading_screen.py
@@ -1,0 +1,46 @@
+# ABOUTME: Unit tests for the LoadingOverlay modal screen.
+# ABOUTME: Verifies spinner display, message text, and modal behavior.
+
+import pytest
+
+from bookery.tui.screens.loading import LoadingOverlay
+
+
+@pytest.mark.asyncio
+class TestLoadingOverlay:
+    """Tests for the LoadingOverlay modal screen."""
+
+    async def test_shows_message_text(self) -> None:
+        """LoadingOverlay displays the provided message."""
+        from textual.app import App
+        from textual.widgets import Static
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(LoadingOverlay("Searching Open Library..."))
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            # Find the message label
+            label = screen.query_one("#loading-message", Static)
+            rendered = str(label.render())
+            assert "Searching Open Library" in rendered
+
+    async def test_default_message(self) -> None:
+        """LoadingOverlay has a default message when none provided."""
+        from textual.app import App
+        from textual.widgets import Static
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(LoadingOverlay())
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            label = screen.query_one("#loading-message", Static)
+            rendered = str(label.render())
+            assert "Loading" in rendered

--- a/tests/unit/test_manual_search_screen.py
+++ b/tests/unit/test_manual_search_screen.py
@@ -1,0 +1,82 @@
+# ABOUTME: Unit tests for the ManualSearchModal.
+# ABOUTME: Verifies input field, submit behavior, and escape cancel.
+
+import pytest
+
+from bookery.tui.screens.manual import ManualSearchModal
+
+
+@pytest.mark.asyncio
+class TestManualSearchModal:
+    """Tests for the ManualSearchModal."""
+
+    async def test_has_input_field(self) -> None:
+        """Modal contains an Input widget."""
+        from textual.app import App
+        from textual.widgets import Input
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(ManualSearchModal())
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            inputs = screen.query(Input)
+            assert len(inputs) == 1
+
+    async def test_escape_cancels(self) -> None:
+        """Pressing Escape dismisses with None."""
+        from textual.app import App
+
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ManualSearchModal(),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: str | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert result is None
+
+    async def test_submit_dismisses_with_query(self) -> None:
+        """Typing text and pressing Enter dismisses with the query string."""
+        from textual.app import App
+        from textual.widgets import Input
+
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ManualSearchModal(),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: str | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            input_widget = screen.query_one(Input)
+            input_widget.value = "Italo Calvino"
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+        assert result == "Italo Calvino"

--- a/tests/unit/test_metadata_diff_widget.py
+++ b/tests/unit/test_metadata_diff_widget.py
@@ -1,0 +1,184 @@
+# ABOUTME: Unit tests for the MetadataDiff widget.
+# ABOUTME: Verifies compact/full modes, change markers, and data loss warnings.
+
+import pytest
+
+from bookery.metadata.types import BookMetadata
+from bookery.tui.widgets.metadata_diff import FieldDiff, MetadataDiff, compute_field_diffs
+
+
+class TestComputeFieldDiffs:
+    """Tests for the compute_field_diffs helper."""
+
+    def test_identical_metadata_all_unchanged(self) -> None:
+        """Identical current and proposed produces all 'unchanged' diffs."""
+        meta = BookMetadata(title="Test", authors=["Author"], isbn="123")
+        diffs = compute_field_diffs(meta, meta)
+        assert all(d.change == "unchanged" for d in diffs)
+
+    def test_added_field_detected(self) -> None:
+        """A field going from None to a value is marked as 'added'."""
+        current = BookMetadata(title="Test")
+        proposed = BookMetadata(title="Test", isbn="978-0-123456-47-2")
+        diffs = compute_field_diffs(current, proposed)
+
+        isbn_diff = next(d for d in diffs if d.field == "ISBN")
+        assert isbn_diff.change == "added"
+        assert isbn_diff.proposed == "978-0-123456-47-2"
+
+    def test_changed_field_detected(self) -> None:
+        """A field with different values is marked as 'changed'."""
+        current = BookMetadata(title="Old Title")
+        proposed = BookMetadata(title="New Title")
+        diffs = compute_field_diffs(current, proposed)
+
+        title_diff = next(d for d in diffs if d.field == "Title")
+        assert title_diff.change == "changed"
+        assert title_diff.current == "Old Title"
+        assert title_diff.proposed == "New Title"
+
+    def test_removed_field_detected(self) -> None:
+        """A field going from a value to None is marked as 'removed'."""
+        current = BookMetadata(title="Test", publisher="Einaudi")
+        proposed = BookMetadata(title="Test", publisher=None)
+        diffs = compute_field_diffs(current, proposed)
+
+        pub_diff = next(d for d in diffs if d.field == "Publisher")
+        assert pub_diff.change == "removed"
+
+    def test_authors_compared_as_string(self) -> None:
+        """Authors lists are compared as joined strings."""
+        current = BookMetadata(title="Test", authors=["Author A"])
+        proposed = BookMetadata(title="Test", authors=["Author B"])
+        diffs = compute_field_diffs(current, proposed)
+
+        author_diff = next(d for d in diffs if d.field == "Authors")
+        assert author_diff.change == "changed"
+
+    def test_subjects_compared_as_string(self) -> None:
+        """Subjects lists are compared as joined strings."""
+        current = BookMetadata(title="Test", subjects=["Fiction"])
+        proposed = BookMetadata(title="Test", subjects=["Fiction", "History"])
+        diffs = compute_field_diffs(current, proposed)
+
+        subj_diff = next(d for d in diffs if d.field == "Subjects")
+        assert subj_diff.change == "changed"
+
+    def test_series_with_index(self) -> None:
+        """Series field includes index when present."""
+        current = BookMetadata(title="Test")
+        proposed = BookMetadata(title="Test", series="Cycle", series_index=3.0)
+        diffs = compute_field_diffs(current, proposed)
+
+        series_diff = next(d for d in diffs if d.field == "Series")
+        assert series_diff.change == "added"
+        assert "#3" in series_diff.proposed
+
+    def test_all_diffed_fields_present(self) -> None:
+        """All expected fields are present in the diff output."""
+        meta = BookMetadata(title="Test")
+        diffs = compute_field_diffs(meta, meta)
+        field_names = {d.field for d in diffs}
+        expected = {"Title", "Authors", "Publisher", "ISBN", "Language",
+                    "Description", "Series", "Subjects"}
+        assert expected == field_names
+
+
+class TestFieldDiffMarker:
+    """Tests for FieldDiff.marker property."""
+
+    def test_added_marker(self) -> None:
+        diff = FieldDiff(field="ISBN", current="", proposed="123", change="added")
+        assert diff.marker == "[+]"
+
+    def test_changed_marker(self) -> None:
+        diff = FieldDiff(field="Title", current="A", proposed="B", change="changed")
+        assert diff.marker == "[~]"
+
+    def test_removed_marker(self) -> None:
+        diff = FieldDiff(field="ISBN", current="123", proposed="", change="removed")
+        assert diff.marker == "[-]"
+
+    def test_unchanged_marker(self) -> None:
+        diff = FieldDiff(field="Title", current="A", proposed="A", change="unchanged")
+        assert diff.marker == ""
+
+
+@pytest.mark.asyncio
+class TestMetadataDiffWidget:
+    """Tests for the MetadataDiff Textual widget."""
+
+    async def test_compact_mode_hides_unchanged_fields(self) -> None:
+        """In compact mode, unchanged fields are not rendered."""
+        from textual.app import App, ComposeResult
+
+        current = BookMetadata(title="Same Title", isbn="123")
+        proposed = BookMetadata(title="Same Title", isbn="456")
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield MetadataDiff(current, proposed, mode="compact")
+
+        app = TestApp()
+        async with app.run_test():
+            widget = app.query_one(MetadataDiff)
+            rendered = str(widget.render())
+            # ISBN changed, should be visible
+            assert "ISBN" in rendered
+            # Title unchanged, should not be in compact mode
+            assert "Same Title" not in rendered or rendered.count("Same Title") == 0
+
+    async def test_full_mode_shows_all_fields(self) -> None:
+        """In full mode, all fields are rendered including unchanged ones."""
+        from textual.app import App, ComposeResult
+
+        current = BookMetadata(title="Same Title", isbn="123")
+        proposed = BookMetadata(title="Same Title", isbn="456")
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield MetadataDiff(current, proposed, mode="full")
+
+        app = TestApp()
+        async with app.run_test():
+            widget = app.query_one(MetadataDiff)
+            rendered = str(widget.render())
+            assert "Title" in rendered
+            assert "ISBN" in rendered
+
+    async def test_data_loss_warning_on_removed_field(self) -> None:
+        """Removed fields show a data loss warning marker in full mode."""
+        from textual.app import App, ComposeResult
+
+        current = BookMetadata(title="Test", publisher="Einaudi")
+        proposed = BookMetadata(title="Test", publisher=None)
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield MetadataDiff(current, proposed, mode="full")
+
+        app = TestApp()
+        async with app.run_test():
+            widget = app.query_one(MetadataDiff)
+            rendered = str(widget.render())
+            assert "[-]" in rendered
+
+    async def test_update_diff_changes_content(self) -> None:
+        """update_diff() changes the displayed content."""
+        from textual.app import App, ComposeResult
+
+        current1 = BookMetadata(title="First")
+        proposed1 = BookMetadata(title="First Changed")
+        current2 = BookMetadata(title="Second")
+        proposed2 = BookMetadata(title="Second Changed")
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield MetadataDiff(current1, proposed1, mode="full")
+
+        app = TestApp()
+        async with app.run_test():
+            widget = app.query_one(MetadataDiff)
+            widget.update_diff(current2, proposed2)
+            rendered = str(widget.render())
+            assert "Second" in rendered

--- a/tests/unit/test_reenrich_screen.py
+++ b/tests/unit/test_reenrich_screen.py
@@ -1,0 +1,103 @@
+# ABOUTME: Unit tests for the ReEnrichConfirmModal.
+# ABOUTME: Verifies confirmation and cancel behavior for already-enriched books.
+
+import pytest
+
+from bookery.tui.screens.reenrich import ReEnrichConfirmModal
+
+
+@pytest.mark.asyncio
+class TestReEnrichConfirmModal:
+    """Tests for the ReEnrichConfirmModal."""
+
+    async def test_confirm_dismisses_with_true(self) -> None:
+        """Pressing 'y' dismisses with True (proceed)."""
+        from textual.app import App
+
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ReEnrichConfirmModal(),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: bool | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("y")
+            await pilot.pause()
+
+        assert result is True
+
+    async def test_cancel_dismisses_with_false(self) -> None:
+        """Pressing Escape dismisses with False (cancel)."""
+        from textual.app import App
+
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ReEnrichConfirmModal(),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: bool | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert result is False
+
+    async def test_n_dismisses_with_false(self) -> None:
+        """Pressing 'n' dismisses with False (cancel)."""
+        from textual.app import App
+
+        result = "not_set"
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(
+                    ReEnrichConfirmModal(),
+                    callback=self._on_dismiss,
+                )
+
+            def _on_dismiss(self, value: bool | None) -> None:
+                nonlocal result
+                result = value
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+
+        assert result is False
+
+    async def test_shows_warning_message(self) -> None:
+        """Modal displays a message about existing enrichment."""
+        from textual.app import App
+        from textual.widgets import Static
+
+        class TestApp(App):
+            def on_mount(self) -> None:
+                self.push_screen(ReEnrichConfirmModal())
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            label = screen.query_one("#reenrich-message", Static)
+            rendered = str(label.render())
+            assert "already" in rendered.lower() or "enriched" in rendered.lower()


### PR DESCRIPTION
## Summary
- Open Library's `/isbn/{isbn}.json` endpoint returns a 302 redirect to the edition URL
- Without `follow_redirects=True`, every ISBN lookup failed with "HTTP 302" and silently fell back to title/author search
- One-line fix in `BookeryHttpClient`

## Test plan
- [x] All 931 existing tests pass
- [x] Verified ISBN lookup now returns results (e.g., `9780134685991` → "Effective Java")