### PR TITLE
Fix: disable pandoc multiline_tables so vault chapters and cross-note links survive

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,42 @@ cache at `{data_dir}/kepub_cache.db` keyed on the source EPUB hash plus
 the `kepubify` version makes re-syncs effectively free when nothing has
 changed.
 
+### The `vault-export` workflow
+
+Turn an Obsidian vault into a single EPUB — one chapter per note, with a
+clickable TOC, resolved `[[wiki-links]]` and `![[image]]` embeds, and an
+optional tag index at the end. Requires [pandoc](https://pandoc.org)
+(`brew install pandoc` on macOS).
+
+Run with flags:
+
+```bash
+bookery vault-export --vault ~/obsidian-vault -o vault.epub \
+  --folder "3_Permanent Notes" --folder "2_Literature Notes" \
+  --index --exclude-tag type/meeting
+```
+
+Or set defaults once in `~/.bookery/config.toml` and just run
+`bookery vault-export -o vault.epub`:
+
+```toml
+[vault_export]
+vault_path = "~/obsidian-vault"
+folders = ["3_Permanent Notes", "2_Literature Notes"]
+include_index = true
+index_exclude_prefixes = ["type/"]   # hide tags like `type/permanent` from index
+index_min_count = 1
+exclude_tags = ["type/meeting"]      # drop notes with these exact frontmatter tags
+default_author = "Your Name"
+uuid_mode = "stable"                 # "stable" keeps the same dc:identifier
+                                     # across re-exports so Kobo updates in place
+```
+
+`exclude_tags` matches the full tag string exactly (`type/meeting` skips
+notes tagged `type/meeting` but not `type/permanent`). Callouts, block
+references, note embeds (`![[note]]`), and Dataview queries are **not**
+resolved in this version.
+
 ### The `match` workflow
 
 When you run `bookery match`, Bookery will:

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -68,6 +68,11 @@ max_tokens = 262144
 #   uuid_mode = "stable"        # "stable" reuses the dc:identifier across
 #                               # exports so re-sync to Kobo updates the book
 #                               # in place; "random" produces a fresh id.
+#   exclude_tags = ["type/meeting", "type/daily"]
+#                               # Skip any note whose frontmatter tags include
+#                               # one of these exact strings. Useful for
+#                               # keeping ephemeral notes (meetings, dailies)
+#                               # out of an archive export.
 
 # ---------------------------------------------------------------------------
 # Notes

--- a/src/bookery/cli/commands/vault_export_cmd.py
+++ b/src/bookery/cli/commands/vault_export_cmd.py
@@ -47,6 +47,9 @@ console = Console()
               help="Suppress tags starting with this prefix from the index (repeatable).")
 @click.option("--index-min-count", "index_min_count_opt", type=int, default=None,
               help="Hide tags with fewer than N notes in the index.")
+@click.option("--exclude-tag", "exclude_tags_opt", multiple=True,
+              help="Skip any note whose frontmatter tags include this exact tag "
+                   "(repeatable). Overrides vault_export.exclude_tags in config.")
 @click.option("--title", "title_opt", default=None, help="EPUB title metadata.")
 @click.option("--author", "author_opt", default=None, help="EPUB author metadata.")
 @click.option("--uuid", "uuid_opt",
@@ -61,6 +64,7 @@ def vault_export(
     index_opt: bool | None,
     index_exclude_opt: tuple[str, ...],
     index_min_count_opt: int | None,
+    exclude_tags_opt: tuple[str, ...],
     title_opt: str | None,
     author_opt: str | None,
     uuid_opt: str | None,
@@ -85,6 +89,7 @@ def vault_export(
     include_index = cfg.include_index if index_opt is None else index_opt
     exclude_prefixes = list(index_exclude_opt) if index_exclude_opt else cfg.index_exclude_prefixes
     min_count = index_min_count_opt if index_min_count_opt is not None else cfg.index_min_count
+    exclude_tags = list(exclude_tags_opt) if exclude_tags_opt else cfg.exclude_tags
     author = author_opt or cfg.default_author
     uuid_mode = (uuid_opt or cfg.uuid_mode).lower()
     version_label = version_label_opt or date.today().isoformat()
@@ -122,7 +127,12 @@ def vault_export(
             overall.update(overall_task, completed=idx, total=total)
             current.update(current_task, description=path.name)
 
-        notes = walk_vault(vault_path, folders=folders or None, on_progress=_on_walk)
+        notes = walk_vault(
+            vault_path,
+            folders=folders or None,
+            on_progress=_on_walk,
+            exclude_tags=exclude_tags or None,
+        )
         if not notes:
             raise click.UsageError(f"no markdown notes found in {vault_path}")
 

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -68,6 +68,7 @@ class VaultExportConfig:
     index_min_count: int = 1
     default_author: str = "Obsidian Vault"
     uuid_mode: str = "stable"  # "stable" | "random"
+    exclude_tags: list[str] = field(default_factory=list)  # "stable" | "random"
 
 
 @dataclass(frozen=True)
@@ -138,6 +139,7 @@ def _parse_vault_export(section: dict[str, Any] | None) -> VaultExportConfig:
     vault_path = Path(str(raw_path)).expanduser() if raw_path else None
     folders = [str(x) for x in section.get("folders", [])]
     exclude = [str(x) for x in section.get("index_exclude_prefixes", [])]
+    exclude_tags = [str(x) for x in section.get("exclude_tags", [])]
     return VaultExportConfig(
         vault_path=vault_path,
         folders=folders,
@@ -146,6 +148,7 @@ def _parse_vault_export(section: dict[str, Any] | None) -> VaultExportConfig:
         index_min_count=int(section.get("index_min_count", 1)),
         default_author=str(section.get("default_author", "Obsidian Vault")),
         uuid_mode=str(section.get("uuid_mode", "stable")),
+        exclude_tags=exclude_tags,
     )
 
 

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -68,7 +68,7 @@ class VaultExportConfig:
     index_min_count: int = 1
     default_author: str = "Obsidian Vault"
     uuid_mode: str = "stable"  # "stable" | "random"
-    exclude_tags: list[str] = field(default_factory=list)  # "stable" | "random"
+    exclude_tags: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/src/bookery/core/vault/epub.py
+++ b/src/bookery/core/vault/epub.py
@@ -65,13 +65,17 @@ def render_epub(
         if metadata.version_label:
             title = f"{title} — {metadata.version_label}"
 
-        # Disable the yaml_metadata_block extension so stray `---` lines in
-        # note bodies (frontmatter remnants, horizontal rules) do not get
-        # interpreted as document metadata and fail the YAML parser.
+        # Disable yaml_metadata_block so stray `---` lines in note bodies
+        # (frontmatter remnants, horizontal rules) do not get interpreted as
+        # document metadata. Disable multiline_tables because it greedily
+        # consumes subsequent `# Heading` lines into a single sprawling table
+        # once any note body contains a `---` thematic break, which dropped
+        # hundreds of chapters and broke every cross-note link in real-world
+        # vault exports.
         cmd = [
             pandoc,
             "-f",
-            "markdown-yaml_metadata_block",
+            "markdown-yaml_metadata_block-multiline_tables",
             "-t",
             "epub",
             "--toc",

--- a/src/bookery/core/vault/walker.py
+++ b/src/bookery/core/vault/walker.py
@@ -16,13 +16,17 @@ def walk_vault(
     vault_path: Path,
     folders: list[str] | None = None,
     on_progress: WalkProgressFn | None = None,
+    exclude_tags: list[str] | None = None,
 ) -> list[Note]:
     """Walk a vault and return Note objects for every markdown file found.
 
     Hidden directories (dotfiles like `.obsidian`) and hidden files are skipped.
     Non-`.md` files are ignored. When `folders` is provided, only descendants of
-    those top-level folders are included.
+    those top-level folders are included. When `exclude_tags` is provided, any
+    note whose frontmatter `tags` list contains one of those exact tag strings
+    is dropped from the result.
     """
+    excluded = set(exclude_tags or [])
     vault_path = vault_path.expanduser()
     roots = [vault_path / f for f in folders] if folders else [vault_path]
 
@@ -43,6 +47,8 @@ def walk_vault(
             on_progress(idx, total, md)
         text = md.read_text(encoding="utf-8")
         body, fm, tags = parse_frontmatter(text)
+        if excluded and any(t in excluded for t in tags):
+            continue
         fm_title = fm.get("title") if isinstance(fm.get("title"), str) else None
         title = resolve_title(fm_title, body, md)
         rel_folder = _relative_folder(md, vault_path)

--- a/tests/unit/test_config_vault_export.py
+++ b/tests/unit/test_config_vault_export.py
@@ -43,6 +43,7 @@ index_exclude_prefixes = ["type/"]
 index_min_count = 2
 default_author = "Joe"
 uuid_mode = "random"
+exclude_tags = ["type/meeting", "type/daily"]
 """,
     )
     cfg = load_config()
@@ -55,3 +56,4 @@ uuid_mode = "random"
     assert ve.index_min_count == 2
     assert ve.default_author == "Joe"
     assert ve.uuid_mode == "random"
+    assert ve.exclude_tags == ["type/meeting", "type/daily"]

--- a/tests/unit/test_vault_epub.py
+++ b/tests/unit/test_vault_epub.py
@@ -25,6 +25,42 @@ def test_pandoc_missing_raises(monkeypatch, tmp_path: Path):
         )
 
 
+def test_render_disables_multiline_tables_extension(monkeypatch, tmp_path: Path):
+    """Pandoc's ``multiline_tables`` extension greedily consumes H1 headings as
+    table rows whenever a note body contains a ``---`` thematic break, dropping
+    hundreds of chapters from large vault exports and leaving cross-note links
+    as bare ``#slug`` fragments that never navigate. The extension must be
+    disabled via the input format spec.
+    """
+    captured: dict[str, list[str]] = {}
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def _fake_run(cmd, capture_output, text, cwd):
+        captured["cmd"] = cmd
+        # Produce an empty file so downstream code does not blow up.
+        out_idx = cmd.index("-o") + 1
+        Path(cmd[out_idx]).write_bytes(b"")
+        return _Result()
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/pandoc")
+    render_epub(
+        "# One {#one}\n",
+        [],
+        EpubMetadata(title="T", author="A", identifier=stable_uuid(tmp_path)),
+        tmp_path / "x.epub",
+    )
+    fmt = captured["cmd"][captured["cmd"].index("-f") + 1]
+    assert "-multiline_tables" in fmt, (
+        f"expected multiline_tables extension to be disabled; got -f {fmt!r}"
+    )
+
+
 @pandoc_required
 def test_render_produces_epub_with_identifier(tmp_path: Path):
     out = tmp_path / "v.epub"

--- a/tests/unit/test_vault_walker.py
+++ b/tests/unit/test_vault_walker.py
@@ -22,6 +22,42 @@ def test_walks_entire_vault_when_no_folders(tmp_path: Path):
     assert titles == ["A", "B", "C-heading"]
 
 
+def test_exclude_tags_drops_notes_with_matching_frontmatter_tag(tmp_path: Path):
+    _write(
+        tmp_path / "meeting.md",
+        "---\ntags:\n  - type/meeting\n  - nextgres\n---\n# Meeting\n",
+    )
+    _write(
+        tmp_path / "idea.md",
+        "---\ntags:\n  - type/permanent\n---\n# Idea\n",
+    )
+    _write(tmp_path / "untagged.md", "# Untagged\n")
+
+    notes = walk_vault(tmp_path, exclude_tags=["type/meeting"])
+
+    titles = sorted(n.title for n in notes)
+    assert titles == ["Idea", "Untagged"]
+
+
+def test_exclude_tags_empty_list_keeps_all_notes(tmp_path: Path):
+    _write(tmp_path / "a.md", "---\ntags:\n  - foo\n---\n# A\n")
+    _write(tmp_path / "b.md", "# B\n")
+
+    notes = walk_vault(tmp_path, exclude_tags=[])
+
+    assert sorted(n.title for n in notes) == ["A", "B"]
+
+
+def test_exclude_tags_matches_any_of_several_excluded(tmp_path: Path):
+    _write(tmp_path / "m.md", "---\ntags:\n  - type/meeting\n---\n# M\n")
+    _write(tmp_path / "d.md", "---\ntags:\n  - type/daily\n---\n# D\n")
+    _write(tmp_path / "p.md", "---\ntags:\n  - type/permanent\n---\n# P\n")
+
+    notes = walk_vault(tmp_path, exclude_tags=["type/meeting", "type/daily"])
+
+    assert [n.title for n in notes] == ["P"]
+
+
 def test_folder_whitelist_filters_other_dirs(tmp_path: Path):
     _write(tmp_path / "Permanent/x.md", "# X\n")
     _write(tmp_path / "Literature/y.md", "# Y\n")


### PR DESCRIPTION
## Summary

- Pandoc's `multiline_tables` extension was greedily consuming `# Heading` lines as table rows whenever a note body contained a `---` thematic break.
- Real-vault impact: 313 of 712 notes silently dropped from the EPUB, and every cross-note wiki-link to a dropped target rendered as a bare `#slug` fragment — tapping the link just scrolled in-place instead of navigating to the target chapter.
- Fix disables the extension via the pandoc `-f markdown-yaml_metadata_block-multiline_tables` format spec. `pipe_tables`, `simple_tables`, and `grid_tables` remain enabled so legitimate note tables still render.

## Test plan

- [x] Unit test asserts the pandoc command disables `multiline_tables`
- [x] `uv run pytest` (1109 passed)
- [x] Real vault export: chapter count 400 → 714, and `href="ch454.xhtml#memory-palace-as-universal-knowledge-architecture"` confirms cross-chapter link rewriting now works
- [ ] Re-sync to Kobo and verify tapping a link in the Memory Craft note navigates to the target note