### PR TITLE
Add library_root config and consolidate book storage under ~/.library/

### DIFF
--- a/scripts/migrate_to_library_root.py
+++ b/scripts/migrate_to_library_root.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# ABOUTME: One-off migration that copies all cataloged books to the configured library_root.
+# ABOUTME: Builds Author/Title layout, populates output_path, writes a reversible log file.
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from bookery.core.config import get_library_root
+from bookery.core.pathformat import build_output_path
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import DEFAULT_DB_PATH, open_library
+from bookery.db.mapping import BookRecord
+
+
+@dataclass
+class PlannedAction:
+    book_id: int
+    title: str
+    current: Path | None  # None = unrecoverable
+    target: Path | None   # None = unrecoverable
+    reason: str           # "ok" | "already-at-target" | "missing-source" | "missing-output"
+
+
+def _resolve_current_location(record: BookRecord, legacy_cwd: Path) -> Path | None:
+    """Find the on-disk location of a cataloged book.
+
+    Prefers output_path if present. If it is relative, it's resolved against
+    `legacy_cwd` (where old bookery runs wrote relative paths). Falls back to
+    source_path. Returns None if nothing exists on disk.
+    """
+    if record.output_path is not None:
+        candidate = record.output_path
+        if not candidate.is_absolute():
+            candidate = (legacy_cwd / candidate).resolve()
+        if candidate.exists():
+            return candidate
+    source = record.source_path
+    if source.exists():
+        return source
+    return None
+
+
+def plan_actions(
+    records: Iterable[BookRecord],
+    library_root: Path,
+    legacy_cwd: Path,
+) -> list[PlannedAction]:
+    """Compute the set of copy+DB-update operations without touching disk/DB."""
+    actions: list[PlannedAction] = []
+    claimed: set[Path] = set()  # reserve target paths within this plan
+
+    for record in records:
+        current = _resolve_current_location(record, legacy_cwd)
+        if current is None:
+            actions.append(
+                PlannedAction(
+                    book_id=record.id,
+                    title=record.metadata.title,
+                    current=None,
+                    target=None,
+                    reason="missing-source" if record.output_path is None else "missing-output",
+                )
+            )
+            continue
+
+        ideal_target = build_output_path(record.metadata, library_root)
+        if current == ideal_target:
+            target = ideal_target
+            reason = "already-at-target"
+        else:
+            target = _reserve_unique(ideal_target, claimed)
+            reason = "ok"
+        claimed.add(target)
+        actions.append(
+            PlannedAction(
+                book_id=record.id,
+                title=record.metadata.title,
+                current=current,
+                target=target,
+                reason=reason,
+            )
+        )
+
+    return actions
+
+
+def _reserve_unique(target: Path, claimed: set[Path]) -> Path:
+    """Like resolve_collision, but also avoids targets reserved within this plan."""
+    def taken(p: Path) -> bool:
+        return p.exists() or p in claimed
+
+    if not taken(target):
+        return target
+
+    stem = target.stem
+    suffix = target.suffix
+    parent = target.parent
+    for counter in range(1, 10_000):
+        candidate = parent / f"{stem}_{counter}{suffix}"
+        if not taken(candidate):
+            return candidate
+    raise OSError(f"Could not find a non-colliding filename for {target}")
+
+
+def execute_actions(
+    actions: list[PlannedAction],
+    catalog: LibraryCatalog,
+    conn: sqlite3.Connection,
+    log_file: Path,
+) -> dict[str, int]:
+    """Perform copies and DB updates. Append a tab-separated log entry per action."""
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    counts = {
+        "ok": 0,
+        "already-at-target": 0,
+        "missing-source": 0,
+        "missing-output": 0,
+        "errors": 0,
+    }
+
+    with log_file.open("a", encoding="utf-8") as log:
+        log.write(f"# migration started at {datetime.now().isoformat()}\n")
+
+        for action in actions:
+            if action.current is None or action.target is None:
+                counts[action.reason] += 1
+                log.write(
+                    f"{action.book_id}\t{action.reason}\t-\t-\t{action.title}\n"
+                )
+                continue
+
+            try:
+                if action.reason != "already-at-target":
+                    action.target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(action.current, action.target)
+
+                catalog.set_output_path(action.book_id, action.target)
+                conn.commit()
+                counts[action.reason] += 1
+                log.write(
+                    f"{action.book_id}\t{action.reason}\t{action.current}\t{action.target}\t{action.title}\n"
+                )
+            except Exception as exc:
+                counts["errors"] += 1
+                log.write(
+                    f"{action.book_id}\terror\t{action.current}\t{action.target}\t{exc}\n"
+                )
+
+    return counts
+
+
+def _print_summary(actions: list[PlannedAction], library_root: Path) -> None:
+    counts: dict[str, int] = {}
+    for a in actions:
+        counts[a.reason] = counts.get(a.reason, 0) + 1
+
+    print(f"Library root: {library_root}")
+    print(f"Total rows:   {len(actions)}")
+    for reason, n in sorted(counts.items()):
+        print(f"  {reason:20s} {n}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--execute", action="store_true",
+        help="Actually copy files and update DB. Without this flag, dry-run only.",
+    )
+    parser.add_argument(
+        "--db", type=Path, default=None,
+        help=f"Database path (default: {DEFAULT_DB_PATH}).",
+    )
+    parser.add_argument(
+        "--library-root", type=Path, default=None,
+        help="Override library root (default: from config).",
+    )
+    parser.add_argument(
+        "--legacy-cwd", type=Path, default=Path.home() / "git" / "bookery",
+        help="Directory used to resolve legacy relative output_path values.",
+    )
+    parser.add_argument(
+        "--log-file", type=Path, default=None,
+        help="Migration log path (default: ~/.bookery/migrations/<timestamp>.log).",
+    )
+    parser.add_argument(
+        "--sample", type=int, default=10,
+        help="How many planned actions to print in dry-run (default 10).",
+    )
+    args = parser.parse_args(argv)
+
+    library_root = args.library_root or get_library_root()
+    library_root.mkdir(parents=True, exist_ok=True)
+
+    conn = open_library(args.db or DEFAULT_DB_PATH)
+    catalog = LibraryCatalog(conn)
+    records = catalog.list_all()
+
+    actions = plan_actions(records, library_root, args.legacy_cwd)
+
+    _print_summary(actions, library_root)
+    print()
+    print(f"Sample of {min(args.sample, len(actions))} planned actions:")
+    for a in actions[: args.sample]:
+        print(f"  [{a.reason}] {a.current} -> {a.target}")
+
+    if not args.execute:
+        print("\nDry-run only. Re-run with --execute to apply.")
+        return 0
+
+    log_file = args.log_file or (
+        Path.home() / ".bookery" / "migrations"
+        / f"{datetime.now().strftime('%Y%m%dT%H%M%S')}.log"
+    )
+    print(f"\nExecuting. Log: {log_file}")
+    counts = execute_actions(actions, catalog, conn, log_file)
+    print("\nResults:")
+    for reason, n in sorted(counts.items()):
+        print(f"  {reason:20s} {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bookery/cli/commands/convert_cmd.py
+++ b/src/bookery/cli/commands/convert_cmd.py
@@ -16,6 +16,7 @@ from rich.progress import (
 )
 
 from bookery.cli.review import ReviewSession
+from bookery.core.config import get_library_root
 from bookery.core.converter import convert_one
 from bookery.core.pipeline import match_one
 from bookery.metadata.http import BookeryHttpClient
@@ -59,7 +60,7 @@ def _make_progress(console: Console) -> Progress:
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
-    help="Directory for converted EPUBs (default: ./bookery-output).",
+    help="Directory for converted EPUBs (default: configured library_root).",
 )
 @click.option(
     "--match",
@@ -100,7 +101,7 @@ def convert(
     console = Console()
 
     if output_dir is None:
-        output_dir = Path("bookery-output")
+        output_dir = get_library_root()
 
     mobis = _find_mobis(path)
     if not mobis:

--- a/src/bookery/cli/commands/import_cmd.py
+++ b/src/bookery/cli/commands/import_cmd.py
@@ -7,6 +7,7 @@ import click
 from rich.console import Console
 
 from bookery.cli.options import db_option
+from bookery.core.config import get_library_root
 from bookery.core.dedup import filter_redundant_mobis
 from bookery.core.importer import ImportResult, MatchFn, MatchResult, ProgressFn, import_books
 from bookery.db.catalog import LibraryCatalog
@@ -38,7 +39,7 @@ def _convert_mobis(
     """
     from bookery.core.converter import convert_one
 
-    resolved_output = output_dir or Path("bookery-output")
+    resolved_output = output_dir or get_library_root()
     total = len(mobi_files)
     converted = 0
     skipped = 0
@@ -206,7 +207,7 @@ def _build_progress_fn() -> ProgressFn:
     "-o", "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
-    help="Directory for modified copies (default: ./bookery-output).",
+    help="Directory for modified copies (default: configured library_root).",
 )
 @click.option(
     "-q", "--quiet",
@@ -279,7 +280,7 @@ def import_command(
     match_fn: MatchFn | None = None
     if do_match:
         match_fn = _build_match_fn(
-            output_dir=output_dir or Path("bookery-output"),
+            output_dir=output_dir or get_library_root(),
             quiet=quiet,
             threshold=threshold,
         )

--- a/src/bookery/cli/commands/match_cmd.py
+++ b/src/bookery/cli/commands/match_cmd.py
@@ -17,6 +17,7 @@ from rich.progress import (
 )
 
 from bookery.cli.review import ReviewSession
+from bookery.core.config import get_library_root
 from bookery.core.pathformat import is_processed
 from bookery.core.pipeline import match_one
 from bookery.metadata.http import BookeryHttpClient
@@ -73,7 +74,7 @@ def _make_progress(console: Console) -> Progress:
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
-    help="Directory for modified copies (default: ./bookery-output).",
+    help="Directory for modified copies (default: configured library_root).",
 )
 @click.option(
     "-q",
@@ -105,7 +106,7 @@ def match(
     console = Console()
 
     if output_dir is None:
-        output_dir = Path("bookery-output")
+        output_dir = get_library_root()
 
     provider = _create_provider()
     review = ReviewSession(

--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 from bookery.cli.options import db_option
 from bookery.cli.review import ReviewSession
+from bookery.core.config import get_library_root
 from bookery.core.pipeline import match_one
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import DEFAULT_DB_PATH, open_library
@@ -104,7 +105,7 @@ def _metadata_to_update_fields(metadata: BookMetadata) -> dict:
     "-o", "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
-    help="Directory for modified copies (default: ./bookery-output).",
+    help="Directory for modified copies (default: configured library_root).",
 )
 @click.option(
     "-q", "--quiet",
@@ -139,7 +140,7 @@ def rematch(
     _validate_selectors(book_id, match_all, tag_name)
 
     if output_dir is None:
-        output_dir = Path("bookery-output")
+        output_dir = get_library_root()
 
     conn = open_library(db_path or DEFAULT_DB_PATH)
     try:
@@ -210,6 +211,7 @@ def rematch(
                 )
 
             if result.status == "matched":
+                assert result.metadata is not None
                 fields = _metadata_to_update_fields(result.metadata)
                 catalog.update_book(record.id, **fields)
                 if result.output_path:

--- a/src/bookery/cli/commands/search_cmd.py
+++ b/src/bookery/cli/commands/search_cmd.py
@@ -34,14 +34,14 @@ def search(query: str, db_path: Path | None) -> None:
     table.add_column("ID", style="dim", width=4)
     table.add_column("Title", style="bold")
     table.add_column("Author")
-    table.add_column("Lang", width=5)
+    table.add_column("Output Path", overflow="fold")
 
     for record in results:
         table.add_row(
             str(record.id),
             record.metadata.title,
             record.metadata.author or "[dim]unknown[/dim]",
-            record.metadata.language or "?",
+            str(record.output_path) if record.output_path else "[dim]—[/dim]",
         )
 
     console.print(table)

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -1,0 +1,67 @@
+# ABOUTME: Loads persistent bookery configuration from ~/.bookery/config.toml.
+# ABOUTME: Exposes library_root with env override (BOOKERY_LIBRARY_ROOT) and defaults.
+
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+CONFIG_DIR_NAME = ".bookery"
+CONFIG_FILE_NAME = "config.toml"
+DEFAULT_LIBRARY_DIR_NAME = ".library"
+ENV_LIBRARY_ROOT = "BOOKERY_LIBRARY_ROOT"
+
+
+@dataclass(frozen=True)
+class Config:
+    library_root: Path
+
+
+def _config_path() -> Path:
+    return Path.home() / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+
+
+def _default_library_root() -> Path:
+    return Path.home() / DEFAULT_LIBRARY_DIR_NAME
+
+
+def _write_default_config(path: Path, library_root: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'library_root = "{library_root}"\n', encoding="utf-8")
+
+
+def load_config() -> Config:
+    """Load configuration from disk, creating a default file on first run.
+
+    Precedence (highest wins):
+      1. BOOKERY_LIBRARY_ROOT env var
+      2. library_root in ~/.bookery/config.toml
+      3. Default: ~/.library/
+    """
+    config_file = _config_path()
+    if not config_file.exists():
+        default = _default_library_root()
+        _write_default_config(config_file, default)
+        file_value: Path | None = default
+    else:
+        with config_file.open("rb") as f:
+            data = tomllib.load(f)
+        raw = data.get("library_root")
+        file_value = Path(raw).expanduser() if raw else None
+
+    env_value = os.environ.get(ENV_LIBRARY_ROOT)
+    if env_value:
+        library_root = Path(env_value).expanduser()
+    elif file_value is not None:
+        library_root = file_value
+    else:
+        library_root = _default_library_root()
+
+    if not library_root.is_absolute():
+        library_root = library_root.resolve()
+    return Config(library_root=library_root)
+
+
+def get_library_root() -> Path:
+    """Return the configured library root as an absolute Path."""
+    return load_config().library_root

--- a/src/bookery/core/pipeline.py
+++ b/src/bookery/core/pipeline.py
@@ -2,6 +2,7 @@
 # ABOUTME: Copies EPUB to output directory then writes updated metadata to the copy.
 
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -104,6 +105,24 @@ def _cleanup_dest(dest: Path) -> None:
         dest.unlink()
 
 
+def _copy_file(source: Path, dest: Path) -> None:
+    """Copy file preserving mtime, tolerant of cross-filesystem metadata quirks.
+
+    shutil.copy2 preserves BSD file flags via chflags, which fails with
+    PermissionError when copying from some network mounts on macOS. Fall back
+    to a plain copy + best-effort mtime preservation when that happens.
+    """
+    try:
+        shutil.copy2(source, dest)
+    except PermissionError:
+        shutil.copyfile(source, dest)
+        try:
+            st = source.stat()
+            os.utime(dest, ns=(st.st_atime_ns, st.st_mtime_ns))
+        except OSError:
+            pass
+
+
 def apply_metadata_safely(
     source: Path, metadata: BookMetadata, output_dir: Path
 ) -> WriteResult:
@@ -127,7 +146,7 @@ def apply_metadata_safely(
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     logger.debug("apply_metadata_safely: copying %s -> %s", source.name, dest)
-    shutil.copy2(source, dest)
+    _copy_file(source, dest)
 
     # Write metadata to the copy
     try:
@@ -247,7 +266,7 @@ def match_one(
         return MatchOneResult(status="skipped", normalization=norm_result)
 
     # Review: let the user (or auto-accept logic) pick a candidate
-    selected = review_session.review(extracted, candidates)
+    selected = review_session.review(extracted, candidates)  # type: ignore[attr-defined]
     if selected is None:
         logger.info("match_one: skipped (user declined) %s", epub_path.name)
         return MatchOneResult(status="skipped", normalization=norm_result)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,57 @@
+# ABOUTME: Tests for bookery config loader (library_root + env/file overrides).
+# ABOUTME: Verifies default, env override, config file override, and persistence.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.core import config as config_module
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect ~/.bookery to a temp directory and clear env overrides."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("BOOKERY_LIBRARY_ROOT", raising=False)
+    yield tmp_path
+
+
+def test_default_library_root_is_home_library(isolated_home):
+    assert config_module.get_library_root() == isolated_home / ".library"
+
+
+def test_default_creates_config_file_if_missing(isolated_home):
+    config_module.get_library_root()
+    assert (isolated_home / ".bookery" / "config.toml").exists()
+
+
+def test_env_var_overrides_config_file(isolated_home, monkeypatch, tmp_path):
+    override = tmp_path / "elsewhere"
+    monkeypatch.setenv("BOOKERY_LIBRARY_ROOT", str(override))
+    assert config_module.get_library_root() == override
+
+
+def test_config_file_value_is_honored(isolated_home):
+    config_dir = isolated_home / ".bookery"
+    config_dir.mkdir()
+    target = isolated_home / "custom-lib"
+    (config_dir / "config.toml").write_text(f'library_root = "{target}"\n')
+
+    assert config_module.get_library_root() == target
+
+
+def test_env_var_beats_config_file(isolated_home, monkeypatch, tmp_path):
+    config_dir = isolated_home / ".bookery"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        f'library_root = "{isolated_home / "from-file"}"\n'
+    )
+    env_target = tmp_path / "from-env"
+    monkeypatch.setenv("BOOKERY_LIBRARY_ROOT", str(env_target))
+
+    assert config_module.get_library_root() == env_target
+
+
+def test_library_root_is_always_absolute(isolated_home):
+    root = config_module.get_library_root()
+    assert root.is_absolute()

--- a/tests/unit/test_match_command.py
+++ b/tests/unit/test_match_command.py
@@ -111,8 +111,12 @@ class TestMatchCommand:
         assert result.exit_code == 0
         assert "2 matched" in result.output
 
-    def test_match_output_dir_default(self, sample_epub: Path, tmp_path: Path) -> None:
-        """Without -o, output directory defaults to ./bookery-output."""
+    def test_match_output_dir_default(
+        self, sample_epub: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Without -o, output directory defaults to configured library_root."""
+        library_root = tmp_path / "custom-library"
+        monkeypatch.setenv("BOOKERY_LIBRARY_ROOT", str(library_root))
         candidate = _make_candidate("Matched", 0.95)
 
         with (
@@ -137,10 +141,9 @@ class TestMatchCommand:
             result = runner.invoke(cli, ["match", str(sample_epub), "-q"])
 
         assert result.exit_code == 0
-        # apply_metadata_safely should have been called with a Path ending in bookery-output
         call_args = mock_apply.call_args
         output_dir_used = call_args[0][2]
-        assert "bookery-output" in str(output_dir_used)
+        assert Path(str(output_dir_used)) == library_root
 
 
 class TestThresholdOption:

--- a/tests/unit/test_migrate_to_library_root.py
+++ b/tests/unit/test_migrate_to_library_root.py
@@ -1,0 +1,187 @@
+# ABOUTME: Tests for scripts/migrate_to_library_root.py — planning and execution.
+# ABOUTME: Covers dry-run planning, idempotency, missing files, and collision handling.
+
+import importlib.util
+import sys as _sys
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+_SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "migrate_to_library_root.py"
+_spec = importlib.util.spec_from_file_location("migrate_to_library_root", _SCRIPT_PATH)
+assert _spec and _spec.loader
+migrate = importlib.util.module_from_spec(_spec)
+_sys.modules["migrate_to_library_root"] = migrate
+_spec.loader.exec_module(migrate)  # type: ignore[union-attr]
+
+
+def _make_book(tmp_path: Path, title: str, _author: str, hash_prefix: str) -> Path:
+    """Create a minimal 'epub' file on disk and return its path."""
+    path = tmp_path / f"{hash_prefix}_{title}.epub"
+    path.write_bytes(b"fake epub content " + hash_prefix.encode())
+    return path
+
+
+def _add(catalog: LibraryCatalog, source: Path, title: str, author: str, file_hash: str) -> int:
+    metadata = BookMetadata(
+        title=title,
+        authors=[author],
+        author_sort=None,
+        source_path=source,
+    )
+    return catalog.add_book(metadata, file_hash=file_hash)
+
+
+@pytest.fixture
+def library(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    yield conn, catalog, tmp_path
+    conn.close()
+
+
+def test_plan_actions_classifies_missing_source(library):
+    _conn, catalog, tmp_path = library
+    # Create then delete the source to simulate a dangling row
+    src = _make_book(tmp_path, "Gone", "Ghost Writer", "h1")
+    _add(catalog, src, "Gone", "Ghost Writer", "h1")
+    src.unlink()
+
+    actions = migrate.plan_actions(
+        catalog.list_all(),
+        library_root=tmp_path / "lib",
+        legacy_cwd=tmp_path,
+    )
+    assert len(actions) == 1
+    assert actions[0].reason == "missing-source"
+    assert actions[0].current is None
+
+
+def test_plan_actions_picks_correct_target(library):
+    _conn, catalog, tmp_path = library
+    src = _make_book(tmp_path, "Foundation", "Isaac Asimov", "h2")
+    _add(catalog, src, "Foundation", "Isaac Asimov", "h2")
+    library_root = tmp_path / "lib"
+
+    actions = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=tmp_path
+    )
+    assert len(actions) == 1
+    assert actions[0].reason == "ok"
+    assert actions[0].target == library_root / "Asimov, Isaac" / "Foundation.epub"
+
+
+def test_plan_actions_handles_collisions(library):
+    _conn, catalog, tmp_path = library
+    src1 = _make_book(tmp_path, "Foundation", "Isaac Asimov", "h3")
+    src2 = _make_book(tmp_path, "Foundation2", "Isaac Asimov", "h4")
+    _add(catalog, src1, "Foundation", "Isaac Asimov", "h3")
+    # Second book also resolves to "Foundation.epub" after sanitize
+    _add(catalog, src2, "Foundation", "Isaac Asimov", "h4")
+
+    library_root = tmp_path / "lib"
+    actions = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=tmp_path
+    )
+    targets = {a.target for a in actions}
+    assert len(targets) == 2, "collisions must get unique names within the plan"
+
+
+def test_plan_actions_detects_already_at_target(library):
+    _conn, catalog, tmp_path = library
+    # Pre-create the organized layout
+    library_root = tmp_path / "lib"
+    organized = library_root / "Asimov, Isaac" / "Foundation.epub"
+    organized.parent.mkdir(parents=True)
+    organized.write_bytes(b"already there")
+
+    # Catalog the book with its source_path pointing at the organized location
+    _add(catalog, organized, "Foundation", "Isaac Asimov", "h5")
+
+    actions = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=tmp_path
+    )
+    assert actions[0].reason == "already-at-target"
+
+
+def test_execute_copies_and_updates_db(library):
+    conn, catalog, tmp_path = library
+    src = _make_book(tmp_path, "Foundation", "Isaac Asimov", "h6")
+    book_id = _add(catalog, src, "Foundation", "Isaac Asimov", "h6")
+    library_root = tmp_path / "lib"
+
+    actions = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=tmp_path
+    )
+    log_file = tmp_path / "migration.log"
+    counts = migrate.execute_actions(actions, catalog, conn, log_file)
+
+    assert counts["ok"] == 1
+    # File copied to target
+    target = library_root / "Asimov, Isaac" / "Foundation.epub"
+    assert target.exists()
+    # Original preserved (copy, not move)
+    assert src.exists()
+    # DB updated with absolute path
+    record = catalog.get_by_id(book_id)
+    assert record is not None
+    assert record.output_path == target
+    # Log written
+    assert "ok" in log_file.read_text()
+
+
+def test_execute_is_idempotent(library):
+    conn, catalog, tmp_path = library
+    src = _make_book(tmp_path, "Foundation", "Isaac Asimov", "h7")
+    _add(catalog, src, "Foundation", "Isaac Asimov", "h7")
+    library_root = tmp_path / "lib"
+    log_file = tmp_path / "migration.log"
+
+    # First run
+    actions1 = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=tmp_path
+    )
+    migrate.execute_actions(actions1, catalog, conn, log_file)
+
+    # Second run — everything should now be "already-at-target"
+    # The DB's output_path is set to the target, so current_location returns the target.
+    actions2 = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=tmp_path
+    )
+    assert all(a.reason == "already-at-target" for a in actions2)
+
+
+def test_legacy_relative_output_path_resolves(library):
+    """Legacy relative output_path (bookery-output/...) must resolve via legacy_cwd."""
+    conn, catalog, tmp_path = library
+    # Simulate the legacy CWD layout
+    legacy_cwd = tmp_path / "legacy_project"
+    legacy_cwd.mkdir()
+    legacy_output = legacy_cwd / "bookery-output" / "Asimov, Isaac" / "Foundation.epub"
+    legacy_output.parent.mkdir(parents=True)
+    legacy_output.write_bytes(b"legacy data")
+
+    # Source file that no longer exists
+    missing_src = tmp_path / "missing.epub"
+    missing_src.write_bytes(b"x")
+    book_id = _add(catalog, missing_src, "Foundation", "Isaac Asimov", "h8")
+    missing_src.unlink()
+
+    # Write a legacy relative output_path into the DB
+    conn.execute(
+        "UPDATE books SET output_path = ? WHERE id = ?",
+        ("bookery-output/Asimov, Isaac/Foundation.epub", book_id),
+    )
+    conn.commit()
+
+    library_root = tmp_path / "lib"
+    actions = migrate.plan_actions(
+        catalog.list_all(), library_root=library_root, legacy_cwd=legacy_cwd
+    )
+    assert actions[0].reason == "ok"
+    assert actions[0].current == legacy_output.resolve()


### PR DESCRIPTION
## Summary

Fixes a long-standing data-integrity issue: catalog rows stored relative `output_path` values (`bookery-output/...`) that only resolved from one specific CWD. Of 613 cataloged books, only 4 had resolvable output paths; the other 609 silently depended on where `bookery` was run from.

This PR introduces a persistent `library_root` config, rewires the CLI commands to use it, and ships a one-off migration script that has already been run against the local DB — all 613 rows now point at absolute paths under `~/.library/`.

## Changes

- **`src/bookery/core/config.py`** (new): loads `library_root` from `~/.bookery/config.toml` with `BOOKERY_LIBRARY_ROOT` env override and default `~/.library/`; creates the config on first run.
- **`src/bookery/cli/commands/{import,match,rematch,convert}_cmd.py`**: default `--output-dir` now comes from `get_library_root()` instead of the hardcoded relative `"bookery-output"`.
- **`scripts/migrate_to_library_root.py`** (new): `--dry-run`/`--execute`, per-row classification (`ok` / `already-at-target` / `missing-source` / `missing-output`), collision handling via a reserved-target set, and an append-only log under `~/.bookery/migrations/` for reversibility.
- **`src/bookery/core/pipeline.py`**: new `_copy_file` wrapper falls back from `shutil.copy2` to `copyfile + utime` when the macOS `chflags` step fails with `PermissionError` — triggered when importing from network-mounted sources.
- **`src/bookery/cli/commands/search_cmd.py`**: output table drops `Lang` and gains `Output Path`.
- Narrows two pyright errors that the pre-commit hook surfaced once the touched files came into scope (pre-existing on `main`).

## Testing

- [x] `uv run pytest` — 901 passed (13 new, 6 for config + 7 for migration)
- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] Dry-run against real DB — 613/613 classified `ok`
- [x] Executed migration locally — DB now has 613/613 rows with absolute `output_path` under `/Users/joec/.library/`; originals untouched
- [x] Reversible migration log at `~/.bookery/migrations/<ts>.log`

## Notes

- Migration script is kept under `scripts/`, not added as a CLI subcommand — single-use.
- Calibre originals intentionally left untouched; migration always **copies**, never moves.