### PR TITLE
Add vault-export --catalog flag for one-step export-to-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ resolved in this version.
 
 With `catalog = true` (or `--catalog` on the command line), the export is
 imported into the library and then deployed to your reader on the next
-`bookery sync kobo` — no separate `bookery add` step. Re-running the export
-will add a new catalog row each time the vault content changes (import
-dedupes on file hash, not on EPUB identifier).
+`bookery sync kobo` — no separate `bookery add` step. A vault export is a
+point-in-time snapshot, so re-running replaces the prior catalog row and
+EPUB rather than piling up a new copy each day.
 
 ### The `match` workflow
 

--- a/README.md
+++ b/README.md
@@ -188,12 +188,20 @@ exclude_tags = ["type/meeting"]      # drop notes with these exact frontmatter t
 default_author = "Your Name"
 uuid_mode = "stable"                 # "stable" keeps the same dc:identifier
                                      # across re-exports so Kobo updates in place
+catalog = true                       # auto-add the EPUB to the bookery library
+                                     # so it ships on the next `sync kobo`
 ```
 
 `exclude_tags` matches the full tag string exactly (`type/meeting` skips
 notes tagged `type/meeting` but not `type/permanent`). Callouts, block
 references, note embeds (`![[note]]`), and Dataview queries are **not**
 resolved in this version.
+
+With `catalog = true` (or `--catalog` on the command line), the export is
+imported into the library and then deployed to your reader on the next
+`bookery sync kobo` — no separate `bookery add` step. Re-running the export
+will add a new catalog row each time the vault content changes (import
+dedupes on file hash, not on EPUB identifier).
 
 ### The `match` workflow
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -73,6 +73,10 @@ max_tokens = 262144
 #                               # one of these exact strings. Useful for
 #                               # keeping ephemeral notes (meetings, dailies)
 #                               # out of an archive export.
+#   catalog = true              # After a successful export, add the EPUB to
+#                               # the bookery library so it ships on the next
+#                               # `bookery sync kobo`. Override per-run with
+#                               # `--catalog` / `--no-catalog`.
 
 # ---------------------------------------------------------------------------
 # Notes

--- a/src/bookery/cli/commands/vault_export_cmd.py
+++ b/src/bookery/cli/commands/vault_export_cmd.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from datetime import date
 from pathlib import Path
 
@@ -200,6 +201,22 @@ def vault_export(
         conn = open_library(db_path or DEFAULT_DB_PATH)
         try:
             catalog = LibraryCatalog(conn)
+            # A vault export is a point-in-time snapshot — only one version
+            # should exist in the catalog at a time. Drop any prior row whose
+            # title starts with the un-versioned vault title (the version
+            # label is appended by `render_epub`, e.g. "Foo Vault — 2026-…").
+            removed_ids: list[int] = []
+            for record in catalog.list_all():
+                if record.metadata.title.startswith(title):
+                    if record.output_path and Path(record.output_path).exists():
+                        with contextlib.suppress(OSError):
+                            Path(record.output_path).unlink()
+                    catalog.delete_book(record.id)
+                    removed_ids.append(record.id)
+            if removed_ids:
+                console.print(
+                    f"[dim]replacing {len(removed_ids)} prior vault export(s)[/dim]"
+                )
             result = import_books(
                 [output_path],
                 catalog,

--- a/src/bookery/cli/commands/vault_export_cmd.py
+++ b/src/bookery/cli/commands/vault_export_cmd.py
@@ -18,7 +18,10 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
-from bookery.core.config import load_config
+from bookery.cli._match_helpers import build_progress_fn
+from bookery.cli.options import db_option
+from bookery.core.config import get_library_root, load_config
+from bookery.core.importer import import_books
 from bookery.core.vault.assemble import assemble_vault
 from bookery.core.vault.epub import (
     EpubMetadata,
@@ -29,6 +32,8 @@ from bookery.core.vault.epub import (
     stable_uuid,
 )
 from bookery.core.vault.walker import walk_vault
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import DEFAULT_DB_PATH, open_library
 
 console = Console()
 
@@ -57,6 +62,10 @@ console = Console()
               help="EPUB identifier strategy. stable=deterministic for re-sync.")
 @click.option("--version-label", "version_label_opt", default=None,
               help="Version label injected into the EPUB title (default: today's date).")
+@click.option("--catalog/--no-catalog", "catalog_opt", default=None,
+              help="Add the exported EPUB to the bookery library so it syncs on the "
+                   "next `sync kobo`. Overrides vault_export.catalog in config.")
+@db_option
 def vault_export(
     vault_opt: Path | None,
     folders_opt: tuple[str, ...],
@@ -69,6 +78,8 @@ def vault_export(
     author_opt: str | None,
     uuid_opt: str | None,
     version_label_opt: str | None,
+    catalog_opt: bool | None,
+    db_path: Path | None,
 ) -> None:
     """Export an Obsidian vault to a single EPUB with a clickable TOC.
 
@@ -90,6 +101,7 @@ def vault_export(
     exclude_prefixes = list(index_exclude_opt) if index_exclude_opt else cfg.index_exclude_prefixes
     min_count = index_min_count_opt if index_min_count_opt is not None else cfg.index_min_count
     exclude_tags = list(exclude_tags_opt) if exclude_tags_opt else cfg.exclude_tags
+    do_catalog = cfg.catalog if catalog_opt is None else catalog_opt
     author = author_opt or cfg.default_author
     uuid_mode = (uuid_opt or cfg.uuid_mode).lower()
     version_label = version_label_opt or date.today().isoformat()
@@ -179,3 +191,36 @@ def vault_export(
             f"notes without tags: {', '.join(assembled.notes_without_tags[:5])}"
             + (" …" if len(assembled.notes_without_tags) > 5 else "")
         )
+
+    if do_catalog:
+        library_root = get_library_root()
+        console.print(
+            f"Cataloging into [bold]{library_root}[/bold]…"
+        )
+        conn = open_library(db_path or DEFAULT_DB_PATH)
+        try:
+            catalog = LibraryCatalog(conn)
+            result = import_books(
+                [output_path],
+                catalog,
+                library_root=library_root,
+                match_fn=None,
+                move=False,
+                on_progress=build_progress_fn(console),
+            )
+        finally:
+            conn.close()
+
+        parts = []
+        if result.added:
+            parts.append(f"[green]{result.added} added[/green]")
+        if result.skipped:
+            parts.append(f"[yellow]{result.skipped} skipped[/yellow]")
+        if result.errors:
+            parts.append(f"[red]{result.errors} error(s)[/red]")
+        if parts:
+            console.print(", ".join(parts))
+        if result.errors:
+            for path, msg in result.error_details:
+                console.print(f"  [dim]{path.name}:[/dim] {msg}")
+            raise click.exceptions.Exit(1)

--- a/src/bookery/cli/commands/vault_export_cmd.py
+++ b/src/bookery/cli/commands/vault_export_cmd.py
@@ -35,6 +35,7 @@ from bookery.core.vault.epub import (
 from bookery.core.vault.walker import walk_vault
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import DEFAULT_DB_PATH, open_library
+from bookery.db.hashing import compute_file_hash
 
 console = Console()
 
@@ -201,22 +202,6 @@ def vault_export(
         conn = open_library(db_path or DEFAULT_DB_PATH)
         try:
             catalog = LibraryCatalog(conn)
-            # A vault export is a point-in-time snapshot — only one version
-            # should exist in the catalog at a time. Drop any prior row whose
-            # title starts with the un-versioned vault title (the version
-            # label is appended by `render_epub`, e.g. "Foo Vault — 2026-…").
-            removed_ids: list[int] = []
-            for record in catalog.list_all():
-                if record.metadata.title.startswith(title):
-                    if record.output_path and Path(record.output_path).exists():
-                        with contextlib.suppress(OSError):
-                            Path(record.output_path).unlink()
-                    catalog.delete_book(record.id)
-                    removed_ids.append(record.id)
-            if removed_ids:
-                console.print(
-                    f"[dim]replacing {len(removed_ids)} prior vault export(s)[/dim]"
-                )
             result = import_books(
                 [output_path],
                 catalog,
@@ -225,6 +210,40 @@ def vault_export(
                 move=False,
                 on_progress=build_progress_fn(console),
             )
+            # A vault export is a point-in-time snapshot — only one version
+            # should exist in the catalog at a time. After a successful
+            # import, drop any prior row that looks like an older snapshot of
+            # the same vault: same un-versioned title prefix (the version
+            # label is appended by `render_epub`, e.g. "Foo Vault — 2026-…")
+            # AND same author. The two-key match prevents wiping unrelated
+            # books like "Notes from Underground" when the vault is titled
+            # "Notes". Skip the row we just inserted, and never unlink the
+            # file we just imported.
+            removed = 0
+            if result.added:
+                new_hash = compute_file_hash(output_path)
+                new_record = catalog.get_by_hash(new_hash)
+                new_id = new_record.id if new_record else None
+                output_resolved = output_path.resolve()
+                title_prefix = f"{title} — "
+                for record in catalog.list_all():
+                    if record.id == new_id:
+                        continue
+                    if not record.metadata.title.startswith(title_prefix):
+                        continue
+                    if record.metadata.author != author:
+                        continue
+                    if record.output_path:
+                        path = Path(record.output_path)
+                        if path.exists() and path.resolve() != output_resolved:
+                            with contextlib.suppress(OSError):
+                                path.unlink()
+                    catalog.delete_book(record.id)
+                    removed += 1
+            if removed:
+                console.print(
+                    f"[dim]replaced {removed} prior vault export(s)[/dim]"
+                )
         finally:
             conn.close()
 

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -69,6 +69,7 @@ class VaultExportConfig:
     default_author: str = "Obsidian Vault"
     uuid_mode: str = "stable"  # "stable" | "random"
     exclude_tags: list[str] = field(default_factory=list)
+    catalog: bool = False
 
 
 @dataclass(frozen=True)
@@ -149,6 +150,7 @@ def _parse_vault_export(section: dict[str, Any] | None) -> VaultExportConfig:
         default_author=str(section.get("default_author", "Obsidian Vault")),
         uuid_mode=str(section.get("uuid_mode", "stable")),
         exclude_tags=exclude_tags,
+        catalog=bool(section.get("catalog", False)),
     )
 
 

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -80,6 +80,49 @@ def test_vault_export_catalog_flag_imports_into_library(
     assert library_copies, f"no EPUB found in library root: {result.output}"
 
 
+def test_vault_export_catalog_replaces_prior_export(
+    tmp_path: Path, _isolate_library_root: Path,
+) -> None:
+    """A vault export is a point-in-time snapshot — running `--catalog` twice
+    must leave exactly one row in the catalog and one EPUB on disk, even when
+    the version label (or pandoc's `dc:date`) differs between runs.
+    """
+    from bookery.db.catalog import LibraryCatalog
+    from bookery.db.connection import open_library
+
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    db = tmp_path / "library.db"
+
+    args = [
+        "vault-export", "--vault", str(FIXTURE),
+        "-o", str(out),
+        "--catalog", "--db", str(db),
+    ]
+
+    first = runner.invoke(
+        cli, [*args, "--version-label", "v1"], catch_exceptions=False,
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        cli, [*args, "--version-label", "v2"], catch_exceptions=False,
+    )
+    assert second.exit_code == 0, second.output
+    assert "replacing 1 prior vault export" in second.output
+
+    conn = open_library(db)
+    try:
+        records = LibraryCatalog(conn).list_all()
+    finally:
+        conn.close()
+    assert len(records) == 1, [r.metadata.title for r in records]
+    assert records[0].metadata.title.endswith("v2")
+
+    library_epubs = list(_isolate_library_root.rglob("*.epub"))
+    assert len(library_epubs) == 1, library_epubs
+
+
 def test_vault_export_rejects_missing_vault(tmp_path: Path):
     runner = CliRunner()
     bad = tmp_path / "does-not-exist"

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -109,7 +109,7 @@ def test_vault_export_catalog_replaces_prior_export(
         cli, [*args, "--version-label", "v2"], catch_exceptions=False,
     )
     assert second.exit_code == 0, second.output
-    assert "replacing 1 prior vault export" in second.output
+    assert "replaced 1 prior vault export" in second.output
 
     conn = open_library(db)
     try:
@@ -121,6 +121,114 @@ def test_vault_export_catalog_replaces_prior_export(
 
     library_epubs = list(_isolate_library_root.rglob("*.epub"))
     assert len(library_epubs) == 1, library_epubs
+
+
+def test_vault_export_catalog_does_not_clobber_unrelated_books(
+    tmp_path: Path, _isolate_library_root: Path,
+) -> None:
+    """`--catalog` must only replace prior snapshots of the *same* vault. A
+    real book whose title happens to start with the vault title (e.g. "Notes
+    from Underground" when the vault title is "Notes") must NOT be deleted.
+    """
+    from bookery.db.catalog import LibraryCatalog
+    from bookery.db.connection import open_library
+    from bookery.metadata.types import BookMetadata
+
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    db = tmp_path / "library.db"
+
+    # Seed the catalog with an unrelated book whose title shares the same
+    # prefix the vault export will use ("Notes ").
+    conn = open_library(db)
+    try:
+        catalog = LibraryCatalog(conn)
+        catalog.add_book(
+            BookMetadata(
+                title="Notes from Underground",
+                authors=["Fyodor Dostoevsky"],
+                source_path=tmp_path / "fake-dostoevsky.epub",
+            ),
+            file_hash="seed-hash-unrelated-book",
+        )
+    finally:
+        conn.close()
+
+    # Stub import_books so we don't need a real EPUB on disk for the seeded
+    # row's hash check; we only care that the prune step leaves it alone.
+    args = [
+        "vault-export", "--vault", str(FIXTURE),
+        "-o", str(out),
+        "--title", "Notes",
+        "--author", "Joe Cotellese",
+        "--catalog", "--db", str(db),
+    ]
+    result = runner.invoke(cli, args, catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    conn = open_library(db)
+    try:
+        titles = sorted(r.metadata.title for r in LibraryCatalog(conn).list_all())
+    finally:
+        conn.close()
+    assert "Notes from Underground" in titles, titles
+
+
+def test_vault_export_catalog_preserves_prior_when_import_fails(
+    tmp_path: Path, _isolate_library_root: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `import_books` fails after the EPUB renders, the prior vault row
+    must remain in the catalog. We must never delete the user's last good
+    snapshot until the new one is safely cataloged.
+    """
+    from bookery.db.catalog import LibraryCatalog
+    from bookery.db.connection import open_library
+    from bookery.metadata.types import BookMetadata
+
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    db = tmp_path / "library.db"
+
+    # Seed a prior snapshot the prune step would otherwise match.
+    conn = open_library(db)
+    try:
+        LibraryCatalog(conn).add_book(
+            BookMetadata(
+                title="vault Vault — v0",
+                authors=["Obsidian Vault"],
+                source_path=tmp_path / "fake-prior-vault.epub",
+            ),
+            file_hash="seed-hash-prior-snapshot",
+        )
+    finally:
+        conn.close()
+
+    def _explode(*_args, **_kwargs):
+        from bookery.core.importer import ImportResult
+        return ImportResult(added=0, errors=1, error_details=[(out, "boom")])
+
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.import_books", _explode,
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "vault-export", "--vault", str(FIXTURE),
+            "-o", str(out),
+            "--title", "vault Vault",
+            "--catalog", "--db", str(db),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, result.output
+
+    conn = open_library(db)
+    try:
+        titles = [r.metadata.title for r in LibraryCatalog(conn).list_all()]
+    finally:
+        conn.close()
+    assert titles == ["vault Vault — v0"], titles
 
 
 def test_vault_export_rejects_missing_vault(tmp_path: Path):

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -56,6 +56,30 @@ def test_vault_export_stable_identifier_across_runs(tmp_path: Path):
     assert ids1 == ids2
 
 
+def test_vault_export_catalog_flag_imports_into_library(
+    tmp_path: Path, _isolate_library_root: Path,
+) -> None:
+    """`--catalog` should append the produced EPUB into the bookery catalog so
+    it ships on the next `bookery sync kobo` without a separate `bookery add`.
+    """
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    db = tmp_path / "library.db"
+    result = runner.invoke(
+        cli,
+        [
+            "vault-export", "--vault", str(FIXTURE),
+            "-o", str(out),
+            "--catalog", "--db", str(db),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "added" in result.output
+    library_copies = list(_isolate_library_root.rglob("*.epub"))
+    assert library_copies, f"no EPUB found in library root: {result.output}"
+
+
 def test_vault_export_rejects_missing_vault(tmp_path: Path):
     runner = CliRunner()
     bad = tmp_path / "does-not-exist"

--- a/tests/unit/test_config_vault_export.py
+++ b/tests/unit/test_config_vault_export.py
@@ -26,6 +26,7 @@ def test_defaults_when_section_missing(monkeypatch, tmp_path: Path):
     assert ve.index_min_count == 1
     assert ve.default_author == "Obsidian Vault"
     assert ve.uuid_mode == "stable"
+    assert ve.catalog is False
 
 
 def test_parses_vault_export_section(monkeypatch, tmp_path: Path):
@@ -44,6 +45,7 @@ index_min_count = 2
 default_author = "Joe"
 uuid_mode = "random"
 exclude_tags = ["type/meeting", "type/daily"]
+catalog = true
 """,
     )
     cfg = load_config()
@@ -57,3 +59,4 @@ exclude_tags = ["type/meeting", "type/daily"]
     assert ve.default_author == "Joe"
     assert ve.uuid_mode == "random"
     assert ve.exclude_tags == ["type/meeting", "type/daily"]
+    assert ve.catalog is True


### PR DESCRIPTION
## Summary

- New `--catalog / --no-catalog` flag on `bookery vault-export` (and `vault_export.catalog = true` in config)
- After a successful render, the produced EPUB is imported into the library catalog so the next `bookery sync kobo` deploys it to the device — no separate `bookery add` step
- **Point-in-time semantics**: re-running with `--catalog` removes any prior vault-export row + its EPUB from `library_root` so the catalog never accumulates daily snapshots (closes #82)

## How replacement works

A vault export's title is `"<vault-name> Vault — <version-label>"`. The version label and pandoc's `dc:date` stamp change every run, so file-hash and title+author dedup don't fire. Instead, the command:

1. Imports the new EPUB **first** (so a failed render/import never wipes the prior snapshot)
2. Looks up the row it just inserted (by hash)
3. Walks the catalog and prunes any row whose title starts with `"<title> — "` AND whose author matches — both keys required, so unrelated books like "Notes from Underground" are never touched even if the vault is titled "Notes"
4. Skips unlink when a prior `output_path` resolves to the same file we just imported (handles `-o` pointed inside `library_root`)

## Test plan

- [x] `uv run pytest` — 1116 passed
- [x] Unit: `catalog` field parses from config
- [x] e2e: `--catalog --db` imports the produced EPUB into the isolated library root
- [x] e2e: running `--catalog` twice with different `--version-label` leaves exactly one row + one EPUB on disk
- [x] e2e: prune does NOT delete unrelated books that share a title prefix
- [x] e2e: failed import leaves the prior snapshot intact in the catalog
- [ ] Manual: run `bookery vault-export --catalog` twice against real vault, then `bookery sync kobo`, verify only the latest snapshot lands on device