### PR TITLE
Add #68: bookery sync kobo — convert library EPUBs to kepub on device transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,13 @@ bookery info 42
 | `sync kobo --dry-run` | Show what would be copied without touching the device |
 
 Requires the [`kepubify`](https://pgaskin.net/kepubify/) binary on `PATH`
-(`brew install kepubify` on macOS). A SQLite cache at
-`{data_dir}/kepub_cache.db` keyed on the source EPUB hash plus the
-`kepubify` version makes re-syncs effectively free when nothing has
+(`brew install kepubify` on macOS). Files are written to
+`<kobo>/Bookery/Author/Title/Title.kepub.epub` — the dedicated `Bookery/`
+subdirectory keeps synced content visibly separate from Calibre
+sideloads, Kobo store purchases, and library borrows. Sync is currently
+**additive**: existing files on the device are never deleted. A SQLite
+cache at `{data_dir}/kepub_cache.db` keyed on the source EPUB hash plus
+the `kepubify` version makes re-syncs effectively free when nothing has
 changed.
 
 ### The `match` workflow

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 - **EPUB metadata extraction** — reads title, author, ISBN, language, publisher, description, cover, and identifiers from any EPUB
 - **MOBI-to-EPUB conversion** — converts MOBI/KF8 files to EPUB, preserving metadata, images, cover art, and chapter structure (via NCX TOC)
-- **PDF-to-EPUB conversion** — `bookery add` and `bookery import` detect text-based PDFs, extract their structure with pdfplumber + a local LLM (LM Studio), and produce a reflowable EPUB plus a Kobo `.kepub.epub` variant. Scanned PDFs are refused (OCR not yet supported).
+- **PDF-to-EPUB conversion** — `bookery add` and `bookery import` detect text-based PDFs, extract their structure with pdfplumber + a local LLM (LM Studio), and produce a reflowable EPUB. Scanned PDFs are refused (OCR not yet supported).
+- **Kobo sync** — `bookery sync kobo` walks the catalog, converts each EPUB to `.kepub.epub` via `kepubify`, and copies the result to a mounted Kobo. The library itself stays format-canonical (EPUB only); kepub is generated on demand at sync time and cached so re-syncs are free when nothing has changed.
 - **Open Library matching** — searches by ISBN (precise) or title/author (fuzzy), with confidence scoring
 - **Interactive review** — presents candidates in a Rich table, lets you accept, compare details, look up by URL, or skip
 - **Smart normalization** — splits mangled filenames like `SteveBerry-TheTemplarLegacy` into clean search queries, detects embedded author names
@@ -138,6 +139,20 @@ bookery info 42
 | `tag rm <id> <tag>` | Remove a tag from a book |
 | `tag ls` | List all tags with book counts |
 | `verify` | Check for missing or changed files (supports `--check-hash`) |
+
+### Device sync
+
+| Command | Description |
+|---------|-------------|
+| `sync kobo` | Convert library EPUBs to `.kepub.epub` and copy to a mounted Kobo |
+| `sync kobo --target <path>` | Override auto-detection with an explicit mount point |
+| `sync kobo --dry-run` | Show what would be copied without touching the device |
+
+Requires the [`kepubify`](https://pgaskin.net/kepubify/) binary on `PATH`
+(`brew install kepubify` on macOS). A SQLite cache at
+`{data_dir}/kepub_cache.db` keyed on the source EPUB hash plus the
+`kepubify` version makes re-syncs effectively free when nothing has
+changed.
 
 ### The `match` workflow
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -74,8 +74,11 @@ max_tokens = 262144
 # so unchanged books are skipped on re-sync.
 
 [sync.kobo]
-# Subdirectory under the mount root where books are placed.
-# books_subdir = "Books"
+# Subdirectory under the mount root where books are placed. Default is
+# "Bookery" so synced files are obviously bookery-managed and never get
+# tangled up with Calibre sideloads or Kobo store purchases. Set to
+# "Books" for Calibre-style colocation if that's what you want.
+# books_subdir = "Bookery"
 
 # When true (default), bookery scans /Volumes (macOS) and /media/$USER
 # (Linux) for a `.kobo/` marker. Disable to require an explicit --target.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -63,3 +63,20 @@ max_tokens = 262144
 # - `max_tokens = 0` (the default) means "don't send max_tokens" and lets
 #   the server choose. Only set it explicitly when a provider's default
 #   truncates long outputs (Moonshot's Kimi, notably).
+
+# ---------------------------------------------------------------------------
+# DEVICE SYNC: Kobo
+# ---------------------------------------------------------------------------
+#
+# `bookery sync kobo` walks the catalog and copies a `.kepub.epub` for each
+# book to the mounted Kobo. The library itself stays canonical EPUB; kepub
+# is generated on demand at sync time and cached in {data_dir}/kepub_cache.db
+# so unchanged books are skipped on re-sync.
+
+[sync.kobo]
+# Subdirectory under the mount root where books are placed.
+# books_subdir = "Books"
+
+# When true (default), bookery scans /Volumes (macOS) and /media/$USER
+# (Linux) for a `.kobo/` marker. Disable to require an explicit --target.
+# auto_detect = true

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -19,6 +19,7 @@ from bookery.cli.commands import (
     rematch_cmd,
     search_cmd,
     serve_cmd,
+    sync_cmd,
     tag_cmd,
     verify_cmd,
 )
@@ -54,5 +55,6 @@ cli.add_command(match_cmd.match)
 cli.add_command(rematch_cmd.rematch)
 cli.add_command(search_cmd.search)
 cli.add_command(serve_cmd.serve)
+cli.add_command(sync_cmd.sync)
 cli.add_command(tag_cmd.tag)
 cli.add_command(verify_cmd.verify)

--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -5,6 +5,14 @@ from pathlib import Path
 
 import click
 from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
 
 from bookery.cli.options import db_option
 from bookery.core.config import get_data_dir, get_sync_config
@@ -80,20 +88,40 @@ def sync_kobo(
     conn = open_library(db_path or DEFAULT_DB_PATH)
     try:
         catalog = LibraryCatalog(conn)
-        try:
-            report = sync_library_to_kobo(
-                catalog=catalog,
-                target=resolved_target,
-                cache=cache,
-                run_kepubify=run_kepubify,
-                kepubify_version=kepubify_version,
-                workspace_dir=workspace_dir,
-                books_subdir=sync_cfg.kobo.books_subdir,
-                dry_run=dry_run,
-            )
-        except DeviceError as exc:
-            console.print(f"[red]{exc}[/red]")
-            raise SystemExit(exc.exit_code) from exc
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=console,
+            transient=True,
+        ) as progress:
+            task_id = progress.add_task("Syncing", total=None)
+
+            def _on_progress(idx: int, total: int, record) -> None:  # type: ignore[no-untyped-def]
+                progress.update(
+                    task_id,
+                    completed=idx - 1,
+                    total=total,
+                    description=record.metadata.title[:50],
+                )
+
+            try:
+                report = sync_library_to_kobo(
+                    catalog=catalog,
+                    target=resolved_target,
+                    cache=cache,
+                    run_kepubify=run_kepubify,
+                    kepubify_version=kepubify_version,
+                    workspace_dir=workspace_dir,
+                    books_subdir=sync_cfg.kobo.books_subdir,
+                    dry_run=dry_run,
+                    on_progress=_on_progress,
+                )
+            except DeviceError as exc:
+                console.print(f"[red]{exc}[/red]")
+                raise SystemExit(exc.exit_code) from exc
     finally:
         conn.close()
 

--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -75,6 +75,7 @@ def sync_kobo(
 
     data_dir = data_dir_override or get_data_dir()
     cache = KepubCache(data_dir / "kepub_cache.db")
+    workspace_dir = data_dir / "sync-workspace"
 
     conn = open_library(db_path or DEFAULT_DB_PATH)
     try:
@@ -86,6 +87,7 @@ def sync_kobo(
                 cache=cache,
                 run_kepubify=run_kepubify,
                 kepubify_version=kepubify_version,
+                workspace_dir=workspace_dir,
                 books_subdir=sync_cfg.kobo.books_subdir,
                 dry_run=dry_run,
             )

--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -4,7 +4,8 @@
 from pathlib import Path
 
 import click
-from rich.console import Console
+from rich.console import Console, Group
+from rich.live import Live
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -85,28 +86,58 @@ def sync_kobo(
     cache = KepubCache(data_dir / "kepub_cache.db")
     workspace_dir = data_dir / "sync-workspace"
 
+    _stage_label = {
+        "hash": "hashing",
+        "convert": "converting",
+        "copy": "copying",
+        "cached": "cached",
+        "done": "done",
+    }
+
+    overall = Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("•"),
+        TimeElapsedColumn(),
+        console=console,
+    )
+    current = Progress(
+        SpinnerColumn(),
+        TextColumn("[dim]└─[/dim] {task.description}"),
+        console=console,
+    )
+    overall_task = overall.add_task("Syncing", total=None)
+    current_task = current.add_task("(starting…)", total=None)
+    current_state: dict[str, str] = {"title": "", "stage": ""}
+
+    def _redraw_current() -> None:
+        title = current_state["title"]
+        stage = current_state["stage"]
+        if title and stage:
+            current.update(current_task, description=f"{title}  [dim][{stage}][/dim]")
+        elif title:
+            current.update(current_task, description=title)
+
+    def _on_progress(idx: int, total: int, record) -> None:  # type: ignore[no-untyped-def]
+        overall.update(overall_task, completed=idx - 1, total=total)
+        current_state["title"] = record.metadata.title[:60]
+        current_state["stage"] = ""
+        _redraw_current()
+
+    def _on_stage(stage: str) -> None:
+        current_state["stage"] = _stage_label.get(stage, stage)
+        _redraw_current()
+
     conn = open_library(db_path or DEFAULT_DB_PATH)
     try:
         catalog = LibraryCatalog(conn)
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
+        with Live(
+            Group(overall, current),
             console=console,
             transient=True,
-        ) as progress:
-            task_id = progress.add_task("Syncing", total=None)
-
-            def _on_progress(idx: int, total: int, record) -> None:  # type: ignore[no-untyped-def]
-                progress.update(
-                    task_id,
-                    completed=idx - 1,
-                    total=total,
-                    description=record.metadata.title[:50],
-                )
-
+            refresh_per_second=10,
+        ):
             try:
                 report = sync_library_to_kobo(
                     catalog=catalog,
@@ -118,7 +149,9 @@ def sync_kobo(
                     books_subdir=sync_cfg.kobo.books_subdir,
                     dry_run=dry_run,
                     on_progress=_on_progress,
+                    on_stage=_on_stage,
                 )
+                overall.update(overall_task, completed=overall.tasks[0].total or 0)
             except DeviceError as exc:
                 console.print(f"[red]{exc}[/red]")
                 raise SystemExit(exc.exit_code) from exc
@@ -139,7 +172,13 @@ def sync_kobo(
         for path, reason in report.skipped:
             console.print(f"  [dim]- {path.name}: {reason}[/dim]")
     if report.failed:
-        console.print(f"[red]Failed {len(report.failed)}:[/red]")
+        # Per-book failures are reported but don't fail the command — a stale
+        # catalog entry or a single un-convertible EPUB shouldn't block a sync
+        # of hundreds of other books. Hard errors (missing kepubify, no Kobo
+        # detected) still exit non-zero from earlier branches.
+        console.print(
+            f"[yellow]Warnings: {len(report.failed)} book(s) could not be "
+            "synced (catalog or EPUB issue):[/yellow]"
+        )
         for path, reason in report.failed:
-            console.print(f"  [red]- {path.name}: {reason}[/red]")
-        raise SystemExit(1)
+            console.print(f"  [yellow]- {path.name}: {reason}[/yellow]")

--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -1,0 +1,115 @@
+# ABOUTME: The `bookery sync` command group; ships `kobo` for syncing to mounted Kobo readers.
+# ABOUTME: Wires the device/ subsystem (detect_mounted_kobo + sync_library_to_kobo) to the CLI.
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from bookery.cli.options import db_option
+from bookery.core.config import get_data_dir, get_sync_config
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import DEFAULT_DB_PATH, open_library
+from bookery.device.errors import DeviceError, KoboNotMounted
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kepubify import kepubify_version, run_kepubify
+from bookery.device.kobo import detect_mounted_kobo, sync_library_to_kobo
+
+console = Console()
+
+
+@click.group("sync")
+def sync() -> None:
+    """Sync the library to a connected device."""
+
+
+@sync.command("kobo")
+@click.option(
+    "--target",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to the mounted Kobo (overrides auto-detection).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be copied without touching the device.",
+)
+@click.option(
+    "--data-dir",
+    "data_dir_override",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Override the data dir (cache location). Mostly for testing.",
+)
+@db_option
+def sync_kobo(
+    target: Path | None,
+    dry_run: bool,
+    data_dir_override: Path | None,
+    db_path: Path | None,
+) -> None:
+    """Convert library EPUBs to .kepub.epub and copy to a mounted Kobo."""
+    sync_cfg = get_sync_config()
+
+    resolved_target = target
+    if resolved_target is None:
+        if not sync_cfg.kobo.auto_detect:
+            console.print(
+                "[red]No --target given and auto_detect is disabled.[/red]"
+            )
+            raise SystemExit(1)
+        detected = detect_mounted_kobo()
+        if detected is None:
+            err = KoboNotMounted()
+            console.print(f"[red]{err}[/red]")
+            raise SystemExit(err.exit_code)
+        resolved_target = detected
+        console.print(f"[dim]Detected Kobo at {resolved_target}[/dim]")
+
+    if not (resolved_target / ".kobo").exists() and not dry_run:
+        console.print(
+            f"[yellow]Warning:[/yellow] {resolved_target} has no .kobo/ marker."
+        )
+
+    data_dir = data_dir_override or get_data_dir()
+    cache = KepubCache(data_dir / "kepub_cache.db")
+
+    conn = open_library(db_path or DEFAULT_DB_PATH)
+    try:
+        catalog = LibraryCatalog(conn)
+        try:
+            report = sync_library_to_kobo(
+                catalog=catalog,
+                target=resolved_target,
+                cache=cache,
+                run_kepubify=run_kepubify,
+                kepubify_version=kepubify_version,
+                books_subdir=sync_cfg.kobo.books_subdir,
+                dry_run=dry_run,
+            )
+        except DeviceError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise SystemExit(exc.exit_code) from exc
+    finally:
+        conn.close()
+
+    label = "Would copy" if dry_run else "Copied"
+    if not report.copied and not report.skipped and not report.failed:
+        console.print("[dim]No books to sync.[/dim]")
+        return
+
+    if report.copied:
+        console.print(f"[green]{label} {len(report.copied)} book(s):[/green]")
+        for path in report.copied:
+            console.print(f"  {path}")
+    if report.skipped:
+        console.print(f"[dim]Skipped {len(report.skipped)}:[/dim]")
+        for path, reason in report.skipped:
+            console.print(f"  [dim]- {path.name}: {reason}[/dim]")
+    if report.failed:
+        console.print(f"[red]Failed {len(report.failed)}:[/red]")
+        for path, reason in report.failed:
+            console.print(f"  [red]- {path.name}: {reason}[/red]")
+        raise SystemExit(1)

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -44,7 +44,7 @@ class ConvertConfig:
     semantic: SemanticConfig = field(default_factory=SemanticConfig)
 
 
-DEFAULT_KOBO_BOOKS_SUBDIR = "Books"
+DEFAULT_KOBO_BOOKS_SUBDIR = "Bookery"
 DEFAULT_KOBO_AUTO_DETECT = True
 
 

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -44,11 +44,27 @@ class ConvertConfig:
     semantic: SemanticConfig = field(default_factory=SemanticConfig)
 
 
+DEFAULT_KOBO_BOOKS_SUBDIR = "Books"
+DEFAULT_KOBO_AUTO_DETECT = True
+
+
+@dataclass(frozen=True, slots=True)
+class SyncKoboConfig:
+    books_subdir: str = DEFAULT_KOBO_BOOKS_SUBDIR
+    auto_detect: bool = DEFAULT_KOBO_AUTO_DETECT
+
+
+@dataclass(frozen=True, slots=True)
+class SyncConfig:
+    kobo: SyncKoboConfig = field(default_factory=SyncKoboConfig)
+
+
 @dataclass(frozen=True)
 class Config:
     library_root: Path
     data_dir: Path
     convert: ConvertConfig = field(default_factory=ConvertConfig)
+    sync: SyncConfig = field(default_factory=SyncConfig)
 
 
 def _config_path() -> Path:
@@ -86,6 +102,21 @@ def _parse_convert(section: dict[str, Any] | None) -> ConvertConfig:
     if not section:
         return ConvertConfig()
     return ConvertConfig(semantic=_parse_semantic(section.get("semantic")))
+
+
+def _parse_sync_kobo(section: dict[str, Any] | None) -> SyncKoboConfig:
+    if not section:
+        return SyncKoboConfig()
+    return SyncKoboConfig(
+        books_subdir=str(section.get("books_subdir", DEFAULT_KOBO_BOOKS_SUBDIR)),
+        auto_detect=bool(section.get("auto_detect", DEFAULT_KOBO_AUTO_DETECT)),
+    )
+
+
+def _parse_sync(section: dict[str, Any] | None) -> SyncConfig:
+    if not section:
+        return SyncConfig()
+    return SyncConfig(kobo=_parse_sync_kobo(section.get("kobo")))
 
 
 def load_config() -> Config:
@@ -128,7 +159,10 @@ def load_config() -> Config:
         data_dir = data_dir.resolve()
 
     convert = _parse_convert(data.get("convert"))
-    return Config(library_root=library_root, data_dir=data_dir, convert=convert)
+    sync = _parse_sync(data.get("sync"))
+    return Config(
+        library_root=library_root, data_dir=data_dir, convert=convert, sync=sync
+    )
 
 
 def get_library_root() -> Path:
@@ -144,3 +178,8 @@ def get_data_dir() -> Path:
 def get_convert_config() -> ConvertConfig:
     """Return the [convert] configuration block."""
     return load_config().convert
+
+
+def get_sync_config() -> SyncConfig:
+    """Return the [sync] configuration block."""
+    return load_config().sync

--- a/src/bookery/device/errors.py
+++ b/src/bookery/device/errors.py
@@ -1,0 +1,35 @@
+# ABOUTME: Typed exceptions for the device sync subsystem (Kobo first).
+# ABOUTME: Each carries an exit_code class attribute the CLI maps to process exit status.
+
+
+class DeviceError(Exception):
+    """Base class for device sync errors."""
+
+    exit_code: int = 1
+
+
+class KepubifyMissing(DeviceError):
+    exit_code = 3
+
+    def __init__(self) -> None:
+        super().__init__(
+            "kepubify is not on PATH. Install it (e.g. `brew install kepubify`) "
+            "and re-run."
+        )
+
+
+class KepubifyFailed(DeviceError):
+    exit_code = 1
+
+    def __init__(self, stderr: str) -> None:
+        super().__init__(f"kepubify failed: {stderr}".rstrip())
+        self.stderr = stderr
+
+
+class KoboNotMounted(DeviceError):
+    exit_code = 1
+
+    def __init__(self) -> None:
+        super().__init__(
+            "No mounted Kobo detected. Pass --target /path/to/mount to override."
+        )

--- a/src/bookery/device/kepub_cache.py
+++ b/src/bookery/device/kepub_cache.py
@@ -3,11 +3,25 @@
 
 import sqlite3
 from contextlib import closing
+from dataclasses import dataclass
 from pathlib import Path
 
 
+@dataclass(frozen=True)
+class KepubCacheEntry:
+    source_hash: str
+    kepubify_version: str
+    kepub_sha: str
+    device_path: Path
+
+
 class KepubCache:
-    """Persistent cache of kepub hashes keyed on (source_hash, kepubify_version)."""
+    """Persistent cache of kepub hashes keyed on (source_hash, kepubify_version).
+
+    Also records the device-side path each kepub was written to, which a
+    future `bookery sync kobo --prune` will use to walk and delete only
+    files we actually wrote.
+    """
 
     def __init__(self, path: Path) -> None:
         self.path = path
@@ -18,6 +32,7 @@ class KepubCache:
                 "  source_hash TEXT NOT NULL,"
                 "  kepubify_version TEXT NOT NULL,"
                 "  kepub_sha TEXT NOT NULL,"
+                "  device_path TEXT NOT NULL,"
                 "  PRIMARY KEY (source_hash, kepubify_version)"
                 ")"
             )
@@ -32,11 +47,35 @@ class KepubCache:
             ).fetchone()
         return row[0] if row else None
 
-    def put(self, source_hash: str, kepubify_version: str, kepub_sha: str) -> None:
+    def put(
+        self,
+        source_hash: str,
+        kepubify_version: str,
+        kepub_sha: str,
+        device_path: Path,
+    ) -> None:
         with closing(sqlite3.connect(self.path)) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO kepub_entries "
-                "(source_hash, kepubify_version, kepub_sha) VALUES (?, ?, ?)",
-                (source_hash, kepubify_version, kepub_sha),
+                "(source_hash, kepubify_version, kepub_sha, device_path) "
+                "VALUES (?, ?, ?, ?)",
+                (source_hash, kepubify_version, kepub_sha, str(device_path)),
             )
             conn.commit()
+
+    def iter_entries(self) -> list[KepubCacheEntry]:
+        """Return every cached entry (for `--prune` walks)."""
+        with closing(sqlite3.connect(self.path)) as conn:
+            rows = conn.execute(
+                "SELECT source_hash, kepubify_version, kepub_sha, device_path "
+                "FROM kepub_entries"
+            ).fetchall()
+        return [
+            KepubCacheEntry(
+                source_hash=r[0],
+                kepubify_version=r[1],
+                kepub_sha=r[2],
+                device_path=Path(r[3]),
+            )
+            for r in rows
+        ]

--- a/src/bookery/device/kepub_cache.py
+++ b/src/bookery/device/kepub_cache.py
@@ -1,0 +1,42 @@
+# ABOUTME: SQLite-backed cache that maps (source EPUB hash, kepubify version) to kepub hash.
+# ABOUTME: Lets `bookery sync kobo` skip kepubify invocations when on-device files already match.
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+
+class KepubCache:
+    """Persistent cache of kepub hashes keyed on (source_hash, kepubify_version)."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(path)) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS kepub_entries ("
+                "  source_hash TEXT NOT NULL,"
+                "  kepubify_version TEXT NOT NULL,"
+                "  kepub_sha TEXT NOT NULL,"
+                "  PRIMARY KEY (source_hash, kepubify_version)"
+                ")"
+            )
+            conn.commit()
+
+    def get(self, source_hash: str, kepubify_version: str) -> str | None:
+        with closing(sqlite3.connect(self.path)) as conn:
+            row = conn.execute(
+                "SELECT kepub_sha FROM kepub_entries "
+                "WHERE source_hash = ? AND kepubify_version = ?",
+                (source_hash, kepubify_version),
+            ).fetchone()
+        return row[0] if row else None
+
+    def put(self, source_hash: str, kepubify_version: str, kepub_sha: str) -> None:
+        with closing(sqlite3.connect(self.path)) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO kepub_entries "
+                "(source_hash, kepubify_version, kepub_sha) VALUES (?, ?, ?)",
+                (source_hash, kepubify_version, kepub_sha),
+            )
+            conn.commit()

--- a/src/bookery/device/kepubify.py
+++ b/src/bookery/device/kepubify.py
@@ -1,0 +1,53 @@
+# ABOUTME: Subprocess wrapper around the external `kepubify` binary.
+# ABOUTME: Used by Kobo sync to convert canonical EPUBs into the .kepub.epub delivery format.
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from bookery.device.errors import KepubifyFailed, KepubifyMissing
+
+KEPUBIFY = "kepubify"
+
+
+def _ensure_present() -> str:
+    path = shutil.which(KEPUBIFY)
+    if path is None:
+        raise KepubifyMissing()
+    return path
+
+
+def run_kepubify(epub: Path, *, out_dir: Path) -> Path:
+    """Run kepubify on `epub`, writing `<name>.kepub.epub` into `out_dir`.
+
+    Returns the path to the produced .kepub.epub file.
+    """
+    _ensure_present()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            [KEPUBIFY, "-o", str(out_dir), str(epub)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise KepubifyFailed(exc.stderr or str(exc)) from exc
+    return out_dir / f"{epub.stem}.kepub.epub"
+
+
+def kepubify_version() -> str:
+    """Return the kepubify version string (e.g. 'v4.4.0')."""
+    _ensure_present()
+    completed = subprocess.run(
+        [KEPUBIFY, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    text = (completed.stdout or completed.stderr or "").strip()
+    # Output looks like "kepubify v4.4.0" — return the v-prefixed token if present.
+    for token in text.split():
+        if token.startswith("v") and any(ch.isdigit() for ch in token):
+            return token
+    return text

--- a/src/bookery/device/kepubify.py
+++ b/src/bookery/device/kepubify.py
@@ -20,20 +20,27 @@ def _ensure_present() -> str:
 def run_kepubify(epub: Path, *, out_dir: Path) -> Path:
     """Run kepubify on `epub`, writing `<name>.kepub.epub` into `out_dir`.
 
+    Passes `-o <out_dir>/<name>.kepub.epub` explicitly so we control the
+    output filename. Different kepubify versions disagree on the default
+    naming (v4.0.x produces `<name>_converted.kepub.epub`, newer versions
+    drop the suffix), and an explicit `-o` filename short-circuits that
+    inconsistency.
+
     Returns the path to the produced .kepub.epub file.
     """
     _ensure_present()
     out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{epub.stem}.kepub.epub"
     try:
         subprocess.run(
-            [KEPUBIFY, "-o", str(out_dir), str(epub)],
+            [KEPUBIFY, "-o", str(out_path), str(epub)],
             check=True,
             capture_output=True,
             text=True,
         )
     except subprocess.CalledProcessError as exc:
         raise KepubifyFailed(exc.stderr or str(exc)) from exc
-    return out_dir / f"{epub.stem}.kepub.epub"
+    return out_path
 
 
 def kepubify_version() -> str:

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -157,6 +157,9 @@ def _sync_record(
     report.copied.append(dest)
 
 
+ProgressCallback = Callable[[int, int, BookRecord], None]
+
+
 def sync_library_to_kobo(
     *,
     catalog: _CatalogProto,
@@ -167,6 +170,7 @@ def sync_library_to_kobo(
     workspace_dir: Path,
     books_subdir: str = "Bookery",
     dry_run: bool = False,
+    on_progress: ProgressCallback | None = None,
 ) -> SyncReport:
     """Walk the catalog and mirror its EPUBs to a Kobo as .kepub.epub files.
 
@@ -182,8 +186,12 @@ def sync_library_to_kobo(
     we never touch the device mount's parent (e.g. /Volumes itself).
     """
     report = SyncReport()
+    records = catalog.list_all()
+    total = len(records)
     if dry_run:
-        for record in catalog.list_all():
+        for idx, record in enumerate(records, 1):
+            if on_progress is not None:
+                on_progress(idx, total, record)
             source = record.output_path
             if source is None:
                 report.skipped.append(
@@ -202,7 +210,9 @@ def sync_library_to_kobo(
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        for record in catalog.list_all():
+        for idx, record in enumerate(records, 1):
+            if on_progress is not None:
+                on_progress(idx, total, record)
             _sync_record(
                 record,
                 target=target,

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -1,0 +1,54 @@
+# ABOUTME: Kobo device sync — detects mounted readers and copies kepubs to them.
+# ABOUTME: The library stays canonical EPUB; kepubify runs only inside this module.
+
+import getpass
+import platform
+from collections.abc import Iterable
+from pathlib import Path
+
+KOBO_MARKER = ".kobo"
+
+
+def _default_mount_roots() -> list[Path]:
+    system = platform.system()
+    if system == "Darwin":
+        return [Path("/Volumes")]
+    if system == "Linux":
+        try:
+            user = getpass.getuser()
+        except Exception:
+            user = ""
+        roots = [Path("/media"), Path("/mnt")]
+        if user:
+            roots.extend([Path(f"/media/{user}"), Path(f"/run/media/{user}")])
+        return roots
+    return []
+
+
+def _scan_roots(roots: Iterable[Path]) -> list[Path]:
+    candidates: list[Path] = []
+    for root in roots:
+        if not root.exists() or not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if child.is_dir():
+                candidates.append(child)
+    return candidates
+
+
+def detect_mounted_kobo(
+    *, candidates: Iterable[Path] | None = None
+) -> Path | None:
+    """Return the first mount path that contains a `.kobo/` marker, else None.
+
+    When `candidates` is None, scans platform-default mount roots (e.g.
+    /Volumes on macOS; /media/$USER and /run/media/$USER on Linux).
+    """
+    if candidates is None:
+        candidates = _scan_roots(_default_mount_roots())
+    for path in candidates:
+        if not path.exists():
+            continue
+        if (path / KOBO_MARKER).is_dir():
+            return path
+    return None

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -85,6 +85,10 @@ class _CacheProto(Protocol):
     ) -> None: ...
 
 
+ProgressCallback = Callable[[int, int, BookRecord], None]
+StageCallback = Callable[[str], None]
+
+
 def _book_dest_dir(target: Path, books_subdir: str, record: BookRecord) -> Path:
     author_raw = (
         record.metadata.authors[0] if record.metadata.authors else "Unknown Author"
@@ -105,7 +109,12 @@ def _sync_record(
     run_kepubify: Callable[..., Path],
     workspace: Path,
     report: SyncReport,
+    on_stage: StageCallback | None = None,
 ) -> None:
+    def stage(name: str) -> None:
+        if on_stage is not None:
+            on_stage(name)
+
     source = record.output_path
     if source is None:
         report.skipped.append(
@@ -123,6 +132,7 @@ def _sync_record(
     title = sanitize_component(record.metadata.title, fallback="Untitled")
     dest = dest_dir / f"{title}.kepub.epub"
 
+    stage("hash")
     try:
         source_hash = compute_file_hash(source)
     except OSError as exc:
@@ -133,17 +143,20 @@ def _sync_record(
     if cached_kepub_sha is not None and dest.exists():
         try:
             if compute_file_hash(dest) == cached_kepub_sha:
+                stage("cached")
                 report.skipped.append((dest, "already up to date"))
                 return
         except OSError:
             pass  # fall through to re-convert
 
+    stage("convert")
     try:
         kepub_path = run_kepubify(source, out_dir=workspace)
     except Exception as exc:
         report.failed.append((source, f"kepubify error: {exc}"))
         return
 
+    stage("copy")
     try:
         kepub_sha = compute_file_hash(kepub_path)
         dest_dir.mkdir(parents=True, exist_ok=True)
@@ -154,10 +167,8 @@ def _sync_record(
         return
 
     cache.put(source_hash, version, kepub_sha, dest)
+    stage("done")
     report.copied.append(dest)
-
-
-ProgressCallback = Callable[[int, int, BookRecord], None]
 
 
 def sync_library_to_kobo(
@@ -171,6 +182,7 @@ def sync_library_to_kobo(
     books_subdir: str = "Bookery",
     dry_run: bool = False,
     on_progress: ProgressCallback | None = None,
+    on_stage: StageCallback | None = None,
 ) -> SyncReport:
     """Walk the catalog and mirror its EPUBs to a Kobo as .kepub.epub files.
 
@@ -222,6 +234,7 @@ def sync_library_to_kobo(
                 run_kepubify=run_kepubify,
                 workspace=workspace_dir,
                 report=report,
+                on_stage=on_stage,
             )
     finally:
         if workspace_dir.exists():

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -1,10 +1,17 @@
 # ABOUTME: Kobo device sync — detects mounted readers and copies kepubs to them.
 # ABOUTME: The library stays canonical EPUB; kepubify runs only inside this module.
 
+import contextlib
 import getpass
+import hashlib
 import platform
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Protocol
+
+from bookery.core.pathformat import sanitize_component
+from bookery.db.mapping import BookRecord
 
 KOBO_MARKER = ".kobo"
 
@@ -52,3 +59,131 @@ def detect_mounted_kobo(
         if (path / KOBO_MARKER).is_dir():
             return path
     return None
+
+
+_HASH_CHUNK = 1024 * 1024
+
+
+def _hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(_HASH_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass
+class SyncReport:
+    copied: list[Path] = field(default_factory=list)
+    skipped: list[tuple[Path, str]] = field(default_factory=list)
+    failed: list[tuple[Path, str]] = field(default_factory=list)
+
+
+class _CatalogProto(Protocol):
+    def list_all(self) -> list[BookRecord]: ...
+
+
+class _CacheProto(Protocol):
+    def get(self, source_hash: str, kepubify_version: str) -> str | None: ...
+
+    def put(
+        self, source_hash: str, kepubify_version: str, kepub_sha: str
+    ) -> None: ...
+
+
+def _book_dest_dir(target: Path, books_subdir: str, record: BookRecord) -> Path:
+    author_raw = (
+        record.metadata.authors[0] if record.metadata.authors else "Unknown Author"
+    )
+    title_raw = record.metadata.title or "Untitled"
+    author = sanitize_component(author_raw, fallback="Unknown Author")
+    title = sanitize_component(title_raw, fallback="Untitled")
+    return target / books_subdir / author / title
+
+
+def sync_library_to_kobo(
+    *,
+    catalog: _CatalogProto,
+    target: Path,
+    cache: _CacheProto,
+    run_kepubify: Callable[..., Path],
+    kepubify_version: Callable[[], str],
+    books_subdir: str = "Books",
+    dry_run: bool = False,
+) -> SyncReport:
+    """Walk the catalog and mirror its EPUBs to a Kobo as .kepub.epub files.
+
+    Cache semantics: row keyed on (source_sha256, kepubify_version) -> kepub_sha.
+    On re-sync we hash the on-device file; if it matches the cached kepub_sha
+    we skip kepubify entirely. Cache miss or device-file mismatch triggers a
+    fresh kepubify run.
+
+    Dependencies are injected so this function stays unit-testable; the CLI
+    wires up the real KepubCache and the kepubify subprocess wrapper.
+    """
+    report = SyncReport()
+    version = kepubify_version() if not dry_run else "dry-run"
+    workspace = target.parent / ".bookery-sync-tmp"
+    if not dry_run:
+        workspace.mkdir(parents=True, exist_ok=True)
+
+    for record in catalog.list_all():
+        source = record.output_path
+        if source is None:
+            report.skipped.append(
+                (record.source_path, "no canonical EPUB in library")
+            )
+            continue
+        if source.suffix.lower() != ".epub":
+            report.skipped.append((source, "output is not an EPUB"))
+            continue
+        if not source.exists():
+            report.failed.append((source, f"source missing: {source}"))
+            continue
+
+        dest_dir = _book_dest_dir(target, books_subdir, record)
+        title = sanitize_component(record.metadata.title, fallback="Untitled")
+        dest = dest_dir / f"{title}.kepub.epub"
+
+        if dry_run:
+            report.copied.append(dest)
+            continue
+
+        try:
+            source_hash = _hash_file(source)
+        except OSError as exc:
+            report.failed.append((source, f"hash failed: {exc}"))
+            continue
+
+        cached_kepub_sha = cache.get(source_hash, version)
+        if cached_kepub_sha is not None and dest.exists():
+            try:
+                if _hash_file(dest) == cached_kepub_sha:
+                    report.skipped.append((dest, "already up to date"))
+                    continue
+            except OSError:
+                pass  # fall through to re-convert
+
+        try:
+            kepub_path = run_kepubify(source, out_dir=workspace)
+        except Exception as exc:
+            report.failed.append((source, f"kepubify error: {exc}"))
+            continue
+
+        try:
+            kepub_sha = _hash_file(kepub_path)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(kepub_path.read_bytes())
+            kepub_path.unlink(missing_ok=True)
+        except OSError as exc:
+            report.failed.append((source, f"copy failed: {exc}"))
+            continue
+
+        cache.put(source_hash, version, kepub_sha)
+        report.copied.append(dest)
+
+    if not dry_run and workspace.exists():
+        with contextlib.suppress(OSError):
+            workspace.rmdir()
+
+    return report

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -3,14 +3,15 @@
 
 import contextlib
 import getpass
-import hashlib
 import platform
+import shutil
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
 from bookery.core.pathformat import sanitize_component
+from bookery.db.hashing import compute_file_hash
 from bookery.db.mapping import BookRecord
 
 KOBO_MARKER = ".kobo"
@@ -61,17 +62,6 @@ def detect_mounted_kobo(
     return None
 
 
-_HASH_CHUNK = 1024 * 1024
-
-
-def _hash_file(path: Path) -> str:
-    h = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(_HASH_CHUNK), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
 @dataclass
 class SyncReport:
     copied: list[Path] = field(default_factory=list)
@@ -87,7 +77,11 @@ class _CacheProto(Protocol):
     def get(self, source_hash: str, kepubify_version: str) -> str | None: ...
 
     def put(
-        self, source_hash: str, kepubify_version: str, kepub_sha: str
+        self,
+        source_hash: str,
+        kepubify_version: str,
+        kepub_sha: str,
+        device_path: Path,
     ) -> None: ...
 
 
@@ -101,6 +95,68 @@ def _book_dest_dir(target: Path, books_subdir: str, record: BookRecord) -> Path:
     return target / books_subdir / author / title
 
 
+def _sync_record(
+    record: BookRecord,
+    *,
+    target: Path,
+    books_subdir: str,
+    cache: _CacheProto,
+    version: str,
+    run_kepubify: Callable[..., Path],
+    workspace: Path,
+    report: SyncReport,
+) -> None:
+    source = record.output_path
+    if source is None:
+        report.skipped.append(
+            (record.source_path, "no canonical EPUB in library")
+        )
+        return
+    if source.suffix.lower() != ".epub":
+        report.skipped.append((source, "output is not an EPUB"))
+        return
+    if not source.exists():
+        report.failed.append((source, f"source missing: {source}"))
+        return
+
+    dest_dir = _book_dest_dir(target, books_subdir, record)
+    title = sanitize_component(record.metadata.title, fallback="Untitled")
+    dest = dest_dir / f"{title}.kepub.epub"
+
+    try:
+        source_hash = compute_file_hash(source)
+    except OSError as exc:
+        report.failed.append((source, f"hash failed: {exc}"))
+        return
+
+    cached_kepub_sha = cache.get(source_hash, version)
+    if cached_kepub_sha is not None and dest.exists():
+        try:
+            if compute_file_hash(dest) == cached_kepub_sha:
+                report.skipped.append((dest, "already up to date"))
+                return
+        except OSError:
+            pass  # fall through to re-convert
+
+    try:
+        kepub_path = run_kepubify(source, out_dir=workspace)
+    except Exception as exc:
+        report.failed.append((source, f"kepubify error: {exc}"))
+        return
+
+    try:
+        kepub_sha = compute_file_hash(kepub_path)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        # shutil.move handles cross-device renames and streams large files.
+        shutil.move(str(kepub_path), str(dest))
+    except OSError as exc:
+        report.failed.append((source, f"copy failed: {exc}"))
+        return
+
+    cache.put(source_hash, version, kepub_sha, dest)
+    report.copied.append(dest)
+
+
 def sync_library_to_kobo(
     *,
     catalog: _CatalogProto,
@@ -108,82 +164,58 @@ def sync_library_to_kobo(
     cache: _CacheProto,
     run_kepubify: Callable[..., Path],
     kepubify_version: Callable[[], str],
-    books_subdir: str = "Books",
+    workspace_dir: Path,
+    books_subdir: str = "Bookery",
     dry_run: bool = False,
 ) -> SyncReport:
     """Walk the catalog and mirror its EPUBs to a Kobo as .kepub.epub files.
 
-    Cache semantics: row keyed on (source_sha256, kepubify_version) -> kepub_sha.
-    On re-sync we hash the on-device file; if it matches the cached kepub_sha
-    we skip kepubify entirely. Cache miss or device-file mismatch triggers a
-    fresh kepubify run.
+    Cache semantics: row keyed on (source_sha256, kepubify_version) -> kepub_sha
+    plus the device-side path that kepub was written to. On re-sync we hash
+    the on-device file; if it matches the cached kepub_sha we skip kepubify
+    entirely. Cache miss or device-file mismatch triggers a fresh run.
 
     Dependencies are injected so this function stays unit-testable; the CLI
     wires up the real KepubCache and the kepubify subprocess wrapper.
+    `workspace_dir` is where kepubify writes intermediate files before they
+    are moved onto the device; the CLI scopes it to the bookery data dir so
+    we never touch the device mount's parent (e.g. /Volumes itself).
     """
     report = SyncReport()
-    version = kepubify_version() if not dry_run else "dry-run"
-    workspace = target.parent / ".bookery-sync-tmp"
-    if not dry_run:
-        workspace.mkdir(parents=True, exist_ok=True)
+    if dry_run:
+        for record in catalog.list_all():
+            source = record.output_path
+            if source is None:
+                report.skipped.append(
+                    (record.source_path, "no canonical EPUB in library")
+                )
+                continue
+            if source.suffix.lower() != ".epub":
+                report.skipped.append((source, "output is not an EPUB"))
+                continue
+            dest_dir = _book_dest_dir(target, books_subdir, record)
+            title = sanitize_component(record.metadata.title, fallback="Untitled")
+            report.copied.append(dest_dir / f"{title}.kepub.epub")
+        return report
 
-    for record in catalog.list_all():
-        source = record.output_path
-        if source is None:
-            report.skipped.append(
-                (record.source_path, "no canonical EPUB in library")
+    version = kepubify_version()
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        for record in catalog.list_all():
+            _sync_record(
+                record,
+                target=target,
+                books_subdir=books_subdir,
+                cache=cache,
+                version=version,
+                run_kepubify=run_kepubify,
+                workspace=workspace_dir,
+                report=report,
             )
-            continue
-        if source.suffix.lower() != ".epub":
-            report.skipped.append((source, "output is not an EPUB"))
-            continue
-        if not source.exists():
-            report.failed.append((source, f"source missing: {source}"))
-            continue
-
-        dest_dir = _book_dest_dir(target, books_subdir, record)
-        title = sanitize_component(record.metadata.title, fallback="Untitled")
-        dest = dest_dir / f"{title}.kepub.epub"
-
-        if dry_run:
-            report.copied.append(dest)
-            continue
-
-        try:
-            source_hash = _hash_file(source)
-        except OSError as exc:
-            report.failed.append((source, f"hash failed: {exc}"))
-            continue
-
-        cached_kepub_sha = cache.get(source_hash, version)
-        if cached_kepub_sha is not None and dest.exists():
-            try:
-                if _hash_file(dest) == cached_kepub_sha:
-                    report.skipped.append((dest, "already up to date"))
-                    continue
-            except OSError:
-                pass  # fall through to re-convert
-
-        try:
-            kepub_path = run_kepubify(source, out_dir=workspace)
-        except Exception as exc:
-            report.failed.append((source, f"kepubify error: {exc}"))
-            continue
-
-        try:
-            kepub_sha = _hash_file(kepub_path)
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(kepub_path.read_bytes())
-            kepub_path.unlink(missing_ok=True)
-        except OSError as exc:
-            report.failed.append((source, f"copy failed: {exc}"))
-            continue
-
-        cache.put(source_hash, version, kepub_sha)
-        report.copied.append(dest)
-
-    if not dry_run and workspace.exists():
-        with contextlib.suppress(OSError):
-            workspace.rmdir()
+    finally:
+        if workspace_dir.exists():
+            with contextlib.suppress(OSError):
+                workspace_dir.rmdir()
 
     return report

--- a/tests/e2e/test_sync_cli.py
+++ b/tests/e2e/test_sync_cli.py
@@ -162,6 +162,57 @@ def test_kepubify_missing_exits_3(tmp_path: Path) -> None:
     assert "kepubify" in result.output.lower()
 
 
+def test_per_book_failure_does_not_fail_command(tmp_path: Path) -> None:
+    """A single bad book (missing source, kepubify error, etc.) should be
+    reported as a warning but not exit non-zero — otherwise one stale
+    catalog entry blocks a sync of hundreds of healthy books."""
+    db_path = tmp_path / "lib.db"
+    library = tmp_path / "library"
+    target = _make_kobo_root(tmp_path)
+
+    # Seed two books: one whose source file actually exists, one whose
+    # output_path points at a missing file (simulates a stale catalog row).
+    good_epub = library / "Good Author" / "Good" / "Good.epub"
+    good_epub.parent.mkdir(parents=True, exist_ok=True)
+    good_epub.write_bytes(b"GOOD-EPUB")
+    missing_epub = library / "Stale" / "Gone" / "Gone.epub"  # never created
+
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        catalog.add_book(
+            BookMetadata(title="Good", authors=["Good Author"], source_path=good_epub),
+            file_hash="good",
+            output_path=good_epub,
+        )
+        catalog.add_book(
+            BookMetadata(title="Gone", authors=["Stale"], source_path=missing_epub),
+            file_hash="gone",
+            output_path=missing_epub,
+        )
+    finally:
+        conn.close()
+
+    runner = CliRunner()
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch("bookery.device.kepubify.subprocess.run", side_effect=_fake_kepubify()),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "sync", "kobo",
+                "--target", str(target),
+                "--db", str(db_path),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Warnings" in result.output
+    assert "Gone.epub" in result.output
+
+
 def test_no_target_and_no_detection_fails(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "lib.db"
     open_library(db_path).close()

--- a/tests/e2e/test_sync_cli.py
+++ b/tests/e2e/test_sync_cli.py
@@ -1,0 +1,183 @@
+# ABOUTME: End-to-end tests for the `bookery sync kobo` CLI command.
+# ABOUTME: Drives the Click app with a real DB; stubs the kepubify subprocess.
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+def _seed(db_path: Path, library: Path) -> Path:
+    epub = library / "Some Author" / "Some Title" / "Some Title.epub"
+    epub.parent.mkdir(parents=True, exist_ok=True)
+    epub.write_bytes(b"FAKE-EPUB")
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        catalog.add_book(
+            BookMetadata(
+                title="Some Title",
+                authors=["Some Author"],
+                source_path=epub,
+            ),
+            file_hash="seed-hash",
+            output_path=epub,
+        )
+    finally:
+        conn.close()
+    return epub
+
+
+def _make_kobo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "kobo"
+    root.mkdir()
+    (root / ".kobo").mkdir()
+    return root
+
+
+def _fake_kepubify(returncode: int = 0, stderr: str = "", payload: bytes = b"FAKE-KEPUB"):
+    def runner(cmd, **_kwargs):
+        if "--version" in cmd:
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="kepubify v4.4.0\n", stderr=""
+            )
+        # `kepubify -o <out> <epub>` form
+        out_dir = Path(cmd[cmd.index("-o") + 1])
+        epub = Path(cmd[-1])
+        out = out_dir / f"{epub.stem}.kepub.epub"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        if returncode == 0:
+            out.write_bytes(payload)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        raise subprocess.CalledProcessError(returncode, cmd, stderr=stderr)
+
+    return runner
+
+
+def test_empty_catalog_exits_zero(tmp_path: Path) -> None:
+    db_path = tmp_path / "lib.db"
+    open_library(db_path).close()
+    target = _make_kobo_root(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch("bookery.device.kepubify.subprocess.run", side_effect=_fake_kepubify()),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "sync", "kobo",
+                "--target", str(target),
+                "--db", str(db_path),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "No books" in result.output or "0" in result.output
+
+
+def test_sync_copies_kepub_to_target(tmp_path: Path) -> None:
+    db_path = tmp_path / "lib.db"
+    library = tmp_path / "library"
+    _seed(db_path, library)
+    target = _make_kobo_root(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch("bookery.device.kepubify.subprocess.run", side_effect=_fake_kepubify()),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "sync", "kobo",
+                "--target", str(target),
+                "--db", str(db_path),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    expected = (
+        target / "Books" / "Some Author" / "Some Title" / "Some Title.kepub.epub"
+    )
+    assert expected.exists()
+    assert "Some Title" in result.output
+
+
+def test_dry_run_makes_no_writes(tmp_path: Path) -> None:
+    db_path = tmp_path / "lib.db"
+    library = tmp_path / "library"
+    _seed(db_path, library)
+    target = _make_kobo_root(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch("bookery.device.kepubify.subprocess.run", side_effect=_fake_kepubify()) as mock_run,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "sync", "kobo",
+                "--target", str(target),
+                "--dry-run",
+                "--db", str(db_path),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # In dry-run we shouldn't call kepubify (not even --version).
+    assert mock_run.call_count == 0
+    # No kepub written.
+    assert not list(target.rglob("*.kepub.epub"))
+
+
+def test_kepubify_missing_exits_3(tmp_path: Path) -> None:
+    db_path = tmp_path / "lib.db"
+    library = tmp_path / "library"
+    _seed(db_path, library)
+    target = _make_kobo_root(tmp_path)
+
+    runner = CliRunner()
+    with patch("bookery.device.kepubify.shutil.which", return_value=None):
+        result = runner.invoke(
+            cli,
+            [
+                "sync", "kobo",
+                "--target", str(target),
+                "--db", str(db_path),
+                "--data-dir", str(tmp_path / "data"),
+            ],
+        )
+
+    assert result.exit_code == 3, result.output
+    assert "kepubify" in result.output.lower()
+
+
+def test_no_target_and_no_detection_fails(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "lib.db"
+    open_library(db_path).close()
+    monkeypatch.setattr("bookery.device.kobo._default_mount_roots", lambda: [])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "sync", "kobo",
+            "--db", str(db_path),
+            "--data-dir", str(tmp_path / "data"),
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "kobo" in result.output.lower()

--- a/tests/e2e/test_sync_cli.py
+++ b/tests/e2e/test_sync_cli.py
@@ -47,11 +47,9 @@ def _fake_kepubify(returncode: int = 0, stderr: str = "", payload: bytes = b"FAK
             return subprocess.CompletedProcess(
                 args=cmd, returncode=0, stdout="kepubify v4.4.0\n", stderr=""
             )
-        # `kepubify -o <out> <epub>` form
-        out_dir = Path(cmd[cmd.index("-o") + 1])
-        epub = Path(cmd[-1])
-        out = out_dir / f"{epub.stem}.kepub.epub"
-        out_dir.mkdir(parents=True, exist_ok=True)
+        # `kepubify -o <out_path> <epub>` form (we pass the full filename).
+        out = Path(cmd[cmd.index("-o") + 1])
+        out.parent.mkdir(parents=True, exist_ok=True)
         if returncode == 0:
             out.write_bytes(payload)
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")

--- a/tests/e2e/test_sync_cli.py
+++ b/tests/e2e/test_sync_cli.py
@@ -107,7 +107,7 @@ def test_sync_copies_kepub_to_target(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     expected = (
-        target / "Books" / "Some Author" / "Some Title" / "Some Title.kepub.epub"
+        target / "Bookery" / "Some Author" / "Some Title" / "Some Title.kepub.epub"
     )
     assert expected.exists()
     assert "Some Title" in result.output

--- a/tests/integration/test_sync_pipeline.py
+++ b/tests/integration/test_sync_pipeline.py
@@ -1,0 +1,153 @@
+# ABOUTME: Integration test for the Kobo sync pipeline (catalog + cache + kepubify stub).
+# ABOUTME: Drives the real LibraryCatalog and KepubCache; only the subprocess is faked.
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kepubify import kepubify_version, run_kepubify
+from bookery.device.kobo import sync_library_to_kobo
+from bookery.metadata.types import BookMetadata
+
+
+def _fake_subprocess(cmd, **_kwargs):
+    if "--version" in cmd:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="kepubify v4.4.0\n", stderr=""
+        )
+    out_dir = Path(cmd[cmd.index("-o") + 1])
+    epub = Path(cmd[-1])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / f"{epub.stem}.kepub.epub"
+    # Make payload deterministic-but-source-dependent so cache lookups behave.
+    out.write_bytes(b"KEPUB:" + epub.read_bytes())
+    return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+
+def _seed(library: Path, db_path: Path, *, n: int) -> None:
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        for i in range(n):
+            epub = library / f"Author {i}" / f"Title {i}" / f"Title {i}.epub"
+            epub.parent.mkdir(parents=True, exist_ok=True)
+            epub.write_bytes(f"EPUB-{i}".encode())
+            catalog.add_book(
+                BookMetadata(
+                    title=f"Title {i}",
+                    authors=[f"Author {i}"],
+                    source_path=epub,
+                ),
+                file_hash=f"hash-{i}",
+                output_path=epub,
+            )
+    finally:
+        conn.close()
+
+
+def test_two_pass_sync_uses_cache(tmp_path: Path) -> None:
+    library = tmp_path / "library"
+    db_path = tmp_path / "lib.db"
+    target = tmp_path / "kobo"
+    target.mkdir()
+    (target / ".kobo").mkdir()
+    cache = KepubCache(tmp_path / "data" / "kepub_cache.db")
+
+    _seed(library, db_path, n=2)
+
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch(
+            "bookery.device.kepubify.subprocess.run", side_effect=_fake_subprocess
+        ) as mock_run,
+    ):
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            first = sync_library_to_kobo(
+                catalog=catalog,
+                target=target,
+                cache=cache,
+                run_kepubify=run_kepubify,
+                kepubify_version=kepubify_version,
+                books_subdir="Books",
+            )
+        finally:
+            conn.close()
+
+        assert len(first.copied) == 2
+        assert len(first.skipped) == 0
+        # 2 conversions + 1 version probe (cached for the rest of this call).
+        first_call_count = mock_run.call_count
+        assert first_call_count >= 3
+
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            second = sync_library_to_kobo(
+                catalog=catalog,
+                target=target,
+                cache=cache,
+                run_kepubify=run_kepubify,
+                kepubify_version=kepubify_version,
+                books_subdir="Books",
+            )
+        finally:
+            conn.close()
+
+        assert len(second.copied) == 0
+        assert len(second.skipped) == 2
+        # Only the version probe runs on second pass (one extra call).
+        assert mock_run.call_count == first_call_count + 1
+
+
+def test_missing_device_file_recopied(tmp_path: Path) -> None:
+    library = tmp_path / "library"
+    db_path = tmp_path / "lib.db"
+    target = tmp_path / "kobo"
+    target.mkdir()
+    (target / ".kobo").mkdir()
+    cache = KepubCache(tmp_path / "data" / "kepub_cache.db")
+    _seed(library, db_path, n=2)
+
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch("bookery.device.kepubify.subprocess.run", side_effect=_fake_subprocess),
+    ):
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            first = sync_library_to_kobo(
+                catalog=catalog,
+                target=target,
+                cache=cache,
+                run_kepubify=run_kepubify,
+                kepubify_version=kepubify_version,
+                books_subdir="Books",
+            )
+        finally:
+            conn.close()
+
+        # Delete one device file before the second sync.
+        first.copied[0].unlink()
+
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            second = sync_library_to_kobo(
+                catalog=catalog,
+                target=target,
+                cache=cache,
+                run_kepubify=run_kepubify,
+                kepubify_version=kepubify_version,
+                books_subdir="Books",
+            )
+        finally:
+            conn.close()
+
+        assert len(second.copied) == 1
+        assert len(second.skipped) == 1
+        assert first.copied[0].exists()

--- a/tests/integration/test_sync_pipeline.py
+++ b/tests/integration/test_sync_pipeline.py
@@ -73,6 +73,7 @@ def test_two_pass_sync_uses_cache(tmp_path: Path) -> None:
                 cache=cache,
                 run_kepubify=run_kepubify,
                 kepubify_version=kepubify_version,
+                workspace_dir=tmp_path / "workspace",
                 books_subdir="Books",
             )
         finally:
@@ -93,6 +94,7 @@ def test_two_pass_sync_uses_cache(tmp_path: Path) -> None:
                 cache=cache,
                 run_kepubify=run_kepubify,
                 kepubify_version=kepubify_version,
+                workspace_dir=tmp_path / "workspace",
                 books_subdir="Books",
             )
         finally:
@@ -126,6 +128,7 @@ def test_missing_device_file_recopied(tmp_path: Path) -> None:
                 cache=cache,
                 run_kepubify=run_kepubify,
                 kepubify_version=kepubify_version,
+                workspace_dir=tmp_path / "workspace",
                 books_subdir="Books",
             )
         finally:
@@ -143,6 +146,7 @@ def test_missing_device_file_recopied(tmp_path: Path) -> None:
                 cache=cache,
                 run_kepubify=run_kepubify,
                 kepubify_version=kepubify_version,
+                workspace_dir=tmp_path / "workspace",
                 books_subdir="Books",
             )
         finally:

--- a/tests/integration/test_sync_pipeline.py
+++ b/tests/integration/test_sync_pipeline.py
@@ -18,10 +18,9 @@ def _fake_subprocess(cmd, **_kwargs):
         return subprocess.CompletedProcess(
             args=cmd, returncode=0, stdout="kepubify v4.4.0\n", stderr=""
         )
-    out_dir = Path(cmd[cmd.index("-o") + 1])
+    out = Path(cmd[cmd.index("-o") + 1])
     epub = Path(cmd[-1])
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out = out_dir / f"{epub.stem}.kepub.epub"
+    out.parent.mkdir(parents=True, exist_ok=True)
     # Make payload deterministic-but-source-dependent so cache lookups behave.
     out.write_bytes(b"KEPUB:" + epub.read_bytes())
     return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")

--- a/tests/unit/test_config_sync.py
+++ b/tests/unit/test_config_sync.py
@@ -1,0 +1,42 @@
+# ABOUTME: Unit tests for the [sync.kobo] section of bookery's TOML config.
+# ABOUTME: Verifies defaults, overrides, and the get_sync_config() helper.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.core.config import get_sync_config, load_config
+
+
+@pytest.fixture
+def _isolated_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("BOOKERY_LIBRARY_ROOT", raising=False)
+    return tmp_path
+
+
+def test_defaults_when_no_sync_section(_isolated_home: Path) -> None:
+    cfg = load_config()
+    assert cfg.sync.kobo.books_subdir == "Books"
+    assert cfg.sync.kobo.auto_detect is True
+
+
+def test_sync_kobo_overrides_parsed(_isolated_home: Path) -> None:
+    config_file = _isolated_home / ".bookery" / "config.toml"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        "[sync.kobo]\n"
+        'books_subdir = "MyBooks"\n'
+        "auto_detect = false\n",
+        encoding="utf-8",
+    )
+    cfg = load_config()
+    assert cfg.sync.kobo.books_subdir == "MyBooks"
+    assert cfg.sync.kobo.auto_detect is False
+
+
+def test_get_sync_config_shortcut(_isolated_home: Path) -> None:
+    sync = get_sync_config()
+    assert sync.kobo.books_subdir == "Books"

--- a/tests/unit/test_config_sync.py
+++ b/tests/unit/test_config_sync.py
@@ -19,7 +19,7 @@ def _isolated_home(
 
 def test_defaults_when_no_sync_section(_isolated_home: Path) -> None:
     cfg = load_config()
-    assert cfg.sync.kobo.books_subdir == "Books"
+    assert cfg.sync.kobo.books_subdir == "Bookery"
     assert cfg.sync.kobo.auto_detect is True
 
 
@@ -39,4 +39,4 @@ def test_sync_kobo_overrides_parsed(_isolated_home: Path) -> None:
 
 def test_get_sync_config_shortcut(_isolated_home: Path) -> None:
     sync = get_sync_config()
-    assert sync.kobo.books_subdir == "Books"
+    assert sync.kobo.books_subdir == "Bookery"

--- a/tests/unit/test_device_kepub_cache.py
+++ b/tests/unit/test_device_kepub_cache.py
@@ -1,0 +1,36 @@
+# ABOUTME: Unit tests for the kepub conversion cache used by Kobo sync.
+# ABOUTME: Verifies key composition (source hash + kepubify version) and round-trip behavior.
+
+from pathlib import Path
+
+from bookery.device.kepub_cache import KepubCache
+
+
+def test_get_returns_none_on_miss(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    assert cache.get("source-hash", "v4.4.0") is None
+
+
+def test_put_then_get_round_trip(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    cache.put("source-hash", "v4.4.0", "kepub-sha")
+    assert cache.get("source-hash", "v4.4.0") == "kepub-sha"
+
+
+def test_different_kepubify_version_misses(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    cache.put("source-hash", "v4.4.0", "kepub-sha")
+    assert cache.get("source-hash", "v4.5.0") is None
+
+
+def test_put_is_idempotent(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    cache.put("source-hash", "v4.4.0", "first")
+    cache.put("source-hash", "v4.4.0", "second")
+    assert cache.get("source-hash", "v4.4.0") == "second"
+
+
+def test_creates_parent_directory(tmp_path: Path) -> None:
+    db = tmp_path / "nested" / "dir" / "kepub.db"
+    KepubCache(db)
+    assert db.parent.exists()

--- a/tests/unit/test_device_kepub_cache.py
+++ b/tests/unit/test_device_kepub_cache.py
@@ -13,21 +13,32 @@ def test_get_returns_none_on_miss(tmp_path: Path) -> None:
 
 def test_put_then_get_round_trip(tmp_path: Path) -> None:
     cache = KepubCache(tmp_path / "kepub.db")
-    cache.put("source-hash", "v4.4.0", "kepub-sha")
+    cache.put("source-hash", "v4.4.0", "kepub-sha", Path("/dev/A/T/T.kepub.epub"))
     assert cache.get("source-hash", "v4.4.0") == "kepub-sha"
 
 
 def test_different_kepubify_version_misses(tmp_path: Path) -> None:
     cache = KepubCache(tmp_path / "kepub.db")
-    cache.put("source-hash", "v4.4.0", "kepub-sha")
+    cache.put("source-hash", "v4.4.0", "kepub-sha", Path("/dev/A/T/T.kepub.epub"))
     assert cache.get("source-hash", "v4.5.0") is None
 
 
 def test_put_is_idempotent(tmp_path: Path) -> None:
     cache = KepubCache(tmp_path / "kepub.db")
-    cache.put("source-hash", "v4.4.0", "first")
-    cache.put("source-hash", "v4.4.0", "second")
+    cache.put("source-hash", "v4.4.0", "first", Path("/dev/A/T/T.kepub.epub"))
+    cache.put("source-hash", "v4.4.0", "second", Path("/dev/A/T/T.kepub.epub"))
     assert cache.get("source-hash", "v4.4.0") == "second"
+
+
+def test_iter_entries_yields_device_paths(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    p1 = Path("/dev/A/T1/T1.kepub.epub")
+    p2 = Path("/dev/B/T2/T2.kepub.epub")
+    cache.put("h1", "v4.4.0", "k1", p1)
+    cache.put("h2", "v4.4.0", "k2", p2)
+    entries = sorted(cache.iter_entries(), key=lambda e: e.source_hash)
+    assert [e.device_path for e in entries] == [p1, p2]
+    assert [e.kepub_sha for e in entries] == ["k1", "k2"]
 
 
 def test_creates_parent_directory(tmp_path: Path) -> None:

--- a/tests/unit/test_device_kepubify.py
+++ b/tests/unit/test_device_kepubify.py
@@ -33,8 +33,45 @@ class TestRunKepubify:
         called_cmd = mock_run.call_args.args[0]
         assert called_cmd[0] == "kepubify"
         assert "-o" in called_cmd
-        assert str(out_dir) in called_cmd
+        # We pass the explicit output filename, not just the directory.
+        # This avoids the v4.0.x `_converted` suffix and any future kepubify
+        # naming changes.
+        assert str(expected) in called_cmd
         assert str(epub) in called_cmd
+
+    def test_uses_explicit_output_filename_not_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: kepubify v4.0.x writes <name>_converted.kepub.epub when
+        given just a directory. We pass `-o <full filename>` to bypass that.
+        """
+        epub = tmp_path / "Hooked.epub"
+        epub.write_bytes(b"x")
+        out_dir = tmp_path / "ws"
+        out_dir.mkdir()
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd, **_kwargs):
+            captured["cmd"] = cmd
+            target = Path(cmd[cmd.index("-o") + 1])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"k")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with (
+            patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+            patch("bookery.device.kepubify.subprocess.run", side_effect=fake_run),
+        ):
+            result = run_kepubify(epub, out_dir=out_dir)
+
+        # The argument after `-o` must be a *file path* ending in .kepub.epub,
+        # never a bare directory.
+        out_arg = captured["cmd"][captured["cmd"].index("-o") + 1]
+        assert out_arg.endswith(".kepub.epub")
+        assert out_arg != str(out_dir)
+        assert result == out_dir / "Hooked.kepub.epub"
+        assert result.exists()
 
     def test_raises_when_binary_missing(self, tmp_path: Path) -> None:
         epub = tmp_path / "book.epub"

--- a/tests/unit/test_device_kepubify.py
+++ b/tests/unit/test_device_kepubify.py
@@ -1,0 +1,83 @@
+# ABOUTME: Unit tests for the kepubify subprocess wrapper used by Kobo sync.
+# ABOUTME: Stubs subprocess.run / shutil.which to verify behavior without the binary.
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bookery.device.errors import KepubifyFailed, KepubifyMissing
+from bookery.device.kepubify import kepubify_version, run_kepubify
+
+
+class TestRunKepubify:
+    def test_invokes_kepubify_and_returns_output_path(self, tmp_path: Path) -> None:
+        epub = tmp_path / "book.epub"
+        epub.write_bytes(b"fake epub")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        expected = out_dir / "book.kepub.epub"
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            expected.write_bytes(b"fake kepub")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with (
+            patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+            patch("bookery.device.kepubify.subprocess.run", side_effect=fake_run) as mock_run,
+        ):
+            result = run_kepubify(epub, out_dir=out_dir)
+
+        assert result == expected
+        called_cmd = mock_run.call_args.args[0]
+        assert called_cmd[0] == "kepubify"
+        assert "-o" in called_cmd
+        assert str(out_dir) in called_cmd
+        assert str(epub) in called_cmd
+
+    def test_raises_when_binary_missing(self, tmp_path: Path) -> None:
+        epub = tmp_path / "book.epub"
+        epub.write_bytes(b"x")
+        with (
+            patch("bookery.device.kepubify.shutil.which", return_value=None),
+            pytest.raises(KepubifyMissing) as exc_info,
+        ):
+            run_kepubify(epub, out_dir=tmp_path)
+        assert exc_info.value.exit_code == 3
+        assert "kepubify" in str(exc_info.value).lower()
+
+    def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
+        epub = tmp_path / "book.epub"
+        epub.write_bytes(b"x")
+        err = subprocess.CalledProcessError(returncode=2, cmd=["kepubify"], stderr="boom")
+        with (
+            patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+            patch("bookery.device.kepubify.subprocess.run", side_effect=err),
+            pytest.raises(KepubifyFailed) as exc_info,
+        ):
+            run_kepubify(epub, out_dir=tmp_path)
+        assert exc_info.value.exit_code == 1
+        assert "boom" in str(exc_info.value)
+
+
+class TestKepubifyVersion:
+    def test_parses_version_string(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["kepubify", "--version"],
+            returncode=0,
+            stdout="kepubify v4.4.0\n",
+            stderr="",
+        )
+        with (
+            patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+            patch("bookery.device.kepubify.subprocess.run", return_value=completed),
+        ):
+            assert kepubify_version() == "v4.4.0"
+
+    def test_raises_when_missing(self) -> None:
+        with (
+            patch("bookery.device.kepubify.shutil.which", return_value=None),
+            pytest.raises(KepubifyMissing),
+        ):
+            kepubify_version()

--- a/tests/unit/test_device_kobo_detect.py
+++ b/tests/unit/test_device_kobo_detect.py
@@ -1,0 +1,49 @@
+# ABOUTME: Unit tests for detect_mounted_kobo() — finds a mounted Kobo by .kobo/ marker.
+# ABOUTME: Uses tmp_path to simulate volumes; no real device required.
+
+from pathlib import Path
+
+from bookery.device.kobo import detect_mounted_kobo
+
+
+def _make_volume(root: Path, name: str, *, with_marker: bool) -> Path:
+    vol = root / name
+    vol.mkdir()
+    if with_marker:
+        (vol / ".kobo").mkdir()
+    return vol
+
+
+def test_returns_path_when_marker_present(tmp_path: Path) -> None:
+    vol = _make_volume(tmp_path, "KOBOeReader", with_marker=True)
+    assert detect_mounted_kobo(candidates=[vol]) == vol
+
+
+def test_returns_none_when_no_marker(tmp_path: Path) -> None:
+    vol = _make_volume(tmp_path, "USB", with_marker=False)
+    assert detect_mounted_kobo(candidates=[vol]) is None
+
+
+def test_returns_first_match_among_multiple(tmp_path: Path) -> None:
+    vol1 = _make_volume(tmp_path, "USB", with_marker=False)
+    vol2 = _make_volume(tmp_path, "KOBOeReader", with_marker=True)
+    vol3 = _make_volume(tmp_path, "OtherKobo", with_marker=True)
+    assert detect_mounted_kobo(candidates=[vol1, vol2, vol3]) == vol2
+
+
+def test_skips_nonexistent_candidates(tmp_path: Path) -> None:
+    vol = _make_volume(tmp_path, "KOBOeReader", with_marker=True)
+    missing = tmp_path / "does-not-exist"
+    assert detect_mounted_kobo(candidates=[missing, vol]) == vol
+
+
+def test_scans_volumes_directories(tmp_path: Path, monkeypatch) -> None:
+    """When candidates is None, scan default platform mount roots."""
+    volumes = tmp_path / "Volumes"
+    volumes.mkdir()
+    _make_volume(volumes, "USB", with_marker=False)
+    kobo = _make_volume(volumes, "KOBOeReader", with_marker=True)
+    monkeypatch.setattr(
+        "bookery.device.kobo._default_mount_roots", lambda: [volumes]
+    )
+    assert detect_mounted_kobo() == kobo

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -300,6 +300,66 @@ def test_non_epub_output_path_is_skipped(tmp_path: Path) -> None:
     assert "not an EPUB" in reason or "epub" in reason.lower()
 
 
+def test_on_stage_emits_full_lifecycle(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    stages: list[str] = []
+
+    def on_stage(stage: str) -> None:
+        stages.append(stage)
+
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        on_stage=on_stage,
+    )
+
+    # First sync: full pipeline.
+    assert stages == ["hash", "convert", "copy", "done"]
+
+
+def test_on_stage_emits_cached_when_skipping(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    # Prime the cache with a successful sync.
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+    )
+
+    stages: list[str] = []
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        on_stage=stages.append,
+    )
+
+    assert stages == ["hash", "cached"]
+
+
 def test_on_progress_callback_invoked_per_record(tmp_path: Path) -> None:
     env = _setup(tmp_path)
     epubs = []

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -300,6 +300,65 @@ def test_non_epub_output_path_is_skipped(tmp_path: Path) -> None:
     assert "not an EPUB" in reason or "epub" in reason.lower()
 
 
+def test_on_progress_callback_invoked_per_record(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epubs = []
+    records = []
+    for i in range(3):
+        epub = env["library"] / f"A{i}" / f"T{i}" / f"T{i}.epub"
+        _write_epub(epub)
+        epubs.append(epub)
+        records.append(_make_record(rec_id=i, title=f"T{i}", author=f"A{i}", epub_path=epub))
+
+    seen: list[tuple[int, int, str]] = []
+
+    def cb(idx: int, total: int, record):  # type: ignore[no-untyped-def]
+        seen.append((idx, total, record.metadata.title))
+
+    sync_library_to_kobo(
+        catalog=StubCatalog(records=records),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        on_progress=cb,
+    )
+
+    assert seen == [
+        (1, 3, "T0"),
+        (2, 3, "T1"),
+        (3, 3, "T2"),
+    ]
+
+
+def test_on_progress_callback_invoked_in_dry_run(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+
+    seen: list[int] = []
+
+    def cb(idx: int, total: int, _record) -> None:  # type: ignore[no-untyped-def]
+        seen.append(idx)
+        assert total == 1
+
+    sync_library_to_kobo(
+        catalog=StubCatalog(records=[record]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        dry_run=True,
+        on_progress=cb,
+    )
+    assert seen == [1]
+
+
 def test_kepubify_failure_is_recorded_not_raised(tmp_path: Path) -> None:
     env = _setup(tmp_path)
     epub = env["library"] / "A" / "T" / "T.epub"

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -70,11 +70,13 @@ def _setup(tmp_path: Path) -> dict[str, Any]:
     target = tmp_path / "kobo"
     cache = KepubCache(tmp_path / "kepub.db")
     kepubify = StubKepubify()
+    workspace = tmp_path / "workspace"
     return {
         "library": library,
         "target": target,
         "cache": cache,
         "kepubify": kepubify,
+        "workspace": workspace,
     }
 
 
@@ -86,6 +88,7 @@ def test_empty_catalog_returns_zero_actions(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
     assert isinstance(report, SyncReport)
@@ -108,6 +111,7 @@ def test_single_book_first_sync_runs_kepubify_and_copies(tmp_path: Path) -> None
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
 
@@ -135,6 +139,7 @@ def test_resync_with_unchanged_files_skips_kepubify(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
     first_call_count = len(env["kepubify"].calls)
@@ -145,6 +150,7 @@ def test_resync_with_unchanged_files_skips_kepubify(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
 
@@ -169,6 +175,7 @@ def test_resync_with_missing_device_file_re_runs(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
     dest = first.copied[0]
@@ -180,6 +187,7 @@ def test_resync_with_missing_device_file_re_runs(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
 
@@ -200,6 +208,7 @@ def test_dry_run_makes_no_writes(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
         dry_run=True,
     )
@@ -228,6 +237,7 @@ def test_record_without_output_path_is_skipped(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
 
@@ -258,6 +268,7 @@ def test_unknown_author_path_component(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
 
@@ -279,6 +290,7 @@ def test_non_epub_output_path_is_skipped(tmp_path: Path) -> None:
         cache=env["cache"],
         run_kepubify=env["kepubify"].run,
         kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
         books_subdir="Books",
     )
 
@@ -304,6 +316,7 @@ def test_kepubify_failure_is_recorded_not_raised(tmp_path: Path) -> None:
             cache=env["cache"],
             run_kepubify=boom,
             kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
             books_subdir="Books",
         )
 

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -1,0 +1,311 @@
+# ABOUTME: Unit tests for sync_library_to_kobo — orchestrates kepubify + cache + copy.
+# ABOUTME: Stubs the kepubify wrapper and uses a real KepubCache + tmp filesystem.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bookery.db.mapping import BookRecord
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kobo import SyncReport, sync_library_to_kobo
+from bookery.metadata.types import BookMetadata
+
+
+class StubKepubify:
+    """Test double for the kepubify subprocess wrapper."""
+
+    def __init__(self, *, version: str = "v4.4.0", payload: bytes = b"FAKE-KEPUB") -> None:
+        self.version = version
+        self.payload = payload
+        self.calls: list[tuple[Path, Path]] = []
+
+    def run(self, epub: Path, *, out_dir: Path) -> Path:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = out_dir / f"{epub.stem}.kepub.epub"
+        result.write_bytes(self.payload)
+        self.calls.append((epub, out_dir))
+        return result
+
+    def get_version(self) -> str:
+        return self.version
+
+
+@dataclass
+class StubCatalog:
+    records: list[BookRecord]
+
+    def list_all(self) -> list[BookRecord]:
+        return list(self.records)
+
+
+def _make_record(
+    *,
+    rec_id: int,
+    title: str,
+    author: str,
+    epub_path: Path,
+    file_hash: str = "deadbeef",
+) -> BookRecord:
+    metadata = BookMetadata(title=title, authors=[author] if author else [])
+    return BookRecord(
+        id=rec_id,
+        metadata=metadata,
+        file_hash=file_hash,
+        source_path=epub_path,
+        output_path=epub_path,
+        date_added="2026-04-18T00:00:00",
+        date_modified="2026-04-18T00:00:00",
+    )
+
+
+def _write_epub(path: Path, body: bytes = b"EPUB-CONTENT") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+
+
+def _setup(tmp_path: Path) -> dict[str, Any]:
+    library = tmp_path / "library"
+    target = tmp_path / "kobo"
+    cache = KepubCache(tmp_path / "kepub.db")
+    kepubify = StubKepubify()
+    return {
+        "library": library,
+        "target": target,
+        "cache": cache,
+        "kepubify": kepubify,
+    }
+
+
+def test_empty_catalog_returns_zero_actions(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    report = sync_library_to_kobo(
+        catalog=StubCatalog(records=[]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+    assert isinstance(report, SyncReport)
+    assert report.copied == []
+    assert report.skipped == []
+    assert report.failed == []
+
+
+def test_single_book_first_sync_runs_kepubify_and_copies(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "Author A" / "Title A" / "Title A.epub"
+    _write_epub(epub)
+    record = _make_record(
+        rec_id=1, title="Title A", author="Author A", epub_path=epub
+    )
+
+    report = sync_library_to_kobo(
+        catalog=StubCatalog(records=[record]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+
+    expected_dest = (
+        env["target"] / "Books" / "Author A" / "Title A" / "Title A.kepub.epub"
+    )
+    assert expected_dest.exists()
+    assert expected_dest.read_bytes() == b"FAKE-KEPUB"
+    assert report.copied == [expected_dest]
+    assert report.skipped == []
+    assert report.failed == []
+    assert len(env["kepubify"].calls) == 1
+
+
+def test_resync_with_unchanged_files_skips_kepubify(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+    first_call_count = len(env["kepubify"].calls)
+
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+
+    assert len(env["kepubify"].calls) == first_call_count, (
+        "kepubify should not be re-invoked when source hash, version and "
+        "on-device hash all match."
+    )
+    assert len(report.skipped) == 1
+    assert len(report.copied) == 0
+
+
+def test_resync_with_missing_device_file_re_runs(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    first = sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+    dest = first.copied[0]
+    dest.unlink()
+
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+
+    assert len(env["kepubify"].calls) == 2
+    assert dest.exists()
+    assert len(report.copied) == 1
+
+
+def test_dry_run_makes_no_writes(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+
+    report = sync_library_to_kobo(
+        catalog=StubCatalog(records=[record]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+        dry_run=True,
+    )
+
+    assert env["kepubify"].calls == []
+    assert not env["target"].exists() or not any(env["target"].rglob("*.kepub.epub"))
+    assert len(report.copied) == 1, "dry-run should still report planned copies"
+
+
+def test_record_without_output_path_is_skipped(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    metadata = BookMetadata(title="Orphan", authors=["Nobody"])
+    record = BookRecord(
+        id=1,
+        metadata=metadata,
+        file_hash="x",
+        source_path=tmp_path / "missing.epub",
+        output_path=None,
+        date_added="",
+        date_modified="",
+    )
+
+    report = sync_library_to_kobo(
+        catalog=StubCatalog(records=[record]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+
+    assert env["kepubify"].calls == []
+    assert len(report.skipped) == 1
+    _path, reason = report.skipped[0]
+    assert "no canonical EPUB" in reason
+
+
+def test_unknown_author_path_component(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "anon" / "Mystery.epub"
+    _write_epub(epub)
+    metadata = BookMetadata(title="Mystery", authors=[])
+    record = BookRecord(
+        id=1,
+        metadata=metadata,
+        file_hash="abc",
+        source_path=epub,
+        output_path=epub,
+        date_added="",
+        date_modified="",
+    )
+
+    sync_library_to_kobo(
+        catalog=StubCatalog(records=[record]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+
+    expected = (
+        env["target"] / "Books" / "Unknown Author" / "Mystery" / "Mystery.kepub.epub"
+    )
+    assert expected.exists()
+
+
+def test_non_epub_output_path_is_skipped(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    pdf = env["library"] / "A" / "T" / "T.pdf"
+    _write_epub(pdf, body=b"%PDF")
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=pdf)
+
+    report = sync_library_to_kobo(
+        catalog=StubCatalog(records=[record]),
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        books_subdir="Books",
+    )
+
+    assert env["kepubify"].calls == []
+    assert len(report.skipped) == 1
+    _, reason = report.skipped[0]
+    assert "not an EPUB" in reason or "epub" in reason.lower()
+
+
+def test_kepubify_failure_is_recorded_not_raised(tmp_path: Path) -> None:
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+
+    def boom(_epub: Path, *, out_dir: Path) -> Path:
+        raise RuntimeError("kepubify crashed")
+
+    with pytest.MonkeyPatch.context():
+        report = sync_library_to_kobo(
+            catalog=StubCatalog(records=[record]),
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=boom,
+            kepubify_version=env["kepubify"].get_version,
+            books_subdir="Books",
+        )
+
+    assert len(report.failed) == 1
+    assert "kepubify crashed" in report.failed[0][1]


### PR DESCRIPTION
## Summary

Implements #68: a new `bookery sync kobo` command that walks the catalog, runs `kepubify` on each EPUB on demand, and copies the result to a mounted Kobo. The library itself stays canonical EPUB; kepub becomes a delivery-format concern owned by the new `device/` subsystem.

## What's in the box

- `bookery sync kobo [--target PATH] [--dry-run]` — auto-detects a Kobo via the `.kobo/` marker; `--target` is the universal escape hatch.
- Files written to `<kobo>/Bookery/Author/Title/Title.kepub.epub` — dedicated subdirectory keeps synced content visibly separate from Calibre sideloads, store purchases, and library borrows. Configurable via `[sync.kobo] books_subdir` if you'd rather use `Books/`.
- SQLite cache at `{data_dir}/kepub_cache.db` keyed on `(sha256(epub), kepubify --version)` plus the on-device path. Re-syncs of unchanged books invoke kepubify zero times.
- Two-line Rich progress UI:
  ```
  Syncing ━━━━━━━━━━━━━━━━━━━━ 234/620 • 0:03:24
  └─ How to Win Friends and Influence People  [converting]
  ```
- Per-book failures (stale catalog rows, un-convertible EPUBs) are surfaced as warnings; only hard errors (kepubify missing, no Kobo detected) exit non-zero.

## Architecture

```
cli/commands/sync_cmd.py    bookery sync kobo [--target] [--dry-run]
        │
        ▼
device/kobo.py              detect_mounted_kobo(), sync_library_to_kobo()
        │                   on_progress + on_stage callbacks → SyncReport
        ├──► device/kepub_cache.py     SQLite keyed on source hash + kepubify version
        └──► device/kepubify.py        run_kepubify(), kepubify_version()
```

## Notable correctness details

- **kepubify v4.0.x quirk fixed.** With `-o <directory>`, kepubify v4.0.x writes `<name>_converted.kepub.epub` while v4.4+ writes `<name>.kepub.epub`. We pass `-o <full filename>` to control naming regardless of version. Caught and fixed during a real 620-book sync run; regression test in `test_device_kepubify.py`.
- **Workspace lives under `data_dir`.** Earlier draft used `target.parent` which would have written to `/Volumes` itself on macOS.
- **Streaming copy.** `shutil.move` instead of `read_bytes`/`write_bytes` so 100MB books don't blow up RAM.
- **Reuses `db.hashing.compute_file_hash`** instead of duplicating SHA-256 chunked-read logic.

## Changes

- **New** `src/bookery/device/{kobo,kepubify,kepub_cache,errors}.py`
- **New** `src/bookery/cli/commands/sync_cmd.py` + registration in `cli/__init__.py`
- **Updated** `src/bookery/core/config.py` with `SyncConfig` / `SyncKoboConfig`
- **Updated** `README.md` (removed stale "PDF→kepub variant" claim from PR #71's path; added device sync section) and `docs/config.example.toml`
- **Tests:** unit (5 files), integration (1), e2e (1) — 1038 total passing

## Testing

- [x] Full unit + integration + e2e suite passing (1038 tests)
- [x] Lint (`ruff`), format, and pyright clean via pre-commit
- [x] Live smoke test: 620 books synced from real catalog to a fake Kobo mount
- [x] Live smoke test: dry-run shows planned actions without writes
- [x] Live smoke test: re-sync with no changes performs zero kepubify invocations

## Follow-ups filed

- #73 — `--prune` flag to delete on-device files we wrote when their catalog entry is gone (cache schema already has `device_path` and `iter_entries()` to support this).
- #74 — Catalog hygiene command to clean up stale `source_path` rows.

## Related

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)