### PR TITLE
Add #63: import copies into library_root by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,15 @@ CLI-first ebook library manager. EPUB-focused, metadata-first, non-destructive.
 - **`MetadataProvider`** protocol (`metadata/provider.py`) — implement this to add new sources
 - **`MetadataCandidate`** wraps metadata + confidence + source for the review pipeline
 - Pipeline: extract → normalize → search → score → review → write copy
-- Non-destructive: originals are never modified, always copy-then-write
+- Non-destructive (contents): metadata writes always go to a copy; original file bytes are never modified
+- Library-canonical: `import` and `add` copy sources into `library_root` by default. `--move` deletes the source after a successful catalog insert.
 
 ## Key Conventions
 
 - All code files start with two `# ABOUTME:` comment lines describing the file's purpose
 - Tests are mandatory: unit, integration, and e2e for every feature
 - TDD: write failing test first, then minimal code to pass
-- Never modify original EPUB files — work on copies in output directory
+- Never modify original EPUB file contents — work on copies in the library
 
 ## Package Layout
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 - **Interactive review** — presents candidates in a Rich table, lets you accept, compare details, look up by URL, or skip
 - **Smart normalization** — splits mangled filenames like `SteveBerry-TheTemplarLegacy` into clean search queries, detects embedded author names
 - **SQLite catalog** — imports books into a local database for querying, tagging, and integrity checks
-- **Non-destructive** — never modifies your original files; writes corrected copies to an output directory
+- **Non-destructive** — metadata writes always go to a copy; original file contents are never modified. `import` copies each source into your library by default (`--move` deletes the source after a successful catalog insert)
 
 ## Installation
 
@@ -49,8 +49,11 @@ bookery match ~/Books/ -o ~/Books-fixed/
 # Auto-accept high-confidence matches (no prompts)
 bookery match ~/Books/ -o ~/Books-fixed/ --quiet
 
-# Import matched EPUBs into the catalog
-bookery import ~/Books-fixed/ --db ~/library.db
+# Import EPUBs into the catalog (copies into ~/.library/ by default)
+bookery import ~/Books/ --db ~/library.db
+
+# Import and remove the sources after they land in the library
+bookery import ~/Downloads/ --db ~/library.db --move
 
 # Search and browse the catalog
 bookery search "martian"
@@ -78,7 +81,7 @@ bookery info 42
 
 | Command | Description |
 |---------|-------------|
-| `import <dir>` | Scan for EPUBs and catalog them in the library (supports `--match` to match first) |
+| `import <dir>` | Scan for EPUBs, copy into `library_root`, and catalog them (supports `--match`, `--move`) |
 | `ls` | List all books in the catalog (filter with `--series` or `--tag`) |
 | `info <id>` | Show detailed metadata for a book by ID |
 | `search <query>` | Search the catalog by title, author, or description |
@@ -159,7 +162,7 @@ See [docs/roadmap.md](docs/roadmap.md) for detailed checklists.
 ## Design Principles
 
 - **Metadata-first** — get the data right before organizing files
-- **Non-destructive** — original files are never modified
+- **Non-destructive** — original file contents are never modified; metadata writes go to a copy in the library
 - **CLI-first** — every feature is a terminal command; no GUI required
 - **Extensible** — providers, formats, and devices will be pluggable
 - **Respectful** — rate-limited API usage, no scraping

--- a/src/bookery/cli/commands/import_cmd.py
+++ b/src/bookery/cli/commands/import_cmd.py
@@ -186,6 +186,11 @@ def _build_progress_fn() -> ProgressFn:
             )
         elif status == "error":
             console.print(f"  [red]✗[/red] {path.name} — [red]{reason}[/red]")
+        elif status == "move_failed":
+            console.print(
+                f"  [yellow]⚠[/yellow] {path.name} — "
+                f"[dim]cataloged but source not removed: {reason}[/dim]"
+            )
 
     return on_progress
 
@@ -233,6 +238,13 @@ def _build_progress_fn() -> ProgressFn:
     default=False,
     help="Import metadata duplicates (same ISBN or title+author) instead of skipping.",
 )
+@click.option(
+    "--move",
+    "do_move",
+    is_flag=True,
+    default=False,
+    help="Delete source file after successful catalog (library copy is preserved).",
+)
 def import_command(
     directory: Path,
     db_path: Path | None,
@@ -242,6 +254,7 @@ def import_command(
     threshold: float,
     do_convert: bool,
     force_duplicates: bool,
+    do_move: bool,
 ) -> None:
     """Scan a directory for EPUB files and catalog them in the library."""
     epub_files = _find_epubs(directory)
@@ -277,10 +290,11 @@ def import_command(
     conn = open_library(db_path or DEFAULT_DB_PATH)
     catalog = LibraryCatalog(conn)
 
+    library_root = output_dir or get_library_root()
     match_fn: MatchFn | None = None
     if do_match:
         match_fn = _build_match_fn(
-            output_dir=output_dir or get_library_root(),
+            output_dir=library_root,
             quiet=quiet,
             threshold=threshold,
         )
@@ -289,7 +303,9 @@ def import_command(
 
     result = import_books(
         epub_files, catalog,
+        library_root=library_root,
         match_fn=match_fn,
+        move=do_move,
         force_duplicates=force_duplicates,
         on_progress=on_progress,
     )

--- a/src/bookery/core/filecopy.py
+++ b/src/bookery/core/filecopy.py
@@ -1,0 +1,24 @@
+# ABOUTME: Filesystem copy helper tolerant of macOS BSD file-flag permission errors.
+# ABOUTME: Preserves mtime via copy2, falls back to copyfile + utime on PermissionError.
+
+import os
+import shutil
+from pathlib import Path
+
+
+def copy_file(source: Path, dest: Path) -> None:
+    """Copy file preserving mtime, tolerant of cross-filesystem metadata quirks.
+
+    shutil.copy2 preserves BSD file flags via chflags, which fails with
+    PermissionError when copying from some network mounts on macOS. Fall back
+    to a plain copy + best-effort mtime preservation when that happens.
+    """
+    try:
+        shutil.copy2(source, dest)
+    except PermissionError:
+        shutil.copyfile(source, dest)
+        try:
+            st = source.stat()
+            os.utime(dest, ns=(st.st_atime_ns, st.st_mtime_ns))
+        except OSError:
+            pass

--- a/src/bookery/core/importer.py
+++ b/src/bookery/core/importer.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from bookery.core.filecopy import copy_file
+from bookery.core.pathformat import build_output_path, resolve_collision
 from bookery.db.catalog import DuplicateBookError, LibraryCatalog
 from bookery.db.hashing import compute_file_hash
 from bookery.formats.epub import EpubReadError, read_epub_metadata
@@ -56,30 +58,43 @@ MatchFn = Callable[[BookMetadata, Path], MatchResult | None]
 ProgressFn = Callable[[Path, str, str, str, str | None, int | None], None]
 
 
+def _is_inside(path: Path, root: Path) -> bool:
+    """Return True if path resolves inside root."""
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
 def import_books(
     paths: list[Path],
     catalog: LibraryCatalog,
     *,
+    library_root: Path,
     match_fn: MatchFn | None = None,
+    move: bool = False,
     force_duplicates: bool = False,
     on_progress: ProgressFn | None = None,
 ) -> ImportResult:
     """Import EPUB files into the library catalog.
 
-    For each file: extracts metadata, computes SHA-256 hash, and adds to
-    the catalog. Duplicate files (same hash) are skipped. Metadata-level
-    duplicates (same ISBN or same title+author) are also skipped unless
-    force_duplicates is True.
+    For each file: extracts metadata, computes SHA-256 hash, copies the file
+    into library_root (unless already inside it, or the match pipeline
+    already produced a copy), and adds a record to the catalog. Duplicate
+    files (same hash) are skipped. Metadata-level duplicates (same ISBN or
+    same title+author) are also skipped unless force_duplicates is True.
 
     When match_fn is provided, it is called with (extracted_metadata, epub_path)
-    after extraction. If it returns a MatchResult, the matched metadata and
-    output_path are used for the catalog entry. If it returns None (user
-    skipped), the original metadata is cataloged without an output_path.
+    after extraction. If it returns a MatchResult with an output_path, that
+    path is used as the catalog output_path and no additional copy is made.
 
     Args:
         paths: List of EPUB file paths to import.
         catalog: The library catalog to add books to.
+        library_root: Directory into which sources are copied.
         match_fn: Optional callback to run the match pipeline per file.
+        move: If True, delete source file after successful catalog insert.
+            Sources already inside library_root are never deleted.
         force_duplicates: If True, import metadata duplicates with a warning.
         on_progress: Optional callback fired per-file with status info.
 
@@ -122,6 +137,7 @@ def import_books(
         metadata.source_path = epub_path
 
         output_path: Path | None = None
+        copied_to_library = False
 
         if match_fn is not None:
             match_result = match_fn(metadata, epub_path)
@@ -129,6 +145,29 @@ def import_books(
                 metadata = match_result.metadata
                 metadata.source_path = epub_path
                 output_path = match_result.output_path
+                if output_path is not None:
+                    copied_to_library = True
+
+        # If no output_path yet, either use the source (idempotent) or copy into library_root.
+        if output_path is None:
+            if _is_inside(epub_path, library_root):
+                output_path = epub_path
+            else:
+                try:
+                    dest = resolve_collision(build_output_path(metadata, library_root))
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    copy_file(epub_path, dest)
+                except OSError as exc:
+                    result.errors += 1
+                    result.error_details.append((epub_path, f"copy failed: {exc}"))
+                    if on_progress:
+                        on_progress(
+                            epub_path, metadata.title, metadata.author,
+                            "error", f"copy failed: {exc}", None,
+                        )
+                    continue
+                output_path = dest
+                copied_to_library = True
 
         # Metadata-level duplicate check (ISBN, then title+author)
         dup_match = catalog.find_duplicate(metadata)
@@ -175,6 +214,16 @@ def import_books(
                 SkipDetail(path=epub_path, reason="hash"),
             )
             continue
+
+        if move and copied_to_library:
+            try:
+                epub_path.unlink()
+            except OSError as exc:
+                if on_progress:
+                    on_progress(
+                        epub_path, metadata.title, metadata.author,
+                        "move_failed", str(exc), None,
+                    )
 
         # Auto-assign genres from subjects
         if metadata.subjects:

--- a/src/bookery/core/pipeline.py
+++ b/src/bookery/core/pipeline.py
@@ -2,11 +2,10 @@
 # ABOUTME: Copies EPUB to output directory then writes updated metadata to the copy.
 
 import logging
-import os
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from bookery.core.filecopy import copy_file
 from bookery.core.pathformat import build_output_path, record_processed, resolve_collision
 from bookery.formats.epub import EpubReadError, read_epub_metadata, write_epub_metadata
 from bookery.metadata.normalizer import NormalizationResult, normalize_metadata
@@ -105,24 +104,6 @@ def _cleanup_dest(dest: Path) -> None:
         dest.unlink()
 
 
-def _copy_file(source: Path, dest: Path) -> None:
-    """Copy file preserving mtime, tolerant of cross-filesystem metadata quirks.
-
-    shutil.copy2 preserves BSD file flags via chflags, which fails with
-    PermissionError when copying from some network mounts on macOS. Fall back
-    to a plain copy + best-effort mtime preservation when that happens.
-    """
-    try:
-        shutil.copy2(source, dest)
-    except PermissionError:
-        shutil.copyfile(source, dest)
-        try:
-            st = source.stat()
-            os.utime(dest, ns=(st.st_atime_ns, st.st_mtime_ns))
-        except OSError:
-            pass
-
-
 def apply_metadata_safely(
     source: Path, metadata: BookMetadata, output_dir: Path
 ) -> WriteResult:
@@ -146,7 +127,7 @@ def apply_metadata_safely(
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     logger.debug("apply_metadata_safely: copying %s -> %s", source.name, dest)
-    _copy_file(source, dest)
+    copy_file(source, dest)
 
     # Write metadata to the copy
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,17 @@ import pytest
 from ebooklib import epub
 
 
+@pytest.fixture(autouse=True)
+def _isolate_library_root(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Point BOOKERY_LIBRARY_ROOT at a per-test tmp dir so tests never touch ~/.library/."""
+    root = tmp_path_factory.mktemp("library_root")
+    monkeypatch.setenv("BOOKERY_LIBRARY_ROOT", str(root))
+    return root
+
+
 @pytest.fixture
 def fixtures_dir() -> Path:
     """Path to the test fixtures directory."""

--- a/tests/e2e/test_import_cli.py
+++ b/tests/e2e/test_import_cli.py
@@ -303,6 +303,61 @@ class TestImportCommand:
         assert "EPUB exists" not in result.output
 
 
+class TestImportCopyByDefaultCli:
+    """E2E tests for copy-by-default import behavior (#63)."""
+
+    def test_cli_import_copies_into_library_root(
+        self, sample_epub: Path, tmp_path: Path, _isolate_library_root: Path,
+    ) -> None:
+        """import (no flags) copies source into library_root."""
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        source = scan_dir / "rose.epub"
+        shutil.copy(sample_epub, source)
+
+        db_path = tmp_path / "test.db"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(scan_dir), "--db", str(db_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert source.exists()  # preserved
+        library_copies = list(_isolate_library_root.rglob("*.epub"))
+        assert len(library_copies) == 1
+
+    def test_cli_import_move_removes_source(
+        self, sample_epub: Path, tmp_path: Path, _isolate_library_root: Path,
+    ) -> None:
+        """--move deletes source after successful copy."""
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        source = scan_dir / "rose.epub"
+        shutil.copy(sample_epub, source)
+
+        db_path = tmp_path / "test.db"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["import", str(scan_dir), "--db", str(db_path), "--move"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not source.exists()
+        assert len(list(_isolate_library_root.rglob("*.epub"))) == 1
+
+    def test_cli_import_rejects_in_place_flag(self, tmp_path: Path) -> None:
+        """Regression guard: --in-place is not an accepted flag."""
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(scan_dir), "--in-place"],
+        )
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
+
+
 class TestImportMetadataDedupCli:
     """E2E tests for metadata-level dedup in CLI output."""
 

--- a/tests/integration/test_genre_workflow.py
+++ b/tests/integration/test_genre_workflow.py
@@ -86,7 +86,10 @@ class TestImportGenreIntegration:
     """Integration test for import with genre auto-assignment."""
 
     def test_import_assigns_genres_from_subjects(
-        self, catalog: LibraryCatalog, sample_epub: Path
+        self,
+        catalog: LibraryCatalog,
+        sample_epub: Path,
+        tmp_path: Path,
     ) -> None:
         """Import pipeline auto-assigns genres from subject metadata."""
         from bookery.core.importer import MatchResult, import_books
@@ -96,7 +99,9 @@ class TestImportGenreIntegration:
             meta.subjects = ["mystery", "detective fiction", "fiction"]
             return MatchResult(metadata=meta)
 
-        result = import_books([sample_epub], catalog, match_fn=match_fn)
+        result = import_books(
+            [sample_epub], catalog, library_root=tmp_path / "lib", match_fn=match_fn
+        )
         assert result.added == 1
 
         # Genres auto-assigned

--- a/tests/integration/test_import_pipeline.py
+++ b/tests/integration/test_import_pipeline.py
@@ -26,12 +26,12 @@ def _make_epub(path: Path, title: str, author: str | None = None) -> Path:
         book.add_author(author)
 
     chapter = epub.EpubHtml(
-        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+        title="Chapter 1",
+        file_name="chap01.xhtml",
+        lang="en",
     )
     chapter.content = (
-        b"<html><body><h1>Chapter 1</h1>"
-        b"<p>Content for " + title.encode() + b".</p>"
-        b"</body></html>"
+        b"<html><body><h1>Chapter 1</h1><p>Content for " + title.encode() + b".</p></body></html>"
     )
     book.add_item(chapter)
     book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
@@ -58,7 +58,7 @@ class TestImportPipelineIntegration:
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
         paths = sorted(books_dir.glob("*.epub"))
-        result = import_books(paths, catalog)
+        result = import_books(paths, catalog, library_root=tmp_path / "lib")
 
         assert result.added == 2
         records = catalog.list_all()
@@ -81,10 +81,10 @@ class TestImportPipelineIntegration:
         catalog = LibraryCatalog(conn)
         paths = sorted(books_dir.glob("*.epub"))
 
-        result1 = import_books(paths, catalog)
+        result1 = import_books(paths, catalog, library_root=tmp_path / "lib")
         assert result1.added == 2
 
-        result2 = import_books(paths, catalog)
+        result2 = import_books(paths, catalog, library_root=tmp_path / "lib")
         assert result2.added == 0
         assert result2.skipped == 2
         conn.close()
@@ -103,10 +103,10 @@ class TestImportPipelineIntegration:
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
 
-        result1 = import_books([dir_a / "book.epub"], catalog)
+        result1 = import_books([dir_a / "book.epub"], catalog, library_root=tmp_path / "lib")
         assert result1.added == 1
 
-        result2 = import_books([dir_b / "book_copy.epub"], catalog)
+        result2 = import_books([dir_b / "book_copy.epub"], catalog, library_root=tmp_path / "lib")
         assert result2.added == 0
         assert result2.skipped == 1
         conn.close()
@@ -122,7 +122,8 @@ class TestFindDuplicate:
 
         # Insert a book with ISBN
         existing = BookMetadata(
-            title="The Name of the Rose", authors=["Umberto Eco"],
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
             isbn="9780151446476",
         )
         existing.source_path = tmp_path / "rose.epub"
@@ -130,7 +131,8 @@ class TestFindDuplicate:
 
         # Search with same ISBN, different format
         candidate = BookMetadata(
-            title="Name of the Rose", authors=["Eco, Umberto"],
+            title="Name of the Rose",
+            authors=["Eco, Umberto"],
             isbn="978-0-15-144647-6",
         )
         result = catalog.find_duplicate(candidate)
@@ -146,14 +148,16 @@ class TestFindDuplicate:
         catalog = LibraryCatalog(conn)
 
         existing = BookMetadata(
-            title="The Name of the Rose", authors=["Umberto Eco"],
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
             isbn="9780151446476",
         )
         existing.source_path = tmp_path / "rose.epub"
         catalog.add_book(existing, file_hash="abc123")
 
         candidate = BookMetadata(
-            title="Whatever", authors=["Whatever"],
+            title="Whatever",
+            authors=["Whatever"],
             isbn="0151446474",
         )
         result = catalog.find_duplicate(candidate)
@@ -168,14 +172,16 @@ class TestFindDuplicate:
         catalog = LibraryCatalog(conn)
 
         existing = BookMetadata(
-            title="The Name of the Rose", authors=["Umberto Eco"],
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
         )
         existing.source_path = tmp_path / "rose.epub"
         catalog.add_book(existing, file_hash="abc123")
 
         # Different article, different author format
         candidate = BookMetadata(
-            title="  The  Name of the  Rose  ", authors=["Eco, Umberto"],
+            title="  The  Name of the  Rose  ",
+            authors=["Eco, Umberto"],
         )
         result = catalog.find_duplicate(candidate)
 
@@ -189,14 +195,16 @@ class TestFindDuplicate:
         catalog = LibraryCatalog(conn)
 
         existing = BookMetadata(
-            title="The Name of the Rose", authors=["Umberto Eco"],
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
             isbn="9780151446476",
         )
         existing.source_path = tmp_path / "rose.epub"
         catalog.add_book(existing, file_hash="abc123")
 
         candidate = BookMetadata(
-            title="The Name of the Rose", authors=["Umberto Eco"],
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
             isbn="978-0-15-144647-6",
         )
         result = catalog.find_duplicate(candidate)
@@ -211,13 +219,15 @@ class TestFindDuplicate:
         catalog = LibraryCatalog(conn)
 
         existing = BookMetadata(
-            title="The Name of the Rose", authors=["Umberto Eco"],
+            title="The Name of the Rose",
+            authors=["Umberto Eco"],
         )
         existing.source_path = tmp_path / "rose.epub"
         catalog.add_book(existing, file_hash="abc123")
 
         candidate = BookMetadata(
-            title="Dune", authors=["Frank Herbert"],
+            title="Dune",
+            authors=["Frank Herbert"],
         )
         result = catalog.find_duplicate(candidate)
 
@@ -230,7 +240,8 @@ class TestFindDuplicate:
         catalog = LibraryCatalog(conn)
 
         candidate = BookMetadata(
-            title="Dune", authors=["Frank Herbert"],
+            title="Dune",
+            authors=["Frank Herbert"],
         )
         result = catalog.find_duplicate(candidate)
 
@@ -247,18 +258,24 @@ class TestImportMetadataDedup:
         catalog = LibraryCatalog(conn)
 
         epub1 = _make_epub_with_isbn(
-            tmp_path / "rose_v1.epub", "The Name of the Rose",
-            "Umberto Eco", "9780151446476", content_marker="edition-1",
+            tmp_path / "rose_v1.epub",
+            "The Name of the Rose",
+            "Umberto Eco",
+            "9780151446476",
+            content_marker="edition-1",
         )
         epub2 = _make_epub_with_isbn(
-            tmp_path / "rose_v2.epub", "Name of the Rose",
-            "Eco, Umberto", "978-0-15-144647-6", content_marker="edition-2",
+            tmp_path / "rose_v2.epub",
+            "Name of the Rose",
+            "Eco, Umberto",
+            "978-0-15-144647-6",
+            content_marker="edition-2",
         )
 
-        result1 = import_books([epub1], catalog)
+        result1 = import_books([epub1], catalog, library_root=tmp_path / "lib")
         assert result1.added == 1
 
-        result2 = import_books([epub2], catalog)
+        result2 = import_books([epub2], catalog, library_root=tmp_path / "lib")
         assert result2.added == 0
         assert result2.skipped == 1
         assert result2.skipped_metadata == 1
@@ -272,18 +289,22 @@ class TestImportMetadataDedup:
         catalog = LibraryCatalog(conn)
 
         epub1 = _make_epub_unique(
-            tmp_path / "rose_v1.epub", "The Name of the Rose",
-            "Umberto Eco", content_marker="version-1",
+            tmp_path / "rose_v1.epub",
+            "The Name of the Rose",
+            "Umberto Eco",
+            content_marker="version-1",
         )
         epub2 = _make_epub_unique(
-            tmp_path / "rose_v2.epub", "The Name of the Rose",
-            "Umberto Eco", content_marker="version-2",
+            tmp_path / "rose_v2.epub",
+            "The Name of the Rose",
+            "Umberto Eco",
+            content_marker="version-2",
         )
 
-        result1 = import_books([epub1], catalog)
+        result1 = import_books([epub1], catalog, library_root=tmp_path / "lib")
         assert result1.added == 1
 
-        result2 = import_books([epub2], catalog)
+        result2 = import_books([epub2], catalog, library_root=tmp_path / "lib")
         assert result2.added == 0
         assert result2.skipped == 1
         assert result2.skipped_metadata == 1
@@ -297,16 +318,22 @@ class TestImportMetadataDedup:
         catalog = LibraryCatalog(conn)
 
         epub1 = _make_epub_unique(
-            tmp_path / "rose_v1.epub", "The Name of the Rose",
-            "Umberto Eco", content_marker="version-1",
+            tmp_path / "rose_v1.epub",
+            "The Name of the Rose",
+            "Umberto Eco",
+            content_marker="version-1",
         )
         epub2 = _make_epub_unique(
-            tmp_path / "rose_v2.epub", "The Name of the Rose",
-            "Umberto Eco", content_marker="version-2",
+            tmp_path / "rose_v2.epub",
+            "The Name of the Rose",
+            "Umberto Eco",
+            content_marker="version-2",
         )
 
-        import_books([epub1], catalog)
-        result = import_books([epub2], catalog, force_duplicates=True)
+        import_books([epub1], catalog, library_root=tmp_path / "lib")
+        result = import_books(
+            [epub2], catalog, library_root=tmp_path / "lib", force_duplicates=True
+        )
 
         assert result.added == 1
         assert result.forced == 1
@@ -317,7 +344,11 @@ class TestImportMetadataDedup:
 
 
 def _make_epub_unique(
-    path: Path, title: str, author: str, *, content_marker: str = "",
+    path: Path,
+    title: str,
+    author: str,
+    *,
+    content_marker: str = "",
 ) -> Path:
     """Create a minimal EPUB with unique content to produce distinct hashes."""
     book = epub.EpubBook()
@@ -327,7 +358,9 @@ def _make_epub_unique(
     book.add_author(author)
 
     chapter = epub.EpubHtml(
-        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+        title="Chapter 1",
+        file_name="chap01.xhtml",
+        lang="en",
     )
     chapter.content = (
         b"<html><body><h1>Chapter 1</h1>"
@@ -345,8 +378,12 @@ def _make_epub_unique(
 
 
 def _make_epub_with_isbn(
-    path: Path, title: str, author: str, isbn: str,
-    *, content_marker: str = "",
+    path: Path,
+    title: str,
+    author: str,
+    isbn: str,
+    *,
+    content_marker: str = "",
 ) -> Path:
     """Create a minimal EPUB with title, author, ISBN, and unique content.
 
@@ -361,7 +398,9 @@ def _make_epub_with_isbn(
     book.add_author(author)
 
     chapter = epub.EpubHtml(
-        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+        title="Chapter 1",
+        file_name="chap01.xhtml",
+        lang="en",
     )
     chapter.content = (
         b"<html><body><h1>Chapter 1</h1>"
@@ -398,7 +437,9 @@ class TestImportConvertIntegration:
 
         # Create another real EPUB that convert_one will "produce"
         converted_epub = _make_epub(
-            tmp_path / "converted.epub", "Converted Book", "Author B",
+            tmp_path / "converted.epub",
+            "Converted Book",
+            "Author B",
         )
         fake_result = ConvertResult(
             source=mobi_path,

--- a/tests/integration/test_inventory_pipeline.py
+++ b/tests/integration/test_inventory_pipeline.py
@@ -47,7 +47,7 @@ class TestDbCrossReference:
         db_path = tmp_path / "test.db"
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
-        import_books(epub_paths, catalog)
+        import_books(epub_paths, catalog, library_root=tmp_path / "lib")
         return catalog
 
     def test_cataloged_book_found(self, tmp_path: Path):

--- a/tests/unit/test_filecopy.py
+++ b/tests/unit/test_filecopy.py
@@ -1,0 +1,61 @@
+# ABOUTME: Unit tests for the copy_file helper in core.filecopy.
+# ABOUTME: Covers content copy, mtime preservation, and PermissionError fallback.
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bookery.core.filecopy import copy_file
+
+
+def test_copy_file_copies_content(tmp_path: Path) -> None:
+    source = tmp_path / "src.txt"
+    source.write_bytes(b"hello world")
+    dest = tmp_path / "dest.txt"
+
+    copy_file(source, dest)
+
+    assert dest.read_bytes() == b"hello world"
+
+
+def test_copy_file_preserves_mtime(tmp_path: Path) -> None:
+    source = tmp_path / "src.txt"
+    source.write_bytes(b"x")
+    import os
+    old_time = 1_500_000_000
+    os.utime(source, (old_time, old_time))
+    dest = tmp_path / "dest.txt"
+
+    copy_file(source, dest)
+
+    assert int(dest.stat().st_mtime) == old_time
+
+
+def test_copy_file_falls_back_on_permission_error(tmp_path: Path) -> None:
+    source = tmp_path / "src.txt"
+    source.write_bytes(b"fallback")
+    dest = tmp_path / "dest.txt"
+
+    original_copyfile = shutil.copyfile
+
+    with (
+        patch("bookery.core.filecopy.shutil.copy2", side_effect=PermissionError("chflags")),
+        patch(
+            "bookery.core.filecopy.shutil.copyfile",
+            side_effect=original_copyfile,
+        ) as mock_copyfile,
+    ):
+        copy_file(source, dest)
+
+    mock_copyfile.assert_called_once()
+    assert dest.read_bytes() == b"fallback"
+
+
+def test_copy_file_raises_on_missing_source(tmp_path: Path) -> None:
+    source = tmp_path / "nope.txt"
+    dest = tmp_path / "dest.txt"
+
+    with pytest.raises(FileNotFoundError):
+        copy_file(source, dest)

--- a/tests/unit/test_import_catalog.py
+++ b/tests/unit/test_import_catalog.py
@@ -1,12 +1,12 @@
-# ABOUTME: Unit tests for the import pipeline (catalog-as-is mode).
-# ABOUTME: Validates file cataloging, dedup, error handling, and result tracking.
+# ABOUTME: Unit tests for the import pipeline (copy-by-default into library_root).
+# ABOUTME: Validates file cataloging, copy/move behavior, dedup, errors, and summaries.
 
 from pathlib import Path
 
 import pytest
 from ebooklib import epub
 
-from bookery.core.importer import import_books
+from bookery.core.importer import MatchResult, import_books
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 
@@ -16,6 +16,14 @@ def catalog(tmp_path: Path) -> LibraryCatalog:
     """Provide a LibraryCatalog backed by a temporary database."""
     conn = open_library(tmp_path / "import_test.db")
     return LibraryCatalog(conn)
+
+
+@pytest.fixture()
+def library_root(tmp_path: Path) -> Path:
+    """Provide a temporary library_root directory."""
+    root = tmp_path / "lib"
+    root.mkdir()
+    return root
 
 
 def _make_epub(path: Path, title: str, author: str | None = None) -> Path:
@@ -49,11 +57,11 @@ class TestImportBooks:
     """Tests for import_books function."""
 
     def test_import_single_file(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """Importing a single EPUB adds one record to the catalog."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book", "Author")
-        result = import_books([epub_path], catalog)
+        result = import_books([epub_path], catalog, library_root=library_root)
 
         assert result.added == 1
         assert result.skipped == 0
@@ -64,27 +72,27 @@ class TestImportBooks:
         assert records[0].metadata.title == "Test Book"
 
     def test_import_directory_of_files(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """Importing multiple EPUBs adds all to the catalog."""
         for i in range(3):
             _make_epub(tmp_path / f"book_{i}.epub", f"Book {i}")
 
         paths = sorted(tmp_path.glob("*.epub"))
-        result = import_books(paths, catalog)
+        result = import_books(paths, catalog, library_root=library_root)
 
         assert result.added == 3
         records = catalog.list_all()
         assert len(records) == 3
 
     def test_import_skips_duplicates(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """Importing the same file twice adds it once and skips the second."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
 
-        result1 = import_books([epub_path], catalog)
-        result2 = import_books([epub_path], catalog)
+        result1 = import_books([epub_path], catalog, library_root=library_root)
+        result2 = import_books([epub_path], catalog, library_root=library_root)
 
         assert result1.added == 1
         assert result2.added == 0
@@ -94,47 +102,36 @@ class TestImportBooks:
         assert len(records) == 1
 
     def test_import_records_source_path(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """source_path in the DB matches the original file location."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
-        import_books([epub_path], catalog)
+        import_books([epub_path], catalog, library_root=library_root)
 
         records = catalog.list_all()
         assert len(records) == 1
         assert records[0].source_path == epub_path
 
     def test_import_stores_file_hash(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """File hash is computed and stored in the catalog."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
-        import_books([epub_path], catalog)
+        import_books([epub_path], catalog, library_root=library_root)
 
         records = catalog.list_all()
         assert len(records) == 1
         assert len(records[0].file_hash) == 64  # SHA-256 hex
 
-    def test_import_no_output_path_for_catalog_only(
-        self, tmp_path: Path, catalog: LibraryCatalog,
-    ) -> None:
-        """Catalog-only import sets output_path to None."""
-        epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
-        import_books([epub_path], catalog)
-
-        records = catalog.list_all()
-        assert len(records) == 1
-        assert records[0].output_path is None
-
     def test_import_handles_corrupt_files(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """Corrupt files are logged as errors; valid files still imported."""
         good = _make_epub(tmp_path / "good.epub", "Good Book")
         bad = tmp_path / "bad.epub"
         bad.write_text("not a valid epub")
 
-        result = import_books([good, bad], catalog)
+        result = import_books([good, bad], catalog, library_root=library_root)
 
         assert result.added == 1
         assert result.errors == 1
@@ -142,7 +139,7 @@ class TestImportBooks:
         assert result.error_details[0][0] == bad
 
     def test_import_returns_result_summary(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
     ) -> None:
         """ImportResult has correct totals for mixed outcomes."""
         epub1 = _make_epub(tmp_path / "a.epub", "Book A")
@@ -151,13 +148,190 @@ class TestImportBooks:
         corrupt.write_text("corrupt")
 
         # First import: 2 added, 1 error
-        result1 = import_books([epub1, epub2, corrupt], catalog)
+        result1 = import_books(
+            [epub1, epub2, corrupt], catalog, library_root=library_root,
+        )
         assert result1.added == 2
         assert result1.errors == 1
         assert result1.skipped == 0
 
         # Second import: 0 added, 2 skipped, 1 error
-        result2 = import_books([epub1, epub2, corrupt], catalog)
+        result2 = import_books(
+            [epub1, epub2, corrupt], catalog, library_root=library_root,
+        )
         assert result2.added == 0
         assert result2.skipped == 2
         assert result2.errors == 1
+
+
+class TestImportCopyByDefault:
+    """Tests for copy-by-default behavior added in #63."""
+
+    def test_import_copies_to_library_root_by_default(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """Import copies source into library_root and records output_path."""
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        epub_path = _make_epub(source_dir / "book.epub", "Test Book", "Alice Adams")
+
+        import_books([epub_path], catalog, library_root=library_root)
+
+        records = catalog.list_all()
+        assert len(records) == 1
+        out = records[0].output_path
+        assert out is not None
+        assert out.exists()
+        assert library_root in out.parents
+
+    def test_import_preserves_source_by_default(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """Source file is preserved when move is False."""
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        epub_path = _make_epub(source_dir / "book.epub", "Test Book", "Alice Adams")
+
+        import_books([epub_path], catalog, library_root=library_root)
+
+        assert epub_path.exists()
+
+    def test_import_move_deletes_source_after_copy(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """With move=True, source is removed after successful catalog."""
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        epub_path = _make_epub(source_dir / "book.epub", "Test Book", "Alice Adams")
+
+        import_books(
+            [epub_path], catalog, library_root=library_root, move=True,
+        )
+
+        assert not epub_path.exists()
+        records = catalog.list_all()
+        assert records[0].output_path is not None
+        assert records[0].output_path.exists()
+
+    def test_import_idempotent_when_source_inside_library_root(
+        self, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """File already inside library_root is cataloged in place, no copy."""
+        author_dir = library_root / "Adams, Alice"
+        author_dir.mkdir()
+        epub_path = _make_epub(author_dir / "Existing.epub", "Existing", "Alice Adams")
+
+        import_books([epub_path], catalog, library_root=library_root)
+
+        records = catalog.list_all()
+        assert records[0].source_path == epub_path
+        assert records[0].output_path == epub_path
+        # File is still there and only once — no duplicate
+        assert len(list(library_root.rglob("*.epub"))) == 1
+
+    def test_import_move_preserves_source_when_idempotent(
+        self, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """--move on an idempotent file must NOT delete it (it's the library copy)."""
+        author_dir = library_root / "Adams, Alice"
+        author_dir.mkdir()
+        epub_path = _make_epub(author_dir / "Existing.epub", "Existing", "Alice Adams")
+
+        import_books(
+            [epub_path], catalog, library_root=library_root, move=True,
+        )
+
+        assert epub_path.exists()
+
+    def test_import_collision_resolved_with_suffix(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """Existing file at target gets _1 suffix via resolve_collision."""
+        # Pre-populate library with a file that would collide on target path
+        author_dir = library_root / "Adams, Alice"
+        author_dir.mkdir()
+        existing = _make_epub(author_dir / "Test Book.epub", "Occupier", "Alice Adams")
+        assert existing.exists()
+
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        new_epub = _make_epub(source_dir / "incoming.epub", "Test Book", "Alice Adams")
+
+        import_books([new_epub], catalog, library_root=library_root)
+
+        # Occupier still there, new copy written with suffix
+        assert existing.exists()
+        epubs = sorted(library_root.rglob("*.epub"))
+        assert len(epubs) == 2
+
+    def test_import_match_path_not_double_copied(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+    ) -> None:
+        """When match_fn returns an output_path, import_books does not recopy."""
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        epub_path = _make_epub(source_dir / "book.epub", "Test Book", "Alice Adams")
+
+        # Simulate what the match pipeline would produce: a copy already written
+        match_copy = library_root / "Adams, Alice" / "Matched.epub"
+        match_copy.parent.mkdir(parents=True, exist_ok=True)
+        match_copy.write_bytes(epub_path.read_bytes())
+
+        def match_fn(metadata, path):
+            return MatchResult(metadata=metadata, output_path=match_copy)
+
+        import_books(
+            [epub_path], catalog, library_root=library_root, match_fn=match_fn,
+        )
+
+        records = catalog.list_all()
+        assert records[0].output_path == match_copy
+        # Only the one copy exists in library (no additional build_output_path copy)
+        assert len(list(library_root.rglob("*.epub"))) == 1
+
+    def test_import_copy_failure_records_error(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OSError during copy is recorded as an error, does not crash."""
+        from bookery.core import importer
+
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        epub_path = _make_epub(source_dir / "book.epub", "Test Book", "Alice Adams")
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(importer, "copy_file", boom)
+
+        result = import_books([epub_path], catalog, library_root=library_root)
+
+        assert result.errors == 1
+        assert result.added == 0
+        assert catalog.list_all() == []
+
+    def test_import_move_failure_warns_but_succeeds(
+        self, tmp_path: Path, catalog: LibraryCatalog, library_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If unlink after copy fails, book is still cataloged."""
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        epub_path = _make_epub(source_dir / "book.epub", "Test Book", "Alice Adams")
+
+        original_unlink = Path.unlink
+
+        def failing_unlink(self, *args, **kwargs):
+            if self == epub_path:
+                raise OSError("read-only fs")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        result = import_books(
+            [epub_path], catalog, library_root=library_root, move=True,
+        )
+
+        assert result.added == 1
+        assert result.errors == 0

--- a/tests/unit/test_import_genre.py
+++ b/tests/unit/test_import_genre.py
@@ -28,12 +28,12 @@ def _make_epub(path: Path, title: str, *, author: str | None = None) -> Path:
         book.add_author(author)
 
     chapter = epub.EpubHtml(
-        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+        title="Chapter 1",
+        file_name="chap01.xhtml",
+        lang="en",
     )
     chapter.content = (
-        b"<html><body><h1>Chapter 1</h1>"
-        b"<p>Content for " + title.encode() + b".</p>"
-        b"</body></html>"
+        b"<html><body><h1>Chapter 1</h1><p>Content for " + title.encode() + b".</p></body></html>"
     )
     book.add_item(chapter)
     book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
@@ -61,7 +61,9 @@ class TestImportWithGenres:
             meta.subjects = ["fiction", "mystery", "detective stories"]
             return MatchResult(metadata=meta)
 
-        result = import_books([epub_path], catalog, match_fn=match_fn)
+        result = import_books(
+            [epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn
+        )
         assert result.added == 1
 
         # Check genres were assigned
@@ -80,7 +82,7 @@ class TestImportWithGenres:
         """Import without subjects assigns no genres."""
         epub_path = _make_epub(tmp_path / "plain.epub", "Plain Book")
 
-        result = import_books([epub_path], catalog)
+        result = import_books([epub_path], catalog, library_root=tmp_path / "lib")
         assert result.added == 1
 
         genres = catalog.get_genres_for_book(1)
@@ -99,7 +101,9 @@ class TestImportWithGenres:
             meta.subjects = ["xyzzy", "basket weaving"]
             return MatchResult(metadata=meta)
 
-        result = import_books([epub_path], catalog, match_fn=match_fn)
+        result = import_books(
+            [epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn
+        )
         assert result.added == 1
 
         # Subjects stored

--- a/tests/unit/test_import_match_mode.py
+++ b/tests/unit/test_import_match_mode.py
@@ -30,12 +30,12 @@ def _make_epub(path: Path, title: str, author: str | None = None) -> Path:
         book.add_author(author)
 
     chapter = epub.EpubHtml(
-        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+        title="Chapter 1",
+        file_name="chap01.xhtml",
+        lang="en",
     )
     chapter.content = (
-        b"<html><body><h1>Chapter 1</h1>"
-        b"<p>Content for " + title.encode() + b".</p>"
-        b"</body></html>"
+        b"<html><body><h1>Chapter 1</h1><p>Content for " + title.encode() + b".</p></body></html>"
     )
     book.add_item(chapter)
     book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
@@ -51,35 +51,43 @@ class TestImportMatchMode:
     """Tests for import_books with match_fn callback."""
 
     def test_match_fn_is_called(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self,
+        tmp_path: Path,
+        catalog: LibraryCatalog,
     ) -> None:
         """match_fn is invoked for each non-duplicate file."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
 
-        match_fn = MagicMock(return_value=MatchResult(
-            metadata=BookMetadata(title="Matched Title", authors=["Author"]),
-            output_path=Path("/output/matched.epub"),
-        ))
+        match_fn = MagicMock(
+            return_value=MatchResult(
+                metadata=BookMetadata(title="Matched Title", authors=["Author"]),
+                output_path=Path("/output/matched.epub"),
+            )
+        )
 
-        import_books([epub_path], catalog, match_fn=match_fn)
+        import_books([epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn)
         match_fn.assert_called_once()
 
     def test_match_fn_result_is_cataloged(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self,
+        tmp_path: Path,
+        catalog: LibraryCatalog,
     ) -> None:
         """Matched metadata and output_path are stored in the catalog."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
 
-        match_fn = MagicMock(return_value=MatchResult(
-            metadata=BookMetadata(
-                title="Better Title",
-                authors=["Correct Author"],
-                isbn="9780000000000",
-            ),
-            output_path=Path("/output/better.epub"),
-        ))
+        match_fn = MagicMock(
+            return_value=MatchResult(
+                metadata=BookMetadata(
+                    title="Better Title",
+                    authors=["Correct Author"],
+                    isbn="9780000000000",
+                ),
+                output_path=Path("/output/better.epub"),
+            )
+        )
 
-        import_books([epub_path], catalog, match_fn=match_fn)
+        import_books([epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn)
 
         records = catalog.list_all()
         assert len(records) == 1
@@ -88,50 +96,65 @@ class TestImportMatchMode:
         assert records[0].output_path == Path("/output/better.epub")
 
     def test_match_fn_none_catalogs_original(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self,
+        tmp_path: Path,
+        catalog: LibraryCatalog,
     ) -> None:
         """When match_fn returns None (user skipped), original metadata is cataloged."""
         epub_path = _make_epub(tmp_path / "book.epub", "Original Title")
 
         match_fn = MagicMock(return_value=None)
 
-        import_books([epub_path], catalog, match_fn=match_fn)
+        import_books([epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn)
 
         records = catalog.list_all()
         assert len(records) == 1
         assert records[0].metadata.title == "Original Title"
-        assert records[0].output_path is None
+        # match_fn returned None, so import falls through to copy-to-library
+        assert records[0].output_path is not None
 
     def test_match_fn_not_called_for_duplicates(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self,
+        tmp_path: Path,
+        catalog: LibraryCatalog,
     ) -> None:
         """Duplicate files are skipped before match_fn is invoked."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
 
-        match_fn = MagicMock(return_value=MatchResult(
-            metadata=BookMetadata(title="Matched"),
-            output_path=None,
-        ))
+        match_fn = MagicMock(
+            return_value=MatchResult(
+                metadata=BookMetadata(title="Matched"),
+                output_path=None,
+            )
+        )
 
-        import_books([epub_path], catalog, match_fn=match_fn)
-        import_books([epub_path], catalog, match_fn=match_fn)
+        import_books([epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn)
+        import_books([epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn)
 
         # Only called once — second import is skipped
         assert match_fn.call_count == 1
 
     def test_dedup_still_works_in_match_mode(
-        self, tmp_path: Path, catalog: LibraryCatalog,
+        self,
+        tmp_path: Path,
+        catalog: LibraryCatalog,
     ) -> None:
         """Duplicate detection works the same in match mode."""
         epub_path = _make_epub(tmp_path / "book.epub", "Test Book")
 
-        match_fn = MagicMock(return_value=MatchResult(
-            metadata=BookMetadata(title="Matched"),
-            output_path=None,
-        ))
+        match_fn = MagicMock(
+            return_value=MatchResult(
+                metadata=BookMetadata(title="Matched"),
+                output_path=None,
+            )
+        )
 
-        result1 = import_books([epub_path], catalog, match_fn=match_fn)
-        result2 = import_books([epub_path], catalog, match_fn=match_fn)
+        result1 = import_books(
+            [epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn
+        )
+        result2 = import_books(
+            [epub_path], catalog, library_root=tmp_path / "lib", match_fn=match_fn
+        )
 
         assert result1.added == 1
         assert result2.skipped == 1


### PR DESCRIPTION
## Summary

- `bookery import` now copies each source into `library_root` by default instead of cataloging in place.
- New `--move` flag deletes the source after a successful catalog insert (idempotent files — already inside `library_root` — are never deleted).
- `--in-place` was **not** added (per decision to align with library-manager identity).

## Motivation

Previously `source_path` pointed wherever the file lived (Calibre tree, Downloads, network mount). Only `--match` produced a library copy, so 609 / 613 rows were location-dependent. The recent migration fixed history; this PR closes the root cause so every import lands in the library.

## Changes

- **`src/bookery/core/filecopy.py` (new)**: extracted `copy_file()` (macOS-tolerant copy) from `pipeline.py` so both the match pipeline and the import path can share it.
- **`src/bookery/core/importer.py`**: `import_books` now takes a required `library_root` kwarg and an optional `move` flag. Behavior per file:
  1. If `match_fn` produced an `output_path`, use it (pipeline already wrote a copy).
  2. Else if the source resolves inside `library_root`, catalog in place (idempotent).
  3. Else build `library_root/Author/Title.epub` (with collision suffix) and copy.
  On `OSError` during copy: record error, continue. On `OSError` during post-catalog `unlink`: emit a `move_failed` progress warning, keep the catalog row.
- **`src/bookery/cli/commands/import_cmd.py`**: threads `library_root` into `import_books`, adds `--move`, renders `move_failed` status.
- **`tests/conftest.py`**: new autouse fixture sets `BOOKERY_LIBRARY_ROOT` to a tmp dir so tests never touch `~/.library/`.
- **Tests**: new coverage for copy-by-default, move, idempotency, collision, match-path no-recopy, copy-failure, and move-failure; existing import tests threaded with `library_root=`.
- **`AGENTS.md`, `README.md`**: non-destructive principle refined to cover contents (not location); import examples updated.

## Breaking change

Default behavior of `import` reverses: files are now copied into `~/.library/` unless they are already inside it. Users who relied on in-place cataloging must add source handling explicitly (no flag preserves the old default; `--move` moves them; `--match` is unchanged).

## Testing

- [x] 916 unit + integration + e2e tests pass
- [x] `uv run ruff check src/ tests/` clean
- [x] Pre-commit pyright clean on staged files
- [x] New regression test asserts `--in-place` is rejected

## Related Issues

Closes #63. Unblocks #62 (`bookery add`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)