### PR TITLE
Metadata: cache provider responses and normalize ISBN-10/13 (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ bookery info 42
   ```toml
   [matching]
   auto_accept_threshold = 0.85
+  cache_ttl_days = 30        # metadata response cache TTL (default 30)
   ```
+
+- **`--no-cache`** on `match`/`rematch` bypasses the on-disk metadata response cache and forces fresh provider lookups. Cached responses live at `{data_dir}/metadata_cache.db` and expire after `[matching].cache_ttl_days`.
 
 ## Commands
 

--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -9,11 +9,41 @@ from bookery.core.importer import ImportResult, MatchFn, MatchResult, ProgressFn
 from bookery.metadata.types import BookMetadata
 
 
+def build_metadata_provider(*, use_cache: bool = True):
+    """Build the default metadata provider with optional response caching.
+
+    When ``use_cache`` is true, wraps the HTTP client in a
+    :class:`CachingHttpClient` backed by a SQLite cache at
+    ``{data_dir}/metadata_cache.db`` with a TTL from
+    ``[matching].cache_ttl_days``.
+    """
+    from bookery.core.config import get_data_dir, get_matching_config
+    from bookery.metadata.cache import MetadataCache
+    from bookery.metadata.http import BookeryHttpClient, CachingHttpClient
+    from bookery.metadata.openlibrary import OpenLibraryProvider
+
+    http_client: object = BookeryHttpClient()
+    if use_cache:
+        matching = get_matching_config()
+        cache = MetadataCache(
+            get_data_dir() / "metadata_cache.db",
+            ttl_seconds=matching.cache_ttl_days * 86400.0,
+        )
+        http_client = CachingHttpClient(
+            http_client,  # type: ignore[arg-type]
+            cache,
+            provider="openlibrary",
+        )
+    return OpenLibraryProvider(http_client=http_client)  # type: ignore[arg-type]
+
+
 def build_match_fn(
     console: Console,
     output_dir: Path,
     quiet: bool,
     threshold: float,
+    *,
+    use_cache: bool = True,
 ) -> MatchFn:
     """Build a match callback that runs the full metadata pipeline.
 
@@ -22,11 +52,8 @@ def build_match_fn(
     """
     from bookery.cli.review import ReviewSession
     from bookery.core.pipeline import match_one
-    from bookery.metadata.http import BookeryHttpClient
-    from bookery.metadata.openlibrary import OpenLibraryProvider
 
-    http_client = BookeryHttpClient()
-    provider = OpenLibraryProvider(http_client=http_client)
+    provider = build_metadata_provider(use_cache=use_cache)
     review = ReviewSession(
         console=console,
         quiet=quiet,

--- a/src/bookery/cli/commands/convert_cmd.py
+++ b/src/bookery/cli/commands/convert_cmd.py
@@ -15,22 +15,19 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
+from bookery.cli._match_helpers import build_metadata_provider
 from bookery.cli.options import auto_accept_option, threshold_option
 from bookery.cli.review import ReviewSession
 from bookery.core.config import get_library_root
 from bookery.core.converter import convert_one
 from bookery.core.pipeline import match_one
-from bookery.metadata.http import BookeryHttpClient
-from bookery.metadata.openlibrary import OpenLibraryProvider
-from bookery.metadata.provider import MetadataProvider
 
 logger = logging.getLogger(__name__)
 
 
-def _create_provider() -> MetadataProvider:
-    """Create the default metadata provider (Open Library)."""
-    http_client = BookeryHttpClient()
-    return OpenLibraryProvider(http_client=http_client)
+def _create_provider():
+    """Create the default metadata provider (Open Library) with caching."""
+    return build_metadata_provider()
 
 
 def _find_mobis(path: Path) -> list[Path]:

--- a/src/bookery/cli/commands/match_cmd.py
+++ b/src/bookery/cli/commands/match_cmd.py
@@ -16,21 +16,19 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
+from bookery.cli._match_helpers import build_metadata_provider
 from bookery.cli.options import auto_accept_option, threshold_option
 from bookery.cli.review import ReviewSession
 from bookery.core.config import get_library_root
 from bookery.core.pathformat import is_processed
 from bookery.core.pipeline import match_one
-from bookery.metadata.http import BookeryHttpClient
-from bookery.metadata.openlibrary import OpenLibraryProvider
-from bookery.metadata.provider import MetadataProvider
 
 logger = logging.getLogger(__name__)
 
-def _create_provider() -> MetadataProvider:
-    """Create the default metadata provider (Open Library)."""
-    http_client = BookeryHttpClient()
-    return OpenLibraryProvider(http_client=http_client)
+
+def _create_provider(*, use_cache: bool = True):
+    """Create the default metadata provider (Open Library), optionally cached."""
+    return build_metadata_provider(use_cache=use_cache)
 
 
 def _find_epubs(path: Path) -> list[Path]:
@@ -84,12 +82,19 @@ def _make_progress(console: Console) -> Progress:
     default=True,
     help="Skip files already in output-dir (default: --resume).",
 )
+@click.option(
+    "--no-cache",
+    "no_cache",
+    is_flag=True,
+    help="Skip the metadata response cache and force fresh provider lookups.",
+)
 def match(
     path: Path,
     output_dir: Path | None,
     auto_accept: bool,
     threshold: float,
     resume: bool,
+    no_cache: bool,
 ) -> None:
     """Match EPUB metadata against Open Library and write corrected copies."""
     console = Console()
@@ -97,7 +102,7 @@ def match(
     if output_dir is None:
         output_dir = get_library_root()
 
-    provider = _create_provider()
+    provider = _create_provider(use_cache=not no_cache)
     review = ReviewSession(
         console=console,
         quiet=auto_accept,

--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from bookery.cli._match_helpers import build_metadata_provider
 from bookery.cli.options import (
     auto_accept_option,
     db_option,
@@ -19,17 +20,14 @@ from bookery.core.pipeline import match_one
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 from bookery.db.mapping import BookRecord
-from bookery.metadata.http import BookeryHttpClient
-from bookery.metadata.openlibrary import OpenLibraryProvider
 from bookery.metadata.types import BookMetadata
 
 logger = logging.getLogger(__name__)
 
 
-def _create_provider() -> OpenLibraryProvider:
-    """Create the default metadata provider (Open Library)."""
-    http_client = BookeryHttpClient()
-    return OpenLibraryProvider(http_client=http_client)
+def _create_provider(*, use_cache: bool = True):
+    """Create the default metadata provider (Open Library), optionally cached."""
+    return build_metadata_provider(use_cache=use_cache)
 
 
 def _validate_selectors(
@@ -119,6 +117,12 @@ def _metadata_to_update_fields(metadata: BookMetadata) -> dict:
     default=True,
     help="Skip books that already have an output_path (default: --resume).",
 )
+@click.option(
+    "--no-cache",
+    "no_cache",
+    is_flag=True,
+    help="Skip the metadata response cache and force fresh provider lookups.",
+)
 def rematch(
     book_id: int | None,
     match_all: bool,
@@ -128,6 +132,7 @@ def rematch(
     auto_accept: bool,
     threshold: float,
     resume: bool,
+    no_cache: bool,
 ) -> None:
     """Re-run metadata matching on cataloged books and update the database."""
     console = Console()
@@ -170,7 +175,7 @@ def rematch(
                 return
 
         # Set up match pipeline
-        provider = _create_provider()
+        provider = _create_provider(use_cache=not no_cache)
         review = ReviewSession(
             console=console,
             quiet=auto_accept,

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -65,6 +65,7 @@ DEFAULT_AUTO_ACCEPT_THRESHOLD = 0.8
 @dataclass(frozen=True, slots=True)
 class MatchingConfig:
     auto_accept_threshold: float = DEFAULT_AUTO_ACCEPT_THRESHOLD
+    cache_ttl_days: int = 30
 
 
 @dataclass(frozen=True)
@@ -149,6 +150,7 @@ def _parse_matching(section: dict[str, Any] | None) -> MatchingConfig:
         auto_accept_threshold=float(
             section.get("auto_accept_threshold", DEFAULT_AUTO_ACCEPT_THRESHOLD),
         ),
+        cache_ttl_days=int(section.get("cache_ttl_days", 30)),
     )
 
 

--- a/src/bookery/core/dedup.py
+++ b/src/bookery/core/dedup.py
@@ -81,17 +81,38 @@ def normalize_isbn(isbn: str | None) -> str:
     if len(cleaned) == 10:
         if not cleaned[:9].isdigit():
             return cleaned
-        cleaned = _isbn10_to_isbn13(cleaned)
+        cleaned = isbn10_to_isbn13(cleaned)
 
     return cleaned
 
 
-def _isbn10_to_isbn13(isbn10: str) -> str:
-    """Convert an ISBN-10 to ISBN-13 by prepending 978 and recalculating check digit."""
+def isbn10_to_isbn13(isbn10: str) -> str:
+    """Convert an ISBN-10 to ISBN-13 by prepending 978 and recalculating the check digit.
+
+    Input must be 10 characters of stripped (no hyphen/space) ISBN-10 with the
+    first 9 characters numeric; the 10th may be 'X'. Returns a 13-digit ISBN-13.
+    """
+    if len(isbn10) != 10 or not isbn10[:9].isdigit():
+        raise ValueError(f"Not a valid ISBN-10: {isbn10!r}")
     base = "978" + isbn10[:9]
-    total = sum(
-        int(d) * (1 if i % 2 == 0 else 3)
-        for i, d in enumerate(base)
-    )
+    total = sum(int(d) * (1 if i % 2 == 0 else 3) for i, d in enumerate(base))
     check = (10 - (total % 10)) % 10
     return base + str(check)
+
+
+def isbn13_to_isbn10(isbn13: str) -> str:
+    """Convert an ISBN-13 (978 prefix) to ISBN-10 by recalculating the mod-11 check digit.
+
+    Only the 978 prefix can round-trip to ISBN-10; a 979 prefix has no ISBN-10
+    equivalent and raises ValueError. Check digit 10 is encoded as 'X'.
+    """
+    if len(isbn13) != 13 or not isbn13.isdigit():
+        raise ValueError(f"Not a valid ISBN-13: {isbn13!r}")
+    if not isbn13.startswith("978"):
+        raise ValueError(f"ISBN-13 with non-978 prefix has no ISBN-10: {isbn13!r}")
+    body = isbn13[3:12]
+    total = sum(int(d) * (10 - i) for i, d in enumerate(body))
+    remainder = total % 11
+    check_num = (11 - remainder) % 11
+    check = "X" if check_num == 10 else str(check_num)
+    return body + check

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -165,7 +165,8 @@ class LibraryCatalog:
         """Update one or more fields on a cataloged book.
 
         Accepts keyword arguments matching books table columns. Authors and
-        identifiers values are JSON-serialized automatically.
+        identifiers values are JSON-serialized automatically. ISBN is
+        canonicalized to ISBN-13 on write.
 
         Raises:
             ValueError: If the book_id does not exist.
@@ -178,6 +179,8 @@ class LibraryCatalog:
             fields["authors"] = json.dumps(fields["authors"])
         if "identifiers" in fields:
             fields["identifiers"] = json.dumps(fields["identifiers"])
+        if fields.get("isbn"):
+            fields["isbn"] = normalize_isbn(fields["isbn"]) or None  # type: ignore[arg-type]
 
         set_clause = ", ".join(f"{k} = ?" for k in fields)
         set_clause += ", date_modified = strftime('%Y-%m-%dT%H:%M:%S', 'now')"

--- a/src/bookery/db/mapping.py
+++ b/src/bookery/db/mapping.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from bookery.core.dedup import normalize_isbn
 from bookery.metadata.types import BookMetadata
 
 
@@ -49,7 +50,7 @@ def metadata_to_row(
         "author_sort": metadata.author_sort,
         "language": metadata.language,
         "publisher": metadata.publisher,
-        "isbn": metadata.isbn,
+        "isbn": normalize_isbn(metadata.isbn) or None,
         "description": metadata.description,
         "series": metadata.series,
         "series_index": metadata.series_index,

--- a/src/bookery/metadata/cache.py
+++ b/src/bookery/metadata/cache.py
@@ -1,0 +1,85 @@
+# ABOUTME: SQLite-backed cache for metadata provider HTTP responses.
+# ABOUTME: Keyed on (provider, query_type, query_key) with a TTL-based freshness check.
+
+import json
+import sqlite3
+import time
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CachedResponse:
+    response: dict[str, Any]
+    fetched_at: float
+
+
+class MetadataCache:
+    """Persistent response cache for metadata providers.
+
+    Each row stores a JSON-serialized HTTP response keyed by
+    ``(provider, query_type, query_key)``. Entries older than
+    ``ttl_seconds`` are treated as missing on read.
+    """
+
+    def __init__(self, path: Path, *, ttl_seconds: float) -> None:
+        self.path = path
+        self.ttl_seconds = ttl_seconds
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(path)) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS metadata_cache ("
+                "  provider TEXT NOT NULL,"
+                "  query_type TEXT NOT NULL,"
+                "  query_key TEXT NOT NULL,"
+                "  response_json TEXT NOT NULL,"
+                "  fetched_at REAL NOT NULL,"
+                "  PRIMARY KEY (provider, query_type, query_key)"
+                ")"
+            )
+            conn.commit()
+
+    def get(
+        self, provider: str, query_type: str, query_key: str
+    ) -> dict[str, Any] | None:
+        """Return the cached response if fresh, otherwise None."""
+        with closing(sqlite3.connect(self.path)) as conn:
+            row = conn.execute(
+                "SELECT response_json, fetched_at FROM metadata_cache "
+                "WHERE provider = ? AND query_type = ? AND query_key = ?",
+                (provider, query_type, query_key),
+            ).fetchone()
+        if row is None:
+            return None
+        response_json, fetched_at = row
+        if self.ttl_seconds >= 0 and (time.time() - float(fetched_at)) > self.ttl_seconds:
+            return None
+        return json.loads(response_json)
+
+    def put(
+        self,
+        provider: str,
+        query_type: str,
+        query_key: str,
+        response: dict[str, Any],
+    ) -> None:
+        """Store (or replace) a provider response."""
+        with closing(sqlite3.connect(self.path)) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO metadata_cache "
+                "(provider, query_type, query_key, response_json, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (provider, query_type, query_key, json.dumps(response), time.time()),
+            )
+            conn.commit()
+
+    def clear(self, provider: str | None = None) -> None:
+        """Remove all entries (or all entries for a single provider)."""
+        with closing(sqlite3.connect(self.path)) as conn:
+            if provider is None:
+                conn.execute("DELETE FROM metadata_cache")
+            else:
+                conn.execute("DELETE FROM metadata_cache WHERE provider = ?", (provider,))
+            conn.commit()

--- a/src/bookery/metadata/http.py
+++ b/src/bookery/metadata/http.py
@@ -3,9 +3,13 @@
 
 import logging
 import time
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from urllib.parse import urlparse
 
 import httpx
+
+if TYPE_CHECKING:
+    from bookery.metadata.cache import MetadataCache
 
 logger = logging.getLogger(__name__)
 
@@ -106,3 +110,40 @@ class BookeryHttpClient:
         if elapsed < self._min_interval and self._last_request_time > 0:
             time.sleep(self._min_interval - elapsed)
         self._last_request_time = time.monotonic()
+
+
+class CachingHttpClient:
+    """HTTP client wrapper that caches GET responses in a :class:`MetadataCache`.
+
+    Cache hits return the stored JSON immediately. Misses delegate to the
+    inner client and persist the response. The provider label is stamped on
+    cache rows so the same cache can safely serve multiple providers.
+    """
+
+    def __init__(
+        self,
+        inner: "HttpClient",
+        cache: "MetadataCache",
+        *,
+        provider: str,
+    ) -> None:
+        self._inner = inner
+        self._cache = cache
+        self._provider = provider
+
+    def get(self, url: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        parsed = urlparse(url)
+        query_type = parsed.path or "/"
+        key_parts = [parsed.netloc, parsed.query]
+        if params:
+            for k in sorted(params):
+                key_parts.append(f"{k}={params[k]}")
+        query_key = "|".join(key_parts)
+
+        hit = self._cache.get(self._provider, query_type, query_key)
+        if hit is not None:
+            return hit
+
+        response = self._inner.get(url, params=params)
+        self._cache.put(self._provider, query_type, query_key, response)
+        return response

--- a/src/bookery/metadata/scoring.py
+++ b/src/bookery/metadata/scoring.py
@@ -1,9 +1,9 @@
 # ABOUTME: Confidence scoring for metadata candidate matching.
 # ABOUTME: Compares extracted EPUB metadata against candidates using weighted field similarity.
 
-import re
 from difflib import SequenceMatcher
 
+from bookery.core.dedup import normalize_isbn as _canonical_isbn
 from bookery.metadata.types import BookMetadata
 
 # Match weights — must sum to 1.0
@@ -24,9 +24,6 @@ _COMPLETENESS_FIELDS: dict[str, float] = {
     "publisher": 0.05,
 }
 
-_ISBN_STRIP_RE = re.compile(r"[\s-]")
-
-
 def _normalize_author(name: str) -> str:
     """Normalize 'Last, First' to 'First Last' and lowercase."""
     name = name.strip().lower()
@@ -37,8 +34,8 @@ def _normalize_author(name: str) -> str:
 
 
 def _normalize_isbn(isbn: str) -> str:
-    """Strip hyphens and spaces from an ISBN for comparison."""
-    return _ISBN_STRIP_RE.sub("", isbn)
+    """Canonicalize ISBN for comparison (strip separators, convert ISBN-10 to ISBN-13)."""
+    return _canonical_isbn(isbn)
 
 
 def _string_similarity(a: str, b: str) -> float:

--- a/tests/unit/test_catalog_isbn_canonical.py
+++ b/tests/unit/test_catalog_isbn_canonical.py
@@ -1,0 +1,52 @@
+# ABOUTME: Verifies that LibraryCatalog writes canonicalize ISBN to ISBN-13.
+# ABOUTME: Covers both insert (add_book) and update (update_book) paths.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture
+def catalog(tmp_path: Path):
+    conn = open_library(tmp_path / "lib.db")
+    try:
+        yield LibraryCatalog(conn)
+    finally:
+        conn.close()
+
+
+def test_add_book_canonicalizes_isbn10_to_13(catalog):
+    meta = BookMetadata(
+        title="X", authors=["Y"], isbn="0151446474", source_path=Path("/tmp/x.epub"),
+    )
+    book_id = catalog.add_book(meta, file_hash="h" * 64)
+    record = catalog.get_by_id(book_id)
+    assert record is not None
+    assert record.metadata.isbn == "9780151446476"
+
+
+def test_add_book_keeps_hyphens_out(catalog):
+    meta = BookMetadata(
+        title="X", authors=["Y"], isbn="0-15-144647-4", source_path=Path("/tmp/x.epub"),
+    )
+    book_id = catalog.add_book(meta, file_hash="h" * 64)
+    record = catalog.get_by_id(book_id)
+    assert record is not None
+    assert record.metadata.isbn == "9780151446476"
+
+
+def test_update_book_canonicalizes_isbn(catalog):
+    meta = BookMetadata(
+        title="X", authors=["Y"], isbn=None, source_path=Path("/tmp/x.epub"),
+    )
+    book_id = catalog.add_book(meta, file_hash="h" * 64)
+
+    catalog.update_book(book_id, isbn="0151446474")
+
+    record = catalog.get_by_id(book_id)
+    assert record is not None
+    assert record.metadata.isbn == "9780151446476"

--- a/tests/unit/test_config_matching.py
+++ b/tests/unit/test_config_matching.py
@@ -32,3 +32,18 @@ def test_config_file_override(isolated_home):
 
 def test_get_matching_config_accessor(isolated_home):
     assert config_module.get_matching_config().auto_accept_threshold == 0.8
+
+
+def test_default_cache_ttl_is_30_days(isolated_home):
+    assert config_module.load_config().matching.cache_ttl_days == 30
+
+
+def test_config_file_cache_ttl_override(isolated_home):
+    config_dir = isolated_home / ".bookery"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        'library_root = "/tmp/lib"\n'
+        "[matching]\n"
+        "cache_ttl_days = 7\n"
+    )
+    assert config_module.load_config().matching.cache_ttl_days == 7

--- a/tests/unit/test_isbn_helpers.py
+++ b/tests/unit/test_isbn_helpers.py
@@ -1,0 +1,50 @@
+# ABOUTME: Unit tests for ISBN-10 ↔ ISBN-13 conversion helpers in core.dedup.
+# ABOUTME: Verifies round-trip conversion and check-digit math for both directions.
+
+import pytest
+
+from bookery.core.dedup import isbn10_to_isbn13, isbn13_to_isbn10, normalize_isbn
+
+
+class TestIsbn10ToIsbn13:
+    def test_known_value(self) -> None:
+        assert isbn10_to_isbn13("0151446474") == "9780151446476"
+
+    def test_check_digit_zero(self) -> None:
+        # The Hobbit ISBN-10: 0547928211 → 9780547928210? Not exactly — pick another
+        # Known: "0596000278" → "9780596000271"
+        assert isbn10_to_isbn13("0596000278") == "9780596000271"
+
+    def test_rejects_bad_input(self) -> None:
+        with pytest.raises(ValueError):
+            isbn10_to_isbn13("12345")
+
+
+class TestIsbn13ToIsbn10:
+    def test_known_value(self) -> None:
+        assert isbn13_to_isbn10("9780151446476") == "0151446474"
+
+    def test_round_trip(self) -> None:
+        original_10 = "0596000278"
+        as_13 = isbn10_to_isbn13(original_10)
+        assert isbn13_to_isbn10(as_13) == original_10
+
+    def test_check_digit_ten_becomes_x(self) -> None:
+        # The Pragmatic Programmer: ISBN-10 ends in X, ISBN-13 is 9780201616224.
+        assert isbn13_to_isbn10("9780201616224") == "020161622X"
+
+    def test_rejects_non_978_prefix(self) -> None:
+        with pytest.raises(ValueError):
+            isbn13_to_isbn10("9791234567896")
+
+    def test_rejects_non_numeric(self) -> None:
+        with pytest.raises(ValueError):
+            isbn13_to_isbn10("97801514464XX")
+
+
+class TestNormalizeIsbnCanonicalization:
+    def test_10_and_13_of_same_book_are_equal(self) -> None:
+        assert normalize_isbn("0151446474") == normalize_isbn("9780151446476")
+
+    def test_hyphenated_10_matches_plain_13(self) -> None:
+        assert normalize_isbn("0-15-144647-4") == normalize_isbn("9780151446476")

--- a/tests/unit/test_match_no_cache_flag.py
+++ b/tests/unit/test_match_no_cache_flag.py
@@ -1,0 +1,69 @@
+# ABOUTME: Verifies --no-cache on match/rematch disables the metadata response cache.
+# ABOUTME: Ensures the CLI flag is wired through to the provider factory.
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from bookery.cli.commands.match_cmd import match
+from bookery.cli.commands.rematch_cmd import rematch
+
+
+def test_match_passes_use_cache_true_by_default(tmp_path: Path) -> None:
+    epub = tmp_path / "stub.epub"
+    epub.write_bytes(b"stub")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    with patch("bookery.cli.commands.match_cmd._create_provider") as factory:
+        factory.return_value = MagicMock(lookup_by_url=lambda _: None)
+        CliRunner().invoke(
+            match,
+            [str(epub), "-o", str(out), "-q", "--no-resume"],
+            catch_exceptions=False,
+        )
+    factory.assert_called_once_with(use_cache=True)
+
+
+def test_match_no_cache_flag_disables_cache(tmp_path: Path) -> None:
+    epub = tmp_path / "stub.epub"
+    epub.write_bytes(b"stub")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    with patch("bookery.cli.commands.match_cmd._create_provider") as factory:
+        factory.return_value = MagicMock(lookup_by_url=lambda _: None)
+        CliRunner().invoke(
+            match,
+            [str(epub), "-o", str(out), "-q", "--no-resume", "--no-cache"],
+            catch_exceptions=False,
+        )
+    factory.assert_called_once_with(use_cache=False)
+
+
+def test_rematch_no_cache_flag_disables_cache(tmp_path: Path) -> None:
+    # rematch requires a DB + at least one book. The factory is short-circuited
+    # by --all with no books in the catalog, so we just need the command to
+    # reach the provider-construction branch.
+    db = tmp_path / "lib.db"
+    from bookery.db.catalog import LibraryCatalog
+    from bookery.db.connection import open_library
+    from bookery.metadata.types import BookMetadata
+
+    conn = open_library(db)
+    catalog = LibraryCatalog(conn)
+    catalog.add_book(
+        BookMetadata(title="T", authors=["A"], source_path=Path("/tmp/x.epub")),
+        file_hash="h" * 64,
+    )
+    conn.close()
+
+    with patch("bookery.cli.commands.rematch_cmd._create_provider") as factory:
+        factory.return_value = MagicMock(lookup_by_url=lambda _: None)
+        result = CliRunner().invoke(
+            rematch,
+            ["--all", "--db", str(db), "-q", "--no-resume", "--no-cache"],
+            catch_exceptions=False,
+        )
+    assert factory.call_args.kwargs == {"use_cache": False}, result.output

--- a/tests/unit/test_metadata_cache.py
+++ b/tests/unit/test_metadata_cache.py
@@ -1,0 +1,95 @@
+# ABOUTME: Unit tests for MetadataCache and CachingHttpClient.
+# ABOUTME: Verifies SQLite round-trip, TTL expiry, per-provider scoping, and HTTP wrapping.
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bookery.metadata.cache import MetadataCache
+from bookery.metadata.http import CachingHttpClient
+
+
+class _RecordingClient:
+    def __init__(self, responses: dict[str, dict[str, Any]]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, tuple[tuple[str, str], ...] | None]] = []
+
+    def get(self, url: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        self.calls.append((url, tuple(sorted(params.items())) if params else None))
+        return self._responses[url]
+
+
+class TestMetadataCache:
+    def test_put_then_get_returns_response(self, tmp_path: Path) -> None:
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        cache.put("openlibrary", "/isbn/X.json", "key1", {"a": 1})
+        assert cache.get("openlibrary", "/isbn/X.json", "key1") == {"a": 1}
+
+    def test_miss_returns_none(self, tmp_path: Path) -> None:
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        assert cache.get("openlibrary", "/x", "k") is None
+
+    def test_ttl_expiry(self, tmp_path: Path) -> None:
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=0.01)
+        cache.put("openlibrary", "/x", "k", {"a": 1})
+        time.sleep(0.05)
+        assert cache.get("openlibrary", "/x", "k") is None
+
+    def test_provider_scoping(self, tmp_path: Path) -> None:
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        cache.put("openlibrary", "/x", "k", {"who": "ol"})
+        cache.put("googlebooks", "/x", "k", {"who": "gb"})
+        assert cache.get("openlibrary", "/x", "k") == {"who": "ol"}
+        assert cache.get("googlebooks", "/x", "k") == {"who": "gb"}
+
+    def test_clear_scoped_by_provider(self, tmp_path: Path) -> None:
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        cache.put("openlibrary", "/x", "k", {"v": 1})
+        cache.put("googlebooks", "/x", "k", {"v": 2})
+        cache.clear(provider="openlibrary")
+        assert cache.get("openlibrary", "/x", "k") is None
+        assert cache.get("googlebooks", "/x", "k") == {"v": 2}
+
+
+class TestCachingHttpClient:
+    def test_second_call_is_served_from_cache(self, tmp_path: Path) -> None:
+        inner = _RecordingClient({"https://example.com/a": {"ok": True}})
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        client = CachingHttpClient(inner, cache, provider="openlibrary")
+
+        first = client.get("https://example.com/a")
+        second = client.get("https://example.com/a")
+
+        assert first == second == {"ok": True}
+        assert len(inner.calls) == 1
+
+    def test_params_part_of_cache_key(self, tmp_path: Path) -> None:
+        inner = _RecordingClient({"https://example.com/s": {"ok": True}})
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        client = CachingHttpClient(inner, cache, provider="openlibrary")
+
+        client.get("https://example.com/s", {"q": "a"})
+        client.get("https://example.com/s", {"q": "b"})
+
+        # Different params = different cache entries → two upstream calls
+        assert len(inner.calls) == 2
+
+    def test_expired_entry_triggers_refresh(self, tmp_path: Path) -> None:
+        inner = _RecordingClient({"https://example.com/a": {"ok": True}})
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=0.01)
+        client = CachingHttpClient(inner, cache, provider="openlibrary")
+
+        client.get("https://example.com/a")
+        time.sleep(0.05)
+        client.get("https://example.com/a")
+
+        assert len(inner.calls) == 2
+
+    def test_missing_response_propagates_keyerror(self, tmp_path: Path) -> None:
+        inner = _RecordingClient({})
+        cache = MetadataCache(tmp_path / "c.db", ttl_seconds=60)
+        client = CachingHttpClient(inner, cache, provider="openlibrary")
+        with pytest.raises(KeyError):
+            client.get("https://example.com/missing")

--- a/tests/unit/test_scoring_isbn.py
+++ b/tests/unit/test_scoring_isbn.py
@@ -1,0 +1,32 @@
+# ABOUTME: Unit tests that ISBN-10 and ISBN-13 of the same book score as equal in scoring.
+# ABOUTME: Complements test_scoring.py by focusing on the ISBN-normalization behavior.
+
+from bookery.metadata.scoring import score_candidate
+from bookery.metadata.types import BookMetadata
+
+
+def _meta(**kwargs) -> BookMetadata:
+    defaults = {"title": "The Hobbit", "authors": ["J.R.R. Tolkien"]}
+    defaults.update(kwargs)
+    return BookMetadata(**defaults)
+
+
+class TestIsbnEquivalence:
+    def test_isbn10_matches_isbn13_of_same_book(self) -> None:
+        extracted = _meta(isbn="0151446474")
+        candidate = _meta(isbn="9780151446476")
+        # Identical title+author, matching ISBN after canonicalization → near-perfect
+        assert score_candidate(extracted, candidate) >= 0.95
+
+    def test_different_isbns_still_penalized(self) -> None:
+        extracted = _meta(isbn="0151446474")
+        candidate = _meta(isbn="9999999999999")
+        # Different books should score lower than the matching-ISBN case
+        match_score = score_candidate(extracted, _meta(isbn="9780151446476"))
+        mismatch_score = score_candidate(extracted, candidate)
+        assert mismatch_score < match_score
+
+    def test_hyphenated_variants_match(self) -> None:
+        extracted = _meta(isbn="0-15-144647-4")
+        candidate = _meta(isbn="978-0-15-144647-6")
+        assert score_candidate(extracted, candidate) >= 0.95


### PR DESCRIPTION
Closes #86.

## Summary
- New `MetadataCache` (SQLite) + `CachingHttpClient` wrapper. Keyed on `(provider, query_type, query_key)`; TTL from `[matching].cache_ttl_days` (default 30 days). Cache lives at `{data_dir}/metadata_cache.db`.
- `--no-cache` flag on `match` and `rematch` to force fresh provider lookups.
- `isbn10_to_isbn13` / `isbn13_to_isbn10` helpers in `core/dedup.py` (check-digit math, handles the `X` case, rejects non-978 prefixes that have no ISBN-10 equivalent).
- `score_candidate` now treats ISBN-10 and ISBN-13 of the same book as equal (canonicalizes to ISBN-13 before comparison).
- `LibraryCatalog.add_book` and `update_book` canonicalize ISBN to ISBN-13 on write.
- New `build_metadata_provider()` factory centralizes provider construction for `match`, `rematch`, `convert`, and the import pipeline.

## Test plan
- [x] `uv run pytest tests/` — 1161 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] New unit tests: `test_isbn_helpers.py`, `test_scoring_isbn.py`, `test_metadata_cache.py`, `test_catalog_isbn_canonical.py`, `test_match_no_cache_flag.py`
- [x] Extended `test_config_matching.py` with `cache_ttl_days` coverage