### PR TITLE
Add #62: bookery add command for one-shot single-file import

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "bookery"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- python
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -6,6 +6,7 @@ import logging
 import click
 
 from bookery.cli.commands import (
+    add_cmd,
     convert_cmd,
     folder_cmd,
     genre_cmd,
@@ -40,6 +41,7 @@ def cli(verbose: int) -> None:
     )
 
 
+cli.add_command(add_cmd.add_command)
 cli.add_command(convert_cmd.convert)
 cli.add_command(folder_cmd.folder)
 cli.add_command(genre_cmd.genre)

--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -1,0 +1,123 @@
+# ABOUTME: Shared helpers for building match and progress callbacks.
+# ABOUTME: Used by both `import` and `add` commands so behavior stays in one place.
+
+from pathlib import Path
+
+from rich.console import Console
+
+from bookery.core.importer import ImportResult, MatchFn, MatchResult, ProgressFn
+from bookery.metadata.types import BookMetadata
+
+
+def build_match_fn(
+    console: Console,
+    output_dir: Path,
+    quiet: bool,
+    threshold: float,
+) -> MatchFn:
+    """Build a match callback that runs the full metadata pipeline.
+
+    Imports match-pipeline dependencies lazily so callers don't pay for
+    them when matching is not used.
+    """
+    from bookery.cli.review import ReviewSession
+    from bookery.core.pipeline import match_one
+    from bookery.metadata.http import BookeryHttpClient
+    from bookery.metadata.openlibrary import OpenLibraryProvider
+
+    http_client = BookeryHttpClient()
+    provider = OpenLibraryProvider(http_client=http_client)
+    review = ReviewSession(
+        console=console,
+        quiet=quiet,
+        threshold=threshold,
+        lookup_fn=provider.lookup_by_url,
+    )
+
+    def match_fn(
+        _extracted: BookMetadata, epub_path: Path,
+    ) -> MatchResult | None:
+        del _extracted  # signature required by MatchFn protocol
+        result = match_one(epub_path, provider, review, output_dir)
+
+        if not quiet and result.normalization and result.normalization.was_modified:
+            console.print(
+                f"  [dim]Normalized:[/dim] {result.normalization.normalized.title}"
+            )
+
+        if result.status == "matched" and result.metadata is not None:
+            if not quiet:
+                console.print(
+                    f"  [green]Written:[/green] {result.output_path}"
+                )
+            return MatchResult(
+                metadata=result.metadata, output_path=result.output_path,
+            )
+
+        if result.status == "error" and not quiet:
+            console.print(
+                f"  [red]Write failed:[/red] {result.error}"
+            )
+
+        return None
+
+    return match_fn
+
+
+def build_progress_fn(console: Console) -> ProgressFn:
+    """Build a per-file progress callback for Rich console output."""
+
+    def on_progress(
+        path: Path,
+        title: str,
+        author: str,
+        status: str,
+        reason: str | None,
+        existing_id: int | None,
+    ) -> None:
+        label = f"{title} — {author}" if title and author else path.name
+        if status == "added":
+            console.print(f"  [green]✓[/green] {label}")
+        elif status == "skipped" and reason:
+            reason_label = reason.replace("_", "+")
+            id_suffix = f", #{existing_id}" if existing_id else ""
+            console.print(
+                f"  [yellow]⊘[/yellow] {label} — "
+                f"[dim]skipped (duplicate: {reason_label}{id_suffix})[/dim]"
+            )
+        elif status == "forced" and reason:
+            reason_label = reason.replace("_", "+")
+            id_suffix = f", #{existing_id}" if existing_id else ""
+            console.print(
+                f"  [yellow]⚠[/yellow] {label} — "
+                f"[dim]imported (duplicate: {reason_label}{id_suffix})[/dim]"
+            )
+        elif status == "error":
+            console.print(f"  [red]✗[/red] {path.name} — [red]{reason}[/red]")
+        elif status == "move_failed":
+            console.print(
+                f"  [yellow]⚠[/yellow] {path.name} — "
+                f"[dim]cataloged but source not removed: {reason}[/dim]"
+            )
+
+    return on_progress
+
+
+def format_skip_breakdown(result: ImportResult) -> str:
+    """Format a skip count with breakdown by reason."""
+    if result.skipped == 0:
+        return ""
+
+    parts = []
+    if result.skipped_hash:
+        parts.append(f"{result.skipped_hash} hash")
+    if result.skipped_metadata:
+        reason_counts: dict[str, int] = {}
+        for detail in result.skip_details:
+            if detail.reason in ("isbn", "title_author"):
+                label = detail.reason.replace("_", "+")
+                reason_counts[label] = reason_counts.get(label, 0) + 1
+        parts.extend(f"{count} {reason}" for reason, count in reason_counts.items())
+
+    breakdown = f" ({', '.join(parts)})" if parts else ""
+    return f"{result.skipped} skipped{breakdown}"

--- a/src/bookery/cli/commands/add_cmd.py
+++ b/src/bookery/cli/commands/add_cmd.py
@@ -1,0 +1,141 @@
+# ABOUTME: The `bookery add` command for one-shot single-file EPUB import.
+# ABOUTME: Thin wrapper over import_books that copies a file into the library and catalogs it.
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from bookery.cli._match_helpers import (
+    build_match_fn,
+    build_progress_fn,
+    format_skip_breakdown,
+)
+from bookery.cli.options import db_option
+from bookery.core.config import get_library_root
+from bookery.core.importer import MatchFn, import_books
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import DEFAULT_DB_PATH, open_library
+
+console = Console()
+
+
+def _is_inside(path: Path, root: Path) -> bool:
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+@click.command("add")
+@click.argument(
+    "file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@db_option
+@click.option(
+    "--move",
+    "do_move",
+    is_flag=True,
+    default=False,
+    help="Delete source file after successful catalog (library copy is preserved).",
+)
+@click.option(
+    "--no-match",
+    "no_match",
+    is_flag=True,
+    default=False,
+    help="Skip the metadata matching pipeline.",
+)
+@click.option(
+    "-q", "--quiet",
+    is_flag=True,
+    default=False,
+    help="Auto-accept high-confidence matches without prompting.",
+)
+@click.option(
+    "-t", "--threshold",
+    type=click.FloatRange(0.0, 1.0),
+    default=0.8,
+    help="Confidence cutoff for auto-accept (0.0-1.0, default 0.8).",
+)
+def add_command(
+    file: Path,
+    db_path: Path | None,
+    do_move: bool,
+    no_match: bool,
+    quiet: bool,
+    threshold: float,
+) -> None:
+    """Add a single EPUB to the library in one step.
+
+    Copies FILE into the configured library_root, runs the match
+    pipeline (unless --no-match), and catalogs the book. The source
+    file is preserved by default; use --move to delete it after a
+    successful catalog insert.
+    """
+    if file.suffix.lower() != ".epub":
+        raise click.BadParameter(
+            f"{file.name} is not an EPUB file.", param_hint="FILE",
+        )
+
+    # --no-match with --quiet / non-default --threshold is a flag conflict
+    if no_match and (quiet or threshold != 0.8):
+        console.print(
+            "[yellow]warning:[/yellow] --quiet/--threshold ignored with --no-match",
+        )
+
+    library_root = get_library_root()
+    # TODO: wrap conn in try-finally or context manager to prevent leak on exception
+    conn = open_library(db_path or DEFAULT_DB_PATH)
+    catalog = LibraryCatalog(conn)
+
+    match_fn: MatchFn | None = None
+    if not no_match:
+        match_fn = build_match_fn(
+            console=console,
+            output_dir=library_root,
+            quiet=quiet,
+            threshold=threshold,
+        )
+
+    idempotent = _is_inside(file, library_root)
+    if not idempotent:
+        console.print(
+            f"Copying to [bold]{library_root}[/bold]…",
+        )
+
+    on_progress = build_progress_fn(console)
+
+    result = import_books(
+        [file], catalog,
+        library_root=library_root,
+        match_fn=match_fn,
+        move=do_move,
+        on_progress=on_progress,
+    )
+
+    # Summary
+    console.print()
+    parts = []
+    if result.added:
+        parts.append(f"[green]{result.added} added[/green]")
+    if result.skipped:
+        parts.append(f"[yellow]{format_skip_breakdown(result)}[/yellow]")
+    if result.errors:
+        parts.append(f"[red]{result.errors} error(s)[/red]")
+
+    if parts:
+        console.print(", ".join(parts))
+
+    if result.error_details:
+        console.print(
+            f"\n[yellow]{result.errors} file(s) could not be read:[/yellow]"
+        )
+        for path, msg in result.error_details:
+            console.print(f"  [dim]{path.name}:[/dim] {msg}")
+
+    conn.close()
+
+    if result.errors:
+        raise click.exceptions.Exit(1)

--- a/src/bookery/cli/commands/import_cmd.py
+++ b/src/bookery/cli/commands/import_cmd.py
@@ -6,13 +6,17 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from bookery.cli._match_helpers import (
+    build_match_fn,
+    build_progress_fn,
+    format_skip_breakdown,
+)
 from bookery.cli.options import db_option
 from bookery.core.config import get_library_root
 from bookery.core.dedup import filter_redundant_mobis
-from bookery.core.importer import ImportResult, MatchFn, MatchResult, ProgressFn, import_books
+from bookery.core.importer import MatchFn, import_books
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import DEFAULT_DB_PATH, open_library
-from bookery.metadata.types import BookMetadata
 
 console = Console()  # TODO: move Console() inside command for testability
 
@@ -83,116 +87,6 @@ def _convert_mobis(
     )
     return epub_files
 
-
-def _build_match_fn(
-    output_dir: Path, quiet: bool, threshold: float,
-) -> MatchFn:
-    """Build a match callback that runs the full metadata pipeline.
-
-    Imports match-pipeline dependencies lazily so the import command
-    doesn't pay for them when --match is not used.
-    """
-    from bookery.cli.review import ReviewSession
-    from bookery.core.pipeline import match_one
-    from bookery.metadata.http import BookeryHttpClient
-    from bookery.metadata.openlibrary import OpenLibraryProvider
-
-    http_client = BookeryHttpClient()
-    provider = OpenLibraryProvider(http_client=http_client)
-    review = ReviewSession(
-        console=console,
-        quiet=quiet,
-        threshold=threshold,
-        lookup_fn=provider.lookup_by_url,
-    )
-
-    def match_fn(
-        extracted: BookMetadata, epub_path: Path,
-    ) -> MatchResult | None:
-        result = match_one(epub_path, provider, review, output_dir)
-
-        if not quiet and result.normalization and result.normalization.was_modified:
-            console.print(
-                f"  [dim]Normalized:[/dim] {result.normalization.normalized.title}"
-            )
-
-        if result.status == "matched" and result.metadata is not None:
-            if not quiet:
-                console.print(
-                    f"  [green]Written:[/green] {result.output_path}"
-                )
-            return MatchResult(
-                metadata=result.metadata, output_path=result.output_path,
-            )
-
-        if result.status == "error" and not quiet:
-            console.print(
-                f"  [red]Write failed:[/red] {result.error}"
-            )
-
-        return None
-
-    return match_fn
-
-
-def _format_skip_breakdown(result: ImportResult) -> str:
-    """Format a skip count with breakdown by reason."""
-    if result.skipped == 0:
-        return ""
-
-    parts = []
-    if result.skipped_hash:
-        parts.append(f"{result.skipped_hash} hash")
-    if result.skipped_metadata:
-        # Break metadata skips down by specific reason
-        reason_counts: dict[str, int] = {}
-        for detail in result.skip_details:
-            if detail.reason in ("isbn", "title_author"):
-                label = detail.reason.replace("_", "+")
-                reason_counts[label] = reason_counts.get(label, 0) + 1
-        parts.extend(f"{count} {reason}" for reason, count in reason_counts.items())
-
-    breakdown = f" ({', '.join(parts)})" if parts else ""
-    return f"{result.skipped} skipped{breakdown}"
-
-
-def _build_progress_fn() -> ProgressFn:
-    """Build a per-file progress callback for Rich console output."""
-
-    def on_progress(
-        path: Path,
-        title: str,
-        author: str,
-        status: str,
-        reason: str | None,
-        existing_id: int | None,
-    ) -> None:
-        label = f"{title} — {author}" if title and author else path.name
-        if status == "added":
-            console.print(f"  [green]✓[/green] {label}")
-        elif status == "skipped" and reason:
-            reason_label = reason.replace("_", "+")
-            id_suffix = f", #{existing_id}" if existing_id else ""
-            console.print(
-                f"  [yellow]⊘[/yellow] {label} — "
-                f"[dim]skipped (duplicate: {reason_label}{id_suffix})[/dim]"
-            )
-        elif status == "forced" and reason:
-            reason_label = reason.replace("_", "+")
-            id_suffix = f", #{existing_id}" if existing_id else ""
-            console.print(
-                f"  [yellow]⚠[/yellow] {label} — "
-                f"[dim]imported (duplicate: {reason_label}{id_suffix})[/dim]"
-            )
-        elif status == "error":
-            console.print(f"  [red]✗[/red] {path.name} — [red]{reason}[/red]")
-        elif status == "move_failed":
-            console.print(
-                f"  [yellow]⚠[/yellow] {path.name} — "
-                f"[dim]cataloged but source not removed: {reason}[/dim]"
-            )
-
-    return on_progress
 
 
 
@@ -293,13 +187,14 @@ def import_command(
     library_root = output_dir or get_library_root()
     match_fn: MatchFn | None = None
     if do_match:
-        match_fn = _build_match_fn(
+        match_fn = build_match_fn(
+            console=console,
             output_dir=library_root,
             quiet=quiet,
             threshold=threshold,
         )
 
-    on_progress = _build_progress_fn()
+    on_progress = build_progress_fn(console)
 
     result = import_books(
         epub_files, catalog,
@@ -316,7 +211,7 @@ def import_command(
     if result.added:
         parts.append(f"[green]{result.added} added[/green]")
     if result.skipped:
-        parts.append(f"[yellow]{_format_skip_breakdown(result)}[/yellow]")
+        parts.append(f"[yellow]{format_skip_breakdown(result)}[/yellow]")
     if result.forced:
         parts.append(f"[yellow]{result.forced} forced[/yellow]")
     if result.errors:

--- a/tests/integration/test_add_integration.py
+++ b/tests/integration/test_add_integration.py
@@ -1,0 +1,80 @@
+# ABOUTME: Integration tests for the `bookery add` command end-to-end.
+# ABOUTME: Exercises full copy → catalog flow with real DB and file operations.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+from ebooklib import epub
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+
+
+def _make_epub(path: Path, title: str, author: str = "Integration Author") -> Path:
+    book = epub.EpubBook()
+    book.set_identifier(f"id-{title}")
+    book.set_title(title)
+    book.set_language("en")
+    book.add_author(author)
+
+    chapter = epub.EpubHtml(
+        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+    )
+    chapter.content = (
+        b"<html><body><h1>Chapter 1</h1><p>" + title.encode() + b".</p></body></html>"
+    )
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+    epub.write_epub(str(path), book)
+    return path
+
+
+class TestAddIntegration:
+    def test_add_full_flow_copies_and_catalogs(
+        self, tmp_path: Path, _isolate_library_root: Path,
+    ) -> None:
+        library_root = _isolate_library_root
+        db_path = tmp_path / "catalog.db"
+        source = _make_epub(tmp_path / "source.epub", "Perdido Street Station", "China Mieville")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+
+        assert result.exit_code == 0, result.output
+        # Source preserved
+        assert source.exists()
+        # Library contains a copy somewhere under library_root
+        copies = list(library_root.rglob("*.epub"))
+        assert len(copies) == 1
+        assert copies[0] != source
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        records = catalog.list_all()
+        assert len(records) == 1
+        assert records[0].metadata.title == "Perdido Street Station"
+        conn.close()
+
+    def test_add_move_with_real_epub(
+        self, tmp_path: Path, _isolate_library_root: Path,
+    ) -> None:
+        library_root = _isolate_library_root
+        db_path = tmp_path / "catalog.db"
+        source = _make_epub(tmp_path / "source.epub", "The Scar", "China Mieville")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["add", str(source), "--db", str(db_path), "--no-match", "--move"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not source.exists(), "source should be deleted with --move"
+        copies = list(library_root.rglob("*.epub"))
+        assert len(copies) == 1

--- a/tests/unit/test_add_command.py
+++ b/tests/unit/test_add_command.py
@@ -1,0 +1,204 @@
+# ABOUTME: Unit tests for the `bookery add` single-file import command.
+# ABOUTME: Validates copy-by-default, --move, --no-match, and idempotency behavior.
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from ebooklib import epub
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+
+
+def _make_epub(path: Path, title: str, author: str = "Some Author") -> Path:
+    book = epub.EpubBook()
+    book.set_identifier(f"id-{title}")
+    book.set_title(title)
+    book.set_language("en")
+    book.add_author(author)
+
+    chapter = epub.EpubHtml(
+        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+    )
+    chapter.content = (
+        b"<html><body><h1>Chapter 1</h1><p>" + title.encode() + b".</p></body></html>"
+    )
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+    epub.write_epub(str(path), book)
+    return path
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "catalog.db"
+
+
+@pytest.fixture()
+def library_root(_isolate_library_root: Path) -> Path:
+    return _isolate_library_root
+
+
+class TestAddCommand:
+    def test_add_single_file_copies_to_library(
+        self, tmp_path: Path, db_path: Path, library_root: Path,
+    ) -> None:
+        source = _make_epub(tmp_path / "book.epub", "Foundation", "Isaac Asimov")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+
+        assert result.exit_code == 0, result.output
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        records = catalog.list_all()
+        assert len(records) == 1
+        output_path = records[0].output_path
+        assert output_path is not None
+        assert Path(output_path).is_absolute() or (library_root / output_path).exists()
+        conn.close()
+
+    def test_add_source_preserved_by_default(
+        self, tmp_path: Path, db_path: Path,
+    ) -> None:
+        source = _make_epub(tmp_path / "book.epub", "Dune", "Frank Herbert")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert source.exists(), "source should not be deleted by default"
+
+    def test_add_move_deletes_source(
+        self, tmp_path: Path, db_path: Path,
+    ) -> None:
+        source = _make_epub(tmp_path / "book.epub", "Neuromancer", "William Gibson")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["add", str(source), "--db", str(db_path), "--no-match", "--move"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not source.exists(), "source should be deleted with --move"
+
+    def test_add_move_preserves_source_when_idempotent(
+        self, db_path: Path, library_root: Path,
+    ) -> None:
+        library_root.mkdir(parents=True, exist_ok=True)
+        source = _make_epub(library_root / "book.epub", "Hyperion", "Dan Simmons")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["add", str(source), "--db", str(db_path), "--no-match", "--move"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert source.exists(), "source inside library_root must never be unlinked"
+
+    def test_add_rejects_non_epub(
+        self, tmp_path: Path, db_path: Path,
+    ) -> None:
+        bad = tmp_path / "notabook.txt"
+        bad.write_text("hello")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["add", str(bad), "--db", str(db_path)])
+
+        assert result.exit_code != 0
+        assert "epub" in result.output.lower() or "not" in result.output.lower()
+
+    def test_add_duplicate_hash_reports_existing(
+        self, tmp_path: Path, db_path: Path,
+    ) -> None:
+        source = _make_epub(tmp_path / "book.epub", "1984", "George Orwell")
+
+        runner = CliRunner()
+        r1 = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+        assert r1.exit_code == 0, r1.output
+
+        # Re-add same file
+        r2 = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+        assert r2.exit_code == 0, r2.output
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        assert len(catalog.list_all()) == 1
+        conn.close()
+
+    def test_add_idempotent_inside_library(
+        self, db_path: Path, library_root: Path,
+    ) -> None:
+        library_root.mkdir(parents=True, exist_ok=True)
+        author_dir = library_root / "Gibson, William"
+        author_dir.mkdir()
+        source = _make_epub(author_dir / "inside.epub", "Count Zero", "William Gibson")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert source.exists()
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        records = catalog.list_all()
+        assert len(records) == 1
+        # Output path should point at the existing location (no copy made)
+        op = records[0].output_path
+        assert op is not None
+        assert Path(op) == source or (library_root / op) == source
+        conn.close()
+
+    def test_add_no_match_skips_pipeline(
+        self, tmp_path: Path, db_path: Path,
+    ) -> None:
+        source = _make_epub(tmp_path / "book.epub", "Solaris", "Stanislaw Lem")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["add", str(source), "--db", str(db_path), "--no-match"],
+        )
+
+        assert result.exit_code == 0, result.output
+        # No network / match activity should be required; record has extracted title
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        records = catalog.list_all()
+        assert len(records) == 1
+        assert records[0].metadata.title == "Solaris"
+        conn.close()
+
+    def test_add_quiet_with_no_match_warns(
+        self, tmp_path: Path, db_path: Path,
+    ) -> None:
+        source = _make_epub(tmp_path / "book.epub", "Roadside Picnic", "Strugatsky")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add", str(source),
+                "--db", str(db_path),
+                "--no-match", "--quiet",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "warn" in result.output.lower() or "ignor" in result.output.lower()


### PR DESCRIPTION
## Summary
- New `bookery add FILE` command: copy → match → catalog in one step
- Copy-by-default (source preserved); `--move` deletes source post-commit
- Idempotent when FILE is already inside `library_root` (no copy, source never unlinked)
- Refactor: shared match/progress helpers extracted to `cli/_match_helpers.py`

## Changes
- **`cli/commands/add_cmd.py`** (new): thin wrapper over `import_books` with idempotency check and flag-conflict warning
- **`cli/_match_helpers.py`** (new): `build_match_fn`, `build_progress_fn`, `format_skip_breakdown` shared by `import` and `add`
- **`cli/commands/import_cmd.py`**: uses the shared helpers (no behavior change)
- **`cli/__init__.py`**: registers `add` command
- **Tests**: 9 unit tests + 2 integration tests covering copy, move, idempotency, duplicates, non-EPUB rejection, `--no-match`, flag conflicts

## Testing
- [x] 927 tests pass (`uv run pytest`)
- [x] Ruff lint clean
- [x] Pyright clean
- [x] Pre-commit hooks pass
- [ ] Manual smoke: `bookery add ~/Downloads/foo.epub`

## Related Issues
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)