### PR TITLE
Add #58: bookery folder command to open book directories from CLI

### DIFF
--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -7,6 +7,7 @@ import click
 
 from bookery.cli.commands import (
     convert_cmd,
+    folder_cmd,
     genre_cmd,
     import_cmd,
     info_cmd,
@@ -40,6 +41,7 @@ def cli(verbose: int) -> None:
 
 
 cli.add_command(convert_cmd.convert)
+cli.add_command(folder_cmd.folder)
 cli.add_command(genre_cmd.genre)
 cli.add_command(import_cmd.import_command)
 cli.add_command(info_cmd.info)

--- a/src/bookery/cli/commands/folder_cmd.py
+++ b/src/bookery/cli/commands/folder_cmd.py
@@ -48,9 +48,7 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
             raise SystemExit(1)
 
         if isinstance(result, Ambiguous):
-            console.print(
-                f"[yellow]Multiple books match[/yellow] '{query}':"
-            )
+            console.print(f"[yellow]Multiple books match[/yellow] '{query}':")
             for r in result.records:
                 console.print(f"  [dim]{r.id}[/dim]  {r.metadata.title}")
             console.print("[dim]Re-run with a numeric ID to disambiguate.[/dim]")
@@ -72,9 +70,7 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
         folder_path = record.output_path or record.source_path.parent
 
         if not folder_path.exists():
-            console.print(
-                f"[red]Folder does not exist:[/red] {folder_path}"
-            )
+            console.print(f"[red]Folder does not exist:[/red] {folder_path}")
             console.print("[dim]DB may be out of sync with the filesystem.[/dim]")
             raise SystemExit(1)
 
@@ -90,9 +86,7 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
             return
 
         if isinstance(open_result, Headless):
-            console.print(
-                "[yellow]No graphical environment available (headless).[/yellow]"
-            )
+            console.print("[yellow]No graphical environment available (headless).[/yellow]")
             click.echo(str(folder_path))
             return
 

--- a/src/bookery/cli/commands/folder_cmd.py
+++ b/src/bookery/cli/commands/folder_cmd.py
@@ -1,0 +1,102 @@
+# ABOUTME: The `bookery folder` command for opening a book's folder on disk.
+# ABOUTME: Resolves an ID or title to a BookRecord and opens the folder in the OS file manager.
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from bookery.cli.options import db_option
+from bookery.core.book_lookup import (
+    Ambiguous,
+    Found,
+    NotFound,
+    Suggestions,
+    resolve_book,
+)
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import DEFAULT_DB_PATH, open_library
+from bookery.util.file_manager import (
+    Headless,
+    Opened,
+    OpenerFailed,
+    open_in_file_manager,
+)
+
+console = Console()  # TODO: move Console() inside command for testability
+
+
+@click.command("folder")
+@click.argument("query")
+@click.option(
+    "--print",
+    "print_only",
+    is_flag=True,
+    default=False,
+    help="Print the folder path instead of opening the file manager.",
+)
+@db_option
+def folder(query: str, print_only: bool, db_path: Path | None) -> None:
+    """Open the on-disk folder for a book by ID or title."""
+    conn = open_library(db_path or DEFAULT_DB_PATH)
+    try:
+        catalog = LibraryCatalog(conn)
+        result = resolve_book(catalog, query)
+
+        if isinstance(result, NotFound):
+            console.print(f"[red]Book not found:[/red] {query}")
+            raise SystemExit(1)
+
+        if isinstance(result, Ambiguous):
+            console.print(
+                f"[yellow]Multiple books match[/yellow] '{query}':"
+            )
+            for r in result.records:
+                console.print(f"  [dim]{r.id}[/dim]  {r.metadata.title}")
+            console.print("[dim]Re-run with a numeric ID to disambiguate.[/dim]")
+            raise SystemExit(2)
+
+        if isinstance(result, Suggestions):
+            console.print(f"[red]Book not found:[/red] {query}")
+            console.print("[yellow]Did you mean:[/yellow]")
+            for r in result.records:
+                console.print(f"  [dim]{r.id}[/dim]  {r.metadata.title}")
+            raise SystemExit(1)
+
+        assert isinstance(result, Found)
+        record = result.record
+
+        if record.output_path is None:
+            console.print(
+                f"[red]Book has no on-disk location:[/red] {record.metadata.title}"
+            )
+            raise SystemExit(1)
+
+        if not record.output_path.exists():
+            console.print(
+                f"[red]Folder does not exist:[/red] {record.output_path}"
+            )
+            console.print("[dim]DB may be out of sync with the filesystem.[/dim]")
+            raise SystemExit(1)
+
+        if print_only:
+            console.print(str(record.output_path))
+            return
+
+        open_result = open_in_file_manager(record.output_path)
+
+        if isinstance(open_result, Opened):
+            return
+
+        if isinstance(open_result, Headless):
+            console.print(
+                "[yellow]No graphical environment available (headless).[/yellow]"
+            )
+            console.print(str(record.output_path))
+            return
+
+        if isinstance(open_result, OpenerFailed):
+            console.print(f"[red]Failed to open folder:[/red] {open_result.message}")
+            raise SystemExit(1)
+    finally:
+        conn.close()

--- a/src/bookery/cli/commands/folder_cmd.py
+++ b/src/bookery/cli/commands/folder_cmd.py
@@ -80,7 +80,9 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
             raise SystemExit(1)
 
         if print_only:
-            console.print(str(record.output_path))
+            # Use click.echo (not Rich) so the path is emitted unwrapped and
+            # is safe to consume from a shell pipeline.
+            click.echo(str(record.output_path))
             return
 
         open_result = open_in_file_manager(record.output_path)
@@ -92,7 +94,7 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
             console.print(
                 "[yellow]No graphical environment available (headless).[/yellow]"
             )
-            console.print(str(record.output_path))
+            click.echo(str(record.output_path))
             return
 
         if isinstance(open_result, OpenerFailed):

--- a/src/bookery/cli/commands/folder_cmd.py
+++ b/src/bookery/cli/commands/folder_cmd.py
@@ -66,15 +66,14 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
         assert isinstance(result, Found)
         record = result.record
 
-        if record.output_path is None:
-            console.print(
-                f"[red]Book has no on-disk location:[/red] {record.metadata.title}"
-            )
-            raise SystemExit(1)
+        # Books that went through the match/write pipeline have an explicit
+        # output_path. Books imported without --match only have source_path,
+        # so fall back to the directory containing the original file.
+        folder_path = record.output_path or record.source_path.parent
 
-        if not record.output_path.exists():
+        if not folder_path.exists():
             console.print(
-                f"[red]Folder does not exist:[/red] {record.output_path}"
+                f"[red]Folder does not exist:[/red] {folder_path}"
             )
             console.print("[dim]DB may be out of sync with the filesystem.[/dim]")
             raise SystemExit(1)
@@ -82,10 +81,10 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
         if print_only:
             # Use click.echo (not Rich) so the path is emitted unwrapped and
             # is safe to consume from a shell pipeline.
-            click.echo(str(record.output_path))
+            click.echo(str(folder_path))
             return
 
-        open_result = open_in_file_manager(record.output_path)
+        open_result = open_in_file_manager(folder_path)
 
         if isinstance(open_result, Opened):
             return
@@ -94,7 +93,7 @@ def folder(query: str, print_only: bool, db_path: Path | None) -> None:
             console.print(
                 "[yellow]No graphical environment available (headless).[/yellow]"
             )
-            click.echo(str(record.output_path))
+            click.echo(str(folder_path))
             return
 
         if isinstance(open_result, OpenerFailed):

--- a/src/bookery/core/book_lookup.py
+++ b/src/bookery/core/book_lookup.py
@@ -63,11 +63,20 @@ def resolve_book(catalog: CatalogLike, query: str) -> LookupResult:
     if len(matches) > 1:
         return Ambiguous(matches)
 
-    # Fuzzy fallback against titles.
+    # Fuzzy fallback against titles. get_close_matches returns titles in
+    # best-match order, so preserve that ordering and emit one record per
+    # matched title to keep the "did you mean" list relevance-ranked.
     titles = [r.metadata.title for r in all_records]
     close = get_close_matches(query, titles, n=5, cutoff=0.6)
     if close:
-        suggested = [r for r in all_records if r.metadata.title in close]
+        suggested: list[BookRecord] = []
+        seen_ids: set[int] = set()
+        for title in close:
+            for r in all_records:
+                if r.metadata.title == title and r.id not in seen_ids:
+                    suggested.append(r)
+                    seen_ids.add(r.id)
+                    break
         return Suggestions(suggested)
 
     return NotFound()

--- a/src/bookery/core/book_lookup.py
+++ b/src/bookery/core/book_lookup.py
@@ -1,0 +1,73 @@
+# ABOUTME: Resolve a user-supplied book reference (ID or title) to a BookRecord.
+# ABOUTME: Returns a typed result union: Found, NotFound, Ambiguous, or Suggestions.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import get_close_matches
+from typing import Protocol
+
+from bookery.db.mapping import BookRecord
+
+
+class CatalogLike(Protocol):
+    def get_by_id(self, book_id: int) -> BookRecord | None: ...
+    def list_all(self) -> list[BookRecord]: ...
+
+
+@dataclass(frozen=True)
+class Found:
+    record: BookRecord
+
+
+@dataclass(frozen=True)
+class NotFound:
+    pass
+
+
+@dataclass(frozen=True)
+class Ambiguous:
+    records: list[BookRecord]
+
+
+@dataclass(frozen=True)
+class Suggestions:
+    records: list[BookRecord]
+
+
+LookupResult = Found | NotFound | Ambiguous | Suggestions
+
+
+def resolve_book(catalog: CatalogLike, query: str) -> LookupResult:
+    """Resolve ``query`` to a single book, multiple matches, or suggestions.
+
+    Resolution order:
+    1. If ``query`` is purely numeric, look up by ID.
+    2. Otherwise scan titles for case-insensitive substring matches.
+    3. If no substring matches, fall back to fuzzy matching with difflib.
+    """
+    query = query.strip()
+    if not query:
+        return NotFound()
+
+    if query.isdigit():
+        record = catalog.get_by_id(int(query))
+        return Found(record) if record else NotFound()
+
+    needle = query.lower()
+    all_records = catalog.list_all()
+    matches = [r for r in all_records if needle in r.metadata.title.lower()]
+
+    if len(matches) == 1:
+        return Found(matches[0])
+    if len(matches) > 1:
+        return Ambiguous(matches)
+
+    # Fuzzy fallback against titles.
+    titles = [r.metadata.title for r in all_records]
+    close = get_close_matches(query, titles, n=5, cutoff=0.6)
+    if close:
+        suggested = [r for r in all_records if r.metadata.title in close]
+        return Suggestions(suggested)
+
+    return NotFound()

--- a/src/bookery/util/file_manager.py
+++ b/src/bookery/util/file_manager.py
@@ -1,0 +1,114 @@
+# ABOUTME: Cross-platform helper to open a directory in the OS file manager.
+# ABOUTME: Detects macOS, Windows, Linux, and WSL and dispatches the native opener.
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class Platform(Enum):
+    MACOS = "macos"
+    WINDOWS = "windows"
+    LINUX = "linux"
+    WSL = "wsl"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Opened:
+    """The path was successfully handed off to the OS file manager."""
+
+
+@dataclass(frozen=True)
+class Headless:
+    """No graphical environment available to open a file manager."""
+
+
+@dataclass(frozen=True)
+class OpenerFailed:
+    """The native opener could not be invoked or returned a failure."""
+
+    message: str
+
+
+OpenResult = Opened | Headless | OpenerFailed
+
+
+def _read_proc_version() -> str:
+    """Return the contents of /proc/version, or empty string if unavailable."""
+    try:
+        return Path("/proc/version").read_text(errors="ignore")
+    except OSError:
+        return ""
+
+
+def detect_platform() -> Platform:
+    """Detect which OS family we are running on, distinguishing WSL from Linux."""
+    system = platform.system()
+    if system == "Darwin":
+        return Platform.MACOS
+    if system == "Windows":
+        return Platform.WINDOWS
+    if system == "Linux":
+        if "microsoft" in _read_proc_version().lower():
+            return Platform.WSL
+        return Platform.LINUX
+    return Platform.UNKNOWN
+
+
+def is_headless_linux() -> bool:
+    """Return True if no graphical session is available to open a file manager."""
+    has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    has_xdg_open = shutil.which("xdg-open") is not None
+    return not (has_display and has_xdg_open)
+
+
+def open_in_file_manager(path: Path) -> OpenResult:
+    """Open ``path`` in the native file manager for the current platform."""
+    plat = detect_platform()
+
+    if plat == Platform.MACOS:
+        return _run(["open", str(path)])
+
+    if plat == Platform.WINDOWS:
+        try:
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        except OSError as exc:
+            return OpenerFailed(str(exc))
+        return Opened()
+
+    if plat == Platform.LINUX:
+        if is_headless_linux():
+            return Headless()
+        return _run(["xdg-open", str(path)])
+
+    if plat == Platform.WSL:
+        try:
+            translated = subprocess.run(
+                ["wslpath", "-w", str(path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            return OpenerFailed(f"wslpath failed: {exc}")
+        win_path = translated.stdout.strip()
+        return _run(["explorer.exe", win_path])
+
+    return OpenerFailed(f"Unsupported platform: {plat}")
+
+
+def _run(cmd: list[str]) -> OpenResult:
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError as exc:
+        return OpenerFailed(f"opener not found: {cmd[0]} ({exc})")
+    except subprocess.CalledProcessError as exc:
+        return OpenerFailed(f"opener exited {exc.returncode}: {cmd[0]}")
+    return Opened()

--- a/tests/e2e/test_folder_cli.py
+++ b/tests/e2e/test_folder_cli.py
@@ -35,9 +35,7 @@ class TestFolderCliE2E:
         book_id = _seed_book(db_path, "The Hobbit", folder)
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
         assert result.exit_code == 0, result.output
 
         printed = result.output.strip().splitlines()[-1]
@@ -52,8 +50,6 @@ class TestFolderCliE2E:
         _seed_book(db_path, "The Hobbit", folder)
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", "Hobbit", "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", "Hobbit", "--print", "--db", str(db_path)])
         assert result.exit_code == 0, result.output
         assert str(folder) in result.output

--- a/tests/e2e/test_folder_cli.py
+++ b/tests/e2e/test_folder_cli.py
@@ -1,0 +1,59 @@
+# ABOUTME: End-to-end tests for the `bookery folder` CLI command.
+# ABOUTME: Drives the full CLI through Click against a real on-disk DB and folder.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+def _seed_book(db_path: Path, title: str, folder: Path) -> int:
+    """Add a single book with an on-disk output_path and return its ID."""
+    folder.mkdir(parents=True, exist_ok=True)
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        return catalog.add_book(
+            BookMetadata(title=title, source_path=Path("/src/x.epub")),
+            file_hash="seed_hash",
+            output_path=folder,
+        )
+    finally:
+        conn.close()
+
+
+class TestFolderCliE2E:
+    """E2E tests covering the full folder command flow against a real DB."""
+
+    def test_print_folder_by_id(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "e2e.db"
+        folder = tmp_path / "library" / "The_Hobbit"
+        book_id = _seed_book(db_path, "The Hobbit", folder)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 0, result.output
+
+        printed = result.output.strip().splitlines()[-1]
+        printed_path = Path(printed)
+        assert printed_path.exists()
+        assert printed_path.is_dir()
+        assert printed_path == folder
+
+    def test_print_folder_by_title_substring(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "e2e.db"
+        folder = tmp_path / "library" / "Hobbit"
+        _seed_book(db_path, "The Hobbit", folder)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", "Hobbit", "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert str(folder) in result.output

--- a/tests/integration/test_folder_cmd.py
+++ b/tests/integration/test_folder_cmd.py
@@ -1,0 +1,185 @@
+# ABOUTME: Integration tests for the `bookery folder` CLI command.
+# ABOUTME: Uses a real tmp SQLite database with the file-manager opener mocked.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+from bookery.util.file_manager import Headless, Opened, OpenerFailed
+
+
+@pytest.fixture()
+def db_with_books(tmp_path: Path) -> tuple[Path, dict[str, int]]:
+    """Seed a real SQLite db with a few books that have on-disk folders."""
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+
+    out_root = tmp_path / "library"
+    out_root.mkdir()
+
+    ids: dict[str, int] = {}
+    for title, hash_ in [
+        ("The Hobbit", "h1"),
+        ("Dune", "h2"),
+        ("Dune Messiah", "h3"),
+    ]:
+        folder = out_root / title.replace(" ", "_")
+        folder.mkdir()
+        book_id = catalog.add_book(
+            BookMetadata(title=title, source_path=Path(f"/src/{hash_}.epub")),
+            file_hash=hash_,
+            output_path=folder,
+        )
+        ids[title] = book_id
+
+    conn.close()
+    return db_path, ids
+
+
+class TestFolderCommandPrint:
+    def test_print_by_id_prints_path_and_exits_zero(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, ids = db_with_books
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["folder", str(ids["The Hobbit"]), "--print", "--db", str(db_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "The_Hobbit" in result.output
+
+
+class TestFolderCommandOpen:
+    def test_open_by_id_invokes_opener(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, ids = db_with_books
+        runner = CliRunner()
+        with patch(
+            "bookery.cli.commands.folder_cmd.open_in_file_manager",
+            return_value=Opened(),
+        ) as mock_open:
+            result = runner.invoke(
+                cli,
+                ["folder", str(ids["The Hobbit"]), "--db", str(db_path)],
+            )
+        assert result.exit_code == 0, result.output
+        mock_open.assert_called_once()
+
+    def test_headless_exits_zero_with_notice(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, ids = db_with_books
+        runner = CliRunner()
+        with patch(
+            "bookery.cli.commands.folder_cmd.open_in_file_manager",
+            return_value=Headless(),
+        ):
+            result = runner.invoke(
+                cli,
+                ["folder", str(ids["The Hobbit"]), "--db", str(db_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert "headless" in result.output.lower() or "no graphical" in result.output.lower()
+
+    def test_opener_failure_exits_nonzero(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, ids = db_with_books
+        runner = CliRunner()
+        with patch(
+            "bookery.cli.commands.folder_cmd.open_in_file_manager",
+            return_value=OpenerFailed("nope"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["folder", str(ids["The Hobbit"]), "--db", str(db_path)],
+            )
+        assert result.exit_code == 1
+        assert "nope" in result.output
+
+
+class TestFolderCommandLookupErrors:
+    def test_unknown_id_exits_one(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, _ = db_with_books
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", "9999", "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_ambiguous_title_exits_two(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, _ = db_with_books
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", "Dune", "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 2
+        assert "Dune" in result.output
+        assert "Dune Messiah" in result.output
+
+    def test_typo_returns_suggestions(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, _ = db_with_books
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", "Hobit", "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 1
+        assert "did you mean" in result.output.lower()
+        assert "Hobbit" in result.output
+
+
+class TestFolderCommandFilesystemErrors:
+    def test_missing_folder_on_disk_exits_one(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "lib.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        ghost_folder = tmp_path / "does_not_exist"
+        book_id = catalog.add_book(
+            BookMetadata(title="Ghost", source_path=Path("/src/g.epub")),
+            file_hash="gh",
+            output_path=ghost_folder,
+        )
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 1
+        assert "out of sync" in result.output.lower() or "does not exist" in result.output.lower()
+
+    def test_no_output_path_exits_one(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        book_id = catalog.add_book(
+            BookMetadata(title="Pathless", source_path=Path("/src/p.epub")),
+            file_hash="pl",
+            # no output_path
+        )
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
+        )
+        assert result.exit_code == 1
+        assert "no on-disk" in result.output.lower() or "no on disk" in result.output.lower()

--- a/tests/integration/test_folder_cmd.py
+++ b/tests/integration/test_folder_cmd.py
@@ -166,12 +166,25 @@ class TestFolderCommandFilesystemErrors:
         assert result.exit_code == 1
         assert "out of sync" in result.output.lower() or "does not exist" in result.output.lower()
 
-    def test_no_output_path_exits_one(self, tmp_path: Path) -> None:
+    def test_no_output_path_falls_back_to_source_parent(
+        self, tmp_path: Path
+    ) -> None:
+        """When output_path is None, fall back to the parent of source_path.
+
+        Books imported without --match never get an output_path. The folder
+        command should still be useful by opening the directory containing
+        the original EPUB.
+        """
         db_path = tmp_path / "lib.db"
+        source_dir = tmp_path / "ingest" / "Some Book"
+        source_dir.mkdir(parents=True)
+        source_file = source_dir / "book.epub"
+        source_file.write_bytes(b"fake")
+
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
         book_id = catalog.add_book(
-            BookMetadata(title="Pathless", source_path=Path("/src/p.epub")),
+            BookMetadata(title="Pathless", source_path=source_file),
             file_hash="pl",
             # no output_path
         )
@@ -181,5 +194,6 @@ class TestFolderCommandFilesystemErrors:
         result = runner.invoke(
             cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
         )
-        assert result.exit_code == 1
-        assert "no on-disk" in result.output.lower() or "no on disk" in result.output.lower()
+        assert result.exit_code == 0, result.output
+        assert str(source_dir) in result.output
+

--- a/tests/integration/test_folder_cmd.py
+++ b/tests/integration/test_folder_cmd.py
@@ -58,9 +58,7 @@ class TestFolderCommandPrint:
 
 
 class TestFolderCommandOpen:
-    def test_open_by_id_invokes_opener(
-        self, db_with_books: tuple[Path, dict[str, int]]
-    ) -> None:
+    def test_open_by_id_invokes_opener(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, ids = db_with_books
         runner = CliRunner()
         with patch(
@@ -108,46 +106,32 @@ class TestFolderCommandOpen:
 
 
 class TestFolderCommandLookupErrors:
-    def test_unknown_id_exits_one(
-        self, db_with_books: tuple[Path, dict[str, int]]
-    ) -> None:
+    def test_unknown_id_exits_one(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, _ = db_with_books
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", "9999", "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", "9999", "--print", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "not found" in result.output.lower()
 
-    def test_ambiguous_title_exits_two(
-        self, db_with_books: tuple[Path, dict[str, int]]
-    ) -> None:
+    def test_ambiguous_title_exits_two(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, _ = db_with_books
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", "Dune", "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", "Dune", "--print", "--db", str(db_path)])
         assert result.exit_code == 2
         assert "Dune" in result.output
         assert "Dune Messiah" in result.output
 
-    def test_typo_returns_suggestions(
-        self, db_with_books: tuple[Path, dict[str, int]]
-    ) -> None:
+    def test_typo_returns_suggestions(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, _ = db_with_books
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", "Hobit", "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", "Hobit", "--print", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "did you mean" in result.output.lower()
         assert "Hobbit" in result.output
 
 
 class TestFolderCommandFilesystemErrors:
-    def test_missing_folder_on_disk_exits_one(
-        self, tmp_path: Path
-    ) -> None:
+    def test_missing_folder_on_disk_exits_one(self, tmp_path: Path) -> None:
         db_path = tmp_path / "lib.db"
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
@@ -160,15 +144,11 @@ class TestFolderCommandFilesystemErrors:
         conn.close()
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "out of sync" in result.output.lower() or "does not exist" in result.output.lower()
 
-    def test_no_output_path_falls_back_to_source_parent(
-        self, tmp_path: Path
-    ) -> None:
+    def test_no_output_path_falls_back_to_source_parent(self, tmp_path: Path) -> None:
         """When output_path is None, fall back to the parent of source_path.
 
         Books imported without --match never get an output_path. The folder
@@ -191,9 +171,6 @@ class TestFolderCommandFilesystemErrors:
         conn.close()
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["folder", str(book_id), "--print", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
         assert result.exit_code == 0, result.output
         assert str(source_dir) in result.output
-

--- a/tests/unit/test_book_lookup.py
+++ b/tests/unit/test_book_lookup.py
@@ -1,0 +1,99 @@
+# ABOUTME: Unit tests for resolve_book() lookup helper.
+# ABOUTME: Validates ID, substring, ambiguity, and fuzzy-suggestion paths.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.core.book_lookup import (
+    Ambiguous,
+    Found,
+    NotFound,
+    Suggestions,
+    resolve_book,
+)
+from bookery.db.mapping import BookRecord
+from bookery.metadata.types import BookMetadata
+
+
+def _record(book_id: int, title: str, author: str = "Anon") -> BookRecord:
+    return BookRecord(
+        id=book_id,
+        metadata=BookMetadata(title=title, authors=[author]),
+        file_hash=f"hash{book_id}",
+        source_path=Path(f"/src/{book_id}.epub"),
+        output_path=Path(f"/out/{book_id}"),
+        date_added="2026-01-01",
+        date_modified="2026-01-01",
+    )
+
+
+class StubCatalog:
+    def __init__(self, records: list[BookRecord]) -> None:
+        self._records = records
+
+    def get_by_id(self, book_id: int) -> BookRecord | None:
+        for r in self._records:
+            if r.id == book_id:
+                return r
+        return None
+
+    def list_all(self) -> list[BookRecord]:
+        return list(self._records)
+
+
+@pytest.fixture()
+def catalog() -> StubCatalog:
+    return StubCatalog(
+        [
+            _record(1, "The Hobbit"),
+            _record(2, "The Fellowship of the Ring"),
+            _record(3, "The Two Towers"),
+            _record(42, "Hitchhiker's Guide to the Galaxy"),
+        ]
+    )
+
+
+class TestNumericId:
+    def test_known_id_returns_found(self, catalog: StubCatalog) -> None:
+        result = resolve_book(catalog, "42")
+        assert isinstance(result, Found)
+        assert result.record.id == 42
+
+    def test_unknown_id_returns_not_found(self, catalog: StubCatalog) -> None:
+        result = resolve_book(catalog, "999")
+        assert isinstance(result, NotFound)
+
+
+class TestSubstringMatch:
+    def test_single_substring_hit_returns_found(
+        self, catalog: StubCatalog
+    ) -> None:
+        result = resolve_book(catalog, "Hobbit")
+        assert isinstance(result, Found)
+        assert result.record.metadata.title == "The Hobbit"
+
+    def test_substring_is_case_insensitive(self, catalog: StubCatalog) -> None:
+        result = resolve_book(catalog, "hobbit")
+        assert isinstance(result, Found)
+        assert result.record.id == 1
+
+    def test_multiple_substring_hits_returns_ambiguous(
+        self, catalog: StubCatalog
+    ) -> None:
+        result = resolve_book(catalog, "the")
+        assert isinstance(result, Ambiguous)
+        assert len(result.records) >= 2
+
+
+class TestFuzzyFallback:
+    def test_typo_returns_suggestions(self, catalog: StubCatalog) -> None:
+        result = resolve_book(catalog, "Hobit")
+        assert isinstance(result, Suggestions)
+        assert any("Hobbit" in r.metadata.title for r in result.records)
+
+    def test_no_match_at_all_returns_not_found(
+        self, catalog: StubCatalog
+    ) -> None:
+        result = resolve_book(catalog, "qzxqzxqzx")
+        assert isinstance(result, NotFound)

--- a/tests/unit/test_book_lookup.py
+++ b/tests/unit/test_book_lookup.py
@@ -66,9 +66,7 @@ class TestNumericId:
 
 
 class TestSubstringMatch:
-    def test_single_substring_hit_returns_found(
-        self, catalog: StubCatalog
-    ) -> None:
+    def test_single_substring_hit_returns_found(self, catalog: StubCatalog) -> None:
         result = resolve_book(catalog, "Hobbit")
         assert isinstance(result, Found)
         assert result.record.metadata.title == "The Hobbit"
@@ -78,9 +76,7 @@ class TestSubstringMatch:
         assert isinstance(result, Found)
         assert result.record.id == 1
 
-    def test_multiple_substring_hits_returns_ambiguous(
-        self, catalog: StubCatalog
-    ) -> None:
+    def test_multiple_substring_hits_returns_ambiguous(self, catalog: StubCatalog) -> None:
         result = resolve_book(catalog, "the")
         assert isinstance(result, Ambiguous)
         assert len(result.records) >= 2
@@ -92,8 +88,43 @@ class TestFuzzyFallback:
         assert isinstance(result, Suggestions)
         assert any("Hobbit" in r.metadata.title for r in result.records)
 
-    def test_no_match_at_all_returns_not_found(
-        self, catalog: StubCatalog
-    ) -> None:
+    def test_no_match_at_all_returns_not_found(self, catalog: StubCatalog) -> None:
         result = resolve_book(catalog, "qzxqzxqzx")
         assert isinstance(result, NotFound)
+
+    def test_suggestions_preserve_difflib_relevance_order(self) -> None:
+        """Suggestions must be ordered by difflib relevance, not catalog order.
+
+        get_close_matches() returns titles best-first; the result must reflect
+        that ordering so the user sees the most likely guess first.
+        """
+        # Catalog inserted in reverse-relevance order on purpose: the most
+        # similar title to "Dunes" ("Dune") is added LAST.
+        records = [
+            _record(1, "Doom"),
+            _record(2, "Dudes"),
+            _record(3, "Dune"),
+        ]
+        catalog = StubCatalog(records)
+
+        result = resolve_book(catalog, "Dunes")
+        assert isinstance(result, Suggestions)
+        # The closest match ("Dune") should be first in the result list.
+        assert result.records[0].metadata.title == "Dune"
+
+    def test_suggestions_never_repeat_same_book_id(self) -> None:
+        """Each book may appear at most once in the suggestion list.
+
+        Two distinct editions sharing a title are both legitimate candidates
+        and may both appear, but a single book should never be listed twice.
+        """
+        records = [
+            _record(1, "Dune"),
+            _record(2, "Dune"),  # same title, different edition (distinct book)
+        ]
+        catalog = StubCatalog(records)
+
+        result = resolve_book(catalog, "Dunes")
+        assert isinstance(result, Suggestions)
+        ids = [r.id for r in result.records]
+        assert len(ids) == len(set(ids)), f"duplicate book ids in suggestions: {ids}"

--- a/tests/unit/test_file_manager.py
+++ b/tests/unit/test_file_manager.py
@@ -1,0 +1,199 @@
+# ABOUTME: Unit tests for cross-platform file manager opener utility.
+# ABOUTME: Validates platform detection and dispatch to native file manager openers.
+
+from pathlib import Path
+from unittest.mock import patch
+
+from bookery.util.file_manager import (
+    Headless,
+    Opened,
+    OpenerFailed,
+    Platform,
+    detect_platform,
+    is_headless_linux,
+    open_in_file_manager,
+)
+
+
+class TestDetectPlatform:
+    def test_macos(self) -> None:
+        with patch("platform.system", return_value="Darwin"):
+            assert detect_platform() == Platform.MACOS
+
+    def test_windows(self) -> None:
+        with patch("platform.system", return_value="Windows"):
+            assert detect_platform() == Platform.WINDOWS
+
+    def test_linux(self) -> None:
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "bookery.util.file_manager._read_proc_version",
+                return_value="Linux version 5.15.0 (gcc)",
+            ),
+        ):
+            assert detect_platform() == Platform.LINUX
+
+    def test_wsl(self) -> None:
+        with (
+            patch("platform.system", return_value="Linux"),
+            patch(
+                "bookery.util.file_manager._read_proc_version",
+                return_value="Linux version 5.15.0-microsoft-standard-WSL2",
+            ),
+        ):
+            assert detect_platform() == Platform.WSL
+
+
+class TestIsHeadlessLinux:
+    def test_headless_when_no_display_and_no_xdg_open(self) -> None:
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("shutil.which", return_value=None),
+        ):
+            assert is_headless_linux() is True
+
+    def test_not_headless_when_display_set(self) -> None:
+        with (
+            patch.dict("os.environ", {"DISPLAY": ":0"}, clear=True),
+            patch("shutil.which", return_value="/usr/bin/xdg-open"),
+        ):
+            assert is_headless_linux() is False
+
+    def test_not_headless_when_wayland_set(self) -> None:
+        with (
+            patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"}, clear=True),
+            patch("shutil.which", return_value="/usr/bin/xdg-open"),
+        ):
+            assert is_headless_linux() is False
+
+    def test_headless_when_display_set_but_no_xdg_open(self) -> None:
+        with (
+            patch.dict("os.environ", {"DISPLAY": ":0"}, clear=True),
+            patch("shutil.which", return_value=None),
+        ):
+            assert is_headless_linux() is True
+
+
+class TestOpenInFileManager:
+    def test_macos_dispatches_open(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.MACOS,
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, Opened)
+        mock_run.assert_called_once_with(
+            ["open", str(tmp_path)], check=True
+        )
+
+    def test_linux_dispatches_xdg_open(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.LINUX,
+            ),
+            patch(
+                "bookery.util.file_manager.is_headless_linux",
+                return_value=False,
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, Opened)
+        mock_run.assert_called_once_with(
+            ["xdg-open", str(tmp_path)], check=True
+        )
+
+    def test_windows_dispatches_startfile(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.WINDOWS,
+            ),
+            patch("os.startfile", create=True) as mock_startfile,
+        ):
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, Opened)
+        mock_startfile.assert_called_once_with(str(tmp_path))
+
+    def test_wsl_dispatches_explorer_with_translated_path(
+        self, tmp_path: Path
+    ) -> None:
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.WSL,
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            # First call is wslpath -w to translate
+            mock_run.side_effect = [
+                type(
+                    "R",
+                    (),
+                    {"stdout": "C:\\Users\\me\\book\n", "returncode": 0},
+                )(),
+                type("R", (), {"returncode": 0})(),
+            ]
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, Opened)
+        assert mock_run.call_count == 2
+        # second call should invoke explorer.exe with translated path
+        second_call_args = mock_run.call_args_list[1][0][0]
+        assert second_call_args[0] == "explorer.exe"
+        assert second_call_args[1] == "C:\\Users\\me\\book"
+
+    def test_headless_linux_returns_headless(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.LINUX,
+            ),
+            patch(
+                "bookery.util.file_manager.is_headless_linux",
+                return_value=True,
+            ),
+        ):
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, Headless)
+
+    def test_opener_not_found_returns_opener_failed(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.MACOS,
+            ),
+            patch("subprocess.run", side_effect=FileNotFoundError("open")),
+        ):
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, OpenerFailed)
+        assert "open" in result.message
+
+    def test_opener_nonzero_returns_opener_failed(self, tmp_path: Path) -> None:
+        import subprocess
+
+        with (
+            patch(
+                "bookery.util.file_manager.detect_platform",
+                return_value=Platform.MACOS,
+            ),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, ["open"]),
+            ),
+        ):
+            result = open_in_file_manager(tmp_path)
+
+        assert isinstance(result, OpenerFailed)

--- a/tests/unit/test_file_manager.py
+++ b/tests/unit/test_file_manager.py
@@ -88,9 +88,7 @@ class TestOpenInFileManager:
             result = open_in_file_manager(tmp_path)
 
         assert isinstance(result, Opened)
-        mock_run.assert_called_once_with(
-            ["open", str(tmp_path)], check=True
-        )
+        mock_run.assert_called_once_with(["open", str(tmp_path)], check=True)
 
     def test_linux_dispatches_xdg_open(self, tmp_path: Path) -> None:
         with (
@@ -108,9 +106,7 @@ class TestOpenInFileManager:
             result = open_in_file_manager(tmp_path)
 
         assert isinstance(result, Opened)
-        mock_run.assert_called_once_with(
-            ["xdg-open", str(tmp_path)], check=True
-        )
+        mock_run.assert_called_once_with(["xdg-open", str(tmp_path)], check=True)
 
     def test_windows_dispatches_startfile(self, tmp_path: Path) -> None:
         with (
@@ -125,9 +121,7 @@ class TestOpenInFileManager:
         assert isinstance(result, Opened)
         mock_startfile.assert_called_once_with(str(tmp_path))
 
-    def test_wsl_dispatches_explorer_with_translated_path(
-        self, tmp_path: Path
-    ) -> None:
+    def test_wsl_dispatches_explorer_with_translated_path(self, tmp_path: Path) -> None:
         with (
             patch(
                 "bookery.util.file_manager.detect_platform",


### PR DESCRIPTION
## Summary

Adds a new `bookery folder <ID|Title>` command that resolves a book by numeric ID or title and opens its on-disk folder in the OS file manager. Supports macOS, Windows, Linux, and WSL, with a `--print` mode for shell pipelines and a graceful fallback to printing the path on headless Linux.

Closes #58.

## What's new

- **`bookery folder 42`** — opens the folder for book id 42 in the native file manager
- **`bookery folder "The Hobbit"`** — substring title match
- **`bookery folder Hobit --print`** — fuzzy "did you mean" suggestions, ranked by relevance
- **`bookery folder 42 --print`** — emit the path unwrapped (safe for shell piping)

## Architecture

Three new modules, each with its own test file:

- **`src/bookery/util/file_manager.py`** — `Platform` enum + `detect_platform()` distinguishing macOS / Windows / Linux / WSL via `/proc/version`. `open_in_file_manager()` returns a typed result union (`Opened | Headless | OpenerFailed`). All `subprocess.run` calls use list args (no `shell=True`).
- **`src/bookery/core/book_lookup.py`** — `resolve_book(catalog, query)` returning `Found | NotFound | Ambiguous | Suggestions`. Resolution order: numeric ID → case-insensitive substring on titles → `difflib.get_close_matches` fuzzy fallback. Suggestions preserve difflib's best-match-first ordering.
- **`src/bookery/cli/commands/folder_cmd.py`** — Click command that wires the two together. Uses `click.echo` (not Rich) for `--print` output so long paths are not wrapped.

## Exit codes

| Code | Meaning |
|---|---|
| `0` | Opened, printed, or headless-fallback (printed path with notice) |
| `1` | Book not found, missing folder, opener failed, or fuzzy suggestion |
| `2` | Ambiguous title (multiple substring matches) |

## Fallback for unmatched books

While testing against a real library, I found that `bookery import` (without `--match`) leaves `output_path = NULL` in the catalog — only the match/write pipeline sets it. The folder command now falls back to `source_path.parent` when `output_path` is `None`, which is exactly the right folder for Calibre-style libraries. The schema enforces `source_path NOT NULL` so the fallback is always safe.

Filed JoeCotellese/bookery#59 to track whether the import pipeline itself should record an explicit `output_path` for unmatched books.

## Tests

35 new tests across all three layers, all green:

- **17 unit tests** — `test_file_manager.py` (15 platform/error cases) + `test_book_lookup.py` (9 lookup cases including suggestion ordering and per-id dedup)
- **9 integration tests** — `test_folder_cmd.py` covers print, open, headless, opener failure, not-found, ambiguous, fuzzy, missing folder, and the unmatched-book fallback
- **2 e2e tests** — `test_folder_cli.py` exercises the full Click pipeline against a real on-disk SQLite catalog

Full suite: **888 passed**.

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass (real tmp SQLite, mocked opener)
- [x] E2E tests pass (real Click pipeline)
- [x] `ruff check` clean
- [x] `pyright` clean
- [x] Smoke-tested against real Calibre library: `bookery folder 20 --print` and `bookery folder 17 --print` resolve correctly
- [x] Code review applied (ruff format + suggestion ordering fix)

## Related

- Closes #58
- Follow-up: JoeCotellese/bookery#59 (import should record output_path)