### PR TITLE
Add #52: Web UI inline metadata editing

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1,5 +1,5 @@
 # ABOUTME: Flask blueprint with route handlers for the Bookery web UI.
-# ABOUTME: Handles book listing, detail view, and search with htmx support.
+# ABOUTME: Handles book listing, detail view, search, and inline editing with htmx support.
 
 from flask import Blueprint, abort, current_app, redirect, render_template, request, url_for
 
@@ -42,4 +42,64 @@ def book_detail(book_id):
     tags = catalog.get_tags_for_book(book_id)
     genres = catalog.get_genres_for_book(book_id)
 
+    if request.headers.get("HX-Request"):
+        return render_template("_detail.html", book=book, tags=tags, genres=genres)
+
     return render_template("detail.html", book=book, tags=tags, genres=genres)
+
+
+@bp.route("/books/<int:book_id>/edit", methods=["GET"])
+def edit_form(book_id):
+    """Return the edit form partial for a book."""
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    return render_template("_edit_form.html", book=book)
+
+
+@bp.route("/books/<int:book_id>/edit", methods=["POST"])
+def update_book(book_id):
+    """Save edited metadata and return the detail partial."""
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    title = request.form.get("title", "").strip()
+    if not title:
+        return render_template("_edit_form.html", book=book, error="Title is required"), 400
+
+    # Parse semicolon-separated authors
+    authors_raw = request.form.get("authors", "").strip()
+    authors = [a.strip() for a in authors_raw.split(";") if a.strip()] if authors_raw else []
+
+    # Parse optional fields — empty string becomes None
+    isbn = request.form.get("isbn", "").strip() or None
+    language = request.form.get("language", "").strip() or None
+    publisher = request.form.get("publisher", "").strip() or None
+    description = request.form.get("description", "").strip() or None
+    series = request.form.get("series", "").strip() or None
+
+    series_index_raw = request.form.get("series_index", "").strip()
+    series_index = float(series_index_raw) if series_index_raw else None
+
+    catalog.update_book(
+        book_id,
+        title=title,
+        authors=authors,
+        isbn=isbn,
+        language=language,
+        publisher=publisher,
+        description=description,
+        series=series,
+        series_index=series_index,
+    )
+
+    # Re-fetch updated book for display
+    book = catalog.get_by_id(book_id)
+    tags = catalog.get_tags_for_book(book_id)
+    genres = catalog.get_genres_for_book(book_id)
+
+    return render_template("_detail.html", book=book, tags=tags, genres=genres)

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -151,3 +151,95 @@ header h1 a {
     color: var(--color-badge);
     font-weight: 600;
 }
+
+/* Edit form */
+
+.edit-form {
+    max-width: 600px;
+}
+
+.form-error {
+    background: #fef2f2;
+    color: #dc2626;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #fecaca;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    font-size: 0.9rem;
+}
+
+.form-group .hint {
+    font-weight: 400;
+    color: var(--color-muted);
+    font-size: 0.8rem;
+}
+
+.form-group .required {
+    color: #dc2626;
+}
+
+.form-group input[type="text"],
+.form-group input[type="number"],
+.form-group textarea {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-family: inherit;
+}
+
+.form-group textarea {
+    resize: vertical;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1rem;
+}
+
+.form-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+}
+
+.btn {
+    padding: 0.5rem 1rem;
+    font-size: 0.9rem;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.btn-primary {
+    background: var(--color-link);
+    color: white;
+    border-color: var(--color-link);
+}
+
+.btn-primary:hover {
+    opacity: 0.9;
+}
+
+.btn-secondary {
+    background: white;
+    color: var(--color-text);
+}
+
+.btn-secondary:hover {
+    background: var(--color-hover);
+}

--- a/src/bookery/web/templates/_detail.html
+++ b/src/bookery/web/templates/_detail.html
@@ -1,0 +1,60 @@
+<h2>{{ book.metadata.title }}</h2>
+
+<button class="btn btn-secondary"
+        hx-get="{{ url_for('web.edit_form', book_id=book.id) }}"
+        hx-target="#book-content"
+        hx-swap="innerHTML">Edit</button>
+
+<dl class="metadata">
+    <dt>Author</dt>
+    <dd>{{ book.metadata.author }}</dd>
+
+    {% if book.metadata.isbn %}
+    <dt>ISBN</dt>
+    <dd>{{ book.metadata.isbn }}</dd>
+    {% endif %}
+
+    {% if book.metadata.language %}
+    <dt>Language</dt>
+    <dd>{{ book.metadata.language }}</dd>
+    {% endif %}
+
+    {% if book.metadata.publisher %}
+    <dt>Publisher</dt>
+    <dd>{{ book.metadata.publisher }}</dd>
+    {% endif %}
+
+    {% if book.metadata.series %}
+    <dt>Series</dt>
+    <dd>{{ book.metadata.series }}{% if book.metadata.series_index %} #{{ book.metadata.series_index }}{% endif %}</dd>
+    {% endif %}
+</dl>
+
+{% if book.metadata.description %}
+<div class="description">
+    <h3>Description</h3>
+    <p>{{ book.metadata.description }}</p>
+</div>
+{% endif %}
+
+{% if tags %}
+<div class="tags">
+    <h3>Tags</h3>
+    <ul>
+        {% for tag in tags %}
+        <li>{{ tag }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+{% if genres %}
+<div class="genres">
+    <h3>Genres</h3>
+    <ul>
+        {% for name, is_primary in genres %}
+        <li>{{ name }}{% if is_primary %} <span class="primary-badge">(primary)</span>{% endif %}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -1,0 +1,51 @@
+<form class="edit-form" hx-post="{{ url_for('web.update_book', book_id=book.id) }}" hx-target="#book-content" hx-swap="innerHTML">
+    {% if error %}
+    <div class="form-error">{{ error }}</div>
+    {% endif %}
+
+    <div class="form-group">
+        <label for="title">Title <span class="required">*</span></label>
+        <input type="text" id="title" name="title" value="{{ book.metadata.title }}" required>
+    </div>
+
+    <div class="form-group">
+        <label for="authors">Authors <span class="hint">(semicolon-separated)</span></label>
+        <input type="text" id="authors" name="authors" value="{{ book.metadata.authors | join('; ') }}">
+    </div>
+
+    <div class="form-group">
+        <label for="isbn">ISBN</label>
+        <input type="text" id="isbn" name="isbn" value="{{ book.metadata.isbn or '' }}">
+    </div>
+
+    <div class="form-group">
+        <label for="language">Language</label>
+        <input type="text" id="language" name="language" value="{{ book.metadata.language or '' }}">
+    </div>
+
+    <div class="form-group">
+        <label for="publisher">Publisher</label>
+        <input type="text" id="publisher" name="publisher" value="{{ book.metadata.publisher or '' }}">
+    </div>
+
+    <div class="form-group">
+        <label for="description">Description</label>
+        <textarea id="description" name="description" rows="4">{{ book.metadata.description or '' }}</textarea>
+    </div>
+
+    <div class="form-group form-row">
+        <div>
+            <label for="series">Series</label>
+            <input type="text" id="series" name="series" value="{{ book.metadata.series or '' }}">
+        </div>
+        <div>
+            <label for="series_index">Series #</label>
+            <input type="number" id="series_index" name="series_index" step="any" value="{{ book.metadata.series_index if book.metadata.series_index is not none else '' }}">
+        </div>
+    </div>
+
+    <div class="form-actions">
+        <button type="submit" class="btn btn-primary">Save</button>
+        <button type="button" class="btn btn-secondary" hx-get="{{ url_for('web.book_detail', book_id=book.id) }}" hx-target="#book-content" hx-swap="innerHTML">Cancel</button>
+    </div>
+</form>

--- a/src/bookery/web/templates/detail.html
+++ b/src/bookery/web/templates/detail.html
@@ -6,60 +6,8 @@
 <div class="book-detail">
     <p class="back-link"><a href="{{ url_for('web.books') }}">&larr; Back to library</a></p>
 
-    <h2>{{ book.metadata.title }}</h2>
-
-    <dl class="metadata">
-        <dt>Author</dt>
-        <dd>{{ book.metadata.author }}</dd>
-
-        {% if book.metadata.isbn %}
-        <dt>ISBN</dt>
-        <dd>{{ book.metadata.isbn }}</dd>
-        {% endif %}
-
-        {% if book.metadata.language %}
-        <dt>Language</dt>
-        <dd>{{ book.metadata.language }}</dd>
-        {% endif %}
-
-        {% if book.metadata.publisher %}
-        <dt>Publisher</dt>
-        <dd>{{ book.metadata.publisher }}</dd>
-        {% endif %}
-
-        {% if book.metadata.series %}
-        <dt>Series</dt>
-        <dd>{{ book.metadata.series }}{% if book.metadata.series_index %} #{{ book.metadata.series_index }}{% endif %}</dd>
-        {% endif %}
-    </dl>
-
-    {% if book.metadata.description %}
-    <div class="description">
-        <h3>Description</h3>
-        <p>{{ book.metadata.description }}</p>
+    <div id="book-content">
+        {% include "_detail.html" %}
     </div>
-    {% endif %}
-
-    {% if tags %}
-    <div class="tags">
-        <h3>Tags</h3>
-        <ul>
-            {% for tag in tags %}
-            <li>{{ tag }}</li>
-            {% endfor %}
-        </ul>
-    </div>
-    {% endif %}
-
-    {% if genres %}
-    <div class="genres">
-        <h3>Genres</h3>
-        <ul>
-            {% for name, is_primary in genres %}
-            <li>{{ name }}{% if is_primary %} <span class="primary-badge">(primary)</span>{% endif %}</li>
-            {% endfor %}
-        </ul>
-    </div>
-    {% endif %}
 </div>
 {% endblock %}

--- a/tests/e2e/test_web_e2e.py
+++ b/tests/e2e/test_web_e2e.py
@@ -97,3 +97,72 @@ class TestWebE2E:
         assert "<html" not in html
 
         conn.close()
+
+    def test_full_edit_flow(self, tmp_path) -> None:
+        """Full user journey: browse → detail → edit → save → verify."""
+        db_path = tmp_path / "library.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+
+        catalog.add_book(
+            BookMetadata(
+                title="Neuromancer",
+                authors=["Gibson, William"],
+                author_sort="Gibson, William",
+                isbn="9780441569595",
+                language="en",
+                publisher="Ace Books",
+                description="Cyberpunk noir.",
+                source_path=Path("/books/neuromancer.epub"),
+            ),
+            file_hash="hash_neuro",
+        )
+
+        app = create_app(catalog)
+        app.config["TESTING"] = True
+        client = app.test_client()
+
+        # Step 1: Browse and find the book
+        response = client.get("/books")
+        assert "Neuromancer" in response.data.decode()
+
+        # Step 2: View detail
+        response = client.get("/books/1")
+        html = response.data.decode()
+        assert "Neuromancer" in html
+        assert "Edit" in html
+
+        # Step 3: Get edit form
+        response = client.get("/books/1/edit")
+        html = response.data.decode()
+        assert "<form" in html
+        assert "Neuromancer" in html
+
+        # Step 4: Save with updated metadata
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Neuromancer (Revised)",
+                "authors": "Gibson, William; Sterling, Bruce",
+                "isbn": "9780441569595",
+                "language": "en",
+                "publisher": "Ace Books",
+                "description": "Cyberpunk noir, updated edition.",
+                "series": "Sprawl Trilogy",
+                "series_index": "1",
+            },
+        )
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "Neuromancer (Revised)" in html
+
+        # Step 5: Verify detail page shows updated data
+        response = client.get("/books/1")
+        html = response.data.decode()
+        assert "Neuromancer (Revised)" in html
+        assert "Gibson, William" in html
+        assert "Sterling, Bruce" in html
+        assert "Sprawl Trilogy" in html
+        assert "Cyberpunk noir, updated edition." in html
+
+        conn.close()

--- a/tests/integration/test_web_integration.py
+++ b/tests/integration/test_web_integration.py
@@ -106,3 +106,57 @@ class TestWebIntegration:
         response = c.get("/books")
         html = response.data.decode()
         assert "Your library is empty" in html
+
+    def test_edit_and_save_persists_changes(self, client):
+        # Get the edit form
+        response = client.get("/books/1/edit")
+        assert response.status_code == 200
+        assert "<form" in response.data.decode()
+
+        # Save with updated title
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Dune Messiah",
+                "authors": "Herbert, Frank",
+                "isbn": "9780441172719",
+                "language": "en",
+                "publisher": "Ace Books",
+                "description": "A desert planet epic.",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 200
+
+        # Verify the detail page shows the updated title
+        response = client.get("/books/1")
+        html = response.data.decode()
+        assert "Dune Messiah" in html
+
+    def test_edit_cancel_preserves_original(self, client):
+        # Load the edit form (read-only, no changes)
+        response = client.get("/books/1/edit")
+        assert response.status_code == 200
+
+        # Without posting, go back to detail — title unchanged
+        response = client.get("/books/1")
+        html = response.data.decode()
+        assert "Dune" in html
+
+    def test_edit_title_validation(self, client):
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "",
+                "authors": "Herbert, Frank",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 400
+        assert "Title is required" in response.data.decode()

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -184,6 +184,25 @@ class TestBookDetail:
         response = client.get("/books/999")
         assert response.status_code == 404
 
+    def test_detail_has_edit_button(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.get("/books/1")
+        html = response.data.decode()
+        assert "Edit" in html
+        assert "hx-get" in html
+        assert "/books/1/edit" in html
+
+    def test_detail_htmx_returns_partial(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.get("/books/1", headers={"HX-Request": "true"})
+        html = response.data.decode()
+        assert response.status_code == 200
+        assert "<html" not in html
+        assert "<head" not in html
+        assert "Test Book" in html
+
 
 # --- Cycle 4: Search with htmx ---
 
@@ -220,3 +239,210 @@ class TestSearch:
         response = client.get("/books?q=test")
         html = response.data.decode()
         assert "<html" in html
+
+
+# --- Cycle 5: Edit Form ---
+
+
+class TestEditForm:
+    def test_edit_form_returns_form_html(self, mock_catalog, client):
+        book = _make_book(
+            1,
+            title="Dune",
+            authors=["Herbert, Frank"],
+            isbn="9780441172719",
+            language="en",
+            publisher="Ace Books",
+            description="A science fiction masterpiece.",
+            series="Dune Chronicles",
+            series_index=1.0,
+        )
+        mock_catalog.get_by_id.return_value = book
+
+        response = client.get("/books/1/edit")
+        html = response.data.decode()
+        assert response.status_code == 200
+        assert "<form" in html
+
+    def test_edit_form_returns_partial_only(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.get("/books/1/edit")
+        html = response.data.decode()
+        assert "<html" not in html
+        assert "<head" not in html
+
+    def test_edit_form_404_for_missing_book(self, client):
+        response = client.get("/books/999/edit")
+        assert response.status_code == 404
+
+    def test_edit_form_has_editable_fields(self, mock_catalog, client):
+        book = _make_book(
+            1,
+            title="Dune",
+            authors=["Herbert, Frank"],
+            isbn="9780441172719",
+            language="en",
+            publisher="Ace Books",
+            description="A science fiction masterpiece.",
+            series="Dune Chronicles",
+            series_index=1.0,
+        )
+        mock_catalog.get_by_id.return_value = book
+
+        response = client.get("/books/1/edit")
+        html = response.data.decode()
+        assert 'name="title"' in html
+        assert 'name="authors"' in html
+        assert 'name="isbn"' in html
+        assert 'name="language"' in html
+        assert 'name="publisher"' in html
+        assert 'name="description"' in html
+        assert 'name="series"' in html
+        assert 'name="series_index"' in html
+        # Values should be pre-populated
+        assert "Dune" in html
+        assert "Herbert, Frank" in html
+        assert "9780441172719" in html
+
+    def test_edit_form_has_cancel_button(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.get("/books/1/edit")
+        html = response.data.decode()
+        assert "Cancel" in html
+        assert "hx-get" in html
+
+
+# --- Cycle 6: Update Book ---
+
+
+class TestUpdateBook:
+    def test_update_calls_catalog_update(self, mock_catalog, client):
+        book = _make_book(1, title="Old Title")
+        mock_catalog.get_by_id.return_value = book
+
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "New Title",
+                "authors": "Herbert, Frank",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 200
+        mock_catalog.update_book.assert_called_once()
+        call_kwargs = mock_catalog.update_book.call_args
+        assert call_kwargs[0][0] == 1  # book_id
+        assert call_kwargs[1]["title"] == "New Title"
+
+    def test_update_returns_detail_partial(self, mock_catalog, client):
+        book = _make_book(1, title="Updated")
+        mock_catalog.get_by_id.return_value = book
+
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Updated",
+                "authors": "Author, Test",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        html = response.data.decode()
+        assert "<html" not in html
+        assert "Updated" in html
+
+    def test_update_title_required(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "",
+                "authors": "Author, Test",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 400
+        html = response.data.decode()
+        assert "Title is required" in html
+
+    def test_update_parses_semicolon_authors(self, mock_catalog, client):
+        book = _make_book(1)
+        mock_catalog.get_by_id.return_value = book
+
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Test",
+                "authors": "Herbert, Frank; Asimov, Isaac",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_catalog.update_book.call_args[1]
+        assert call_kwargs["authors"] == ["Herbert, Frank", "Asimov, Isaac"]
+
+    def test_update_404_for_missing_book(self, client):
+        response = client.post("/books/999/edit", data={"title": "X"})
+        assert response.status_code == 404
+
+    def test_update_parses_series_index_as_float(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Test",
+                "authors": "Author, Test",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "A Series",
+                "series_index": "2.5",
+            },
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_catalog.update_book.call_args[1]
+        assert call_kwargs["series_index"] == 2.5
+
+    def test_update_empty_series_index_is_none(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = _make_book(1)
+
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Test",
+                "authors": "Author, Test",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_catalog.update_book.call_args[1]
+        assert call_kwargs["series_index"] is None


### PR DESCRIPTION
## Summary

- Adds inline metadata editing to the web UI detail page via htmx swap
- Edit button swaps detail content for a pre-populated form; save persists and swaps back; cancel restores original
- Authors use semicolon separator (since names contain commas: "Herbert, Frank")
- Server-side validation: title required (400 response with error displayed in form)
- Extracted `_detail.html` partial from `detail.html` to enable htmx swap targets for both edit and detail views

## Routes Added

| Method | URL | Purpose |
|--------|-----|---------|
| GET | `/books/<id>/edit` | Return edit form partial |
| POST | `/books/<id>/edit` | Validate, save, return detail partial |

## Editable Fields

title, authors, ISBN, language, publisher, description, series, series_index

## Test Plan

- [x] 7 unit tests (edit form rendering, update route, validation, author parsing, series_index parsing)
- [x] 3 integration tests (persist changes, cancel preserves, title validation with real DB)
- [x] 1 e2e test (full browse → detail → edit → save → verify flow)
- [x] All 974 tests pass
- [x] ruff + pyright clean

Closes #52