### PR TITLE
Metadata: extend BookMetadata with published_date, page_count, cover_url (#87)

### DIFF
--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -45,6 +45,14 @@ def info(book_id: int, db_path: Path | None) -> None:
         table.add_row("Publisher", meta.publisher)
     if meta.isbn:
         table.add_row("ISBN", meta.isbn)
+    if meta.published_date:
+        table.add_row("Published", meta.published_date)
+    if meta.original_publication_date:
+        table.add_row("First Published", meta.original_publication_date)
+    if meta.page_count is not None:
+        table.add_row("Pages", str(meta.page_count))
+    if meta.cover_url:
+        table.add_row("Cover URL", meta.cover_url)
     if meta.description:
         table.add_row("Description", meta.description)
     if meta.series:

--- a/src/bookery/db/mapping.py
+++ b/src/bookery/db/mapping.py
@@ -55,6 +55,10 @@ def metadata_to_row(
         "series_index": metadata.series_index,
         "identifiers": json.dumps(metadata.identifiers),
         "subjects": json.dumps(metadata.subjects),
+        "cover_url": metadata.cover_url,
+        "published_date": metadata.published_date,
+        "original_publication_date": metadata.original_publication_date,
+        "page_count": metadata.page_count,
         "source_path": str(metadata.source_path) if metadata.source_path else None,
         "output_path": str(output_path) if output_path else None,
         "file_hash": file_hash,
@@ -71,6 +75,13 @@ def row_to_metadata(row: Any) -> BookMetadata:
         subjects_raw = row["subjects"]
     except (KeyError, IndexError):
         subjects_raw = None
+
+    def _opt(key: str) -> Any:
+        try:
+            return row[key]
+        except (KeyError, IndexError):
+            return None
+
     return BookMetadata(
         title=row["title"],
         authors=json.loads(row["authors"]) if row["authors"] else [],
@@ -83,6 +94,10 @@ def row_to_metadata(row: Any) -> BookMetadata:
         series_index=row["series_index"],
         subjects=json.loads(subjects_raw) if subjects_raw else [],
         identifiers=json.loads(row["identifiers"]) if row["identifiers"] else {},
+        cover_url=_opt("cover_url"),
+        published_date=_opt("published_date"),
+        original_publication_date=_opt("original_publication_date"),
+        page_count=_opt("page_count"),
         source_path=Path(source) if source else None,
     )
 

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -112,4 +112,13 @@ ALTER TABLE books ADD COLUMN subjects TEXT;
 INSERT INTO schema_version (version) VALUES (3);
 """
 
-MIGRATIONS = [(2, SCHEMA_V2), (3, SCHEMA_V3)]
+SCHEMA_V4 = """
+ALTER TABLE books ADD COLUMN cover_url TEXT;
+ALTER TABLE books ADD COLUMN published_date TEXT;
+ALTER TABLE books ADD COLUMN original_publication_date TEXT;
+ALTER TABLE books ADD COLUMN page_count INTEGER;
+
+INSERT INTO schema_version (version) VALUES (4);
+"""
+
+MIGRATIONS = [(2, SCHEMA_V2), (3, SCHEMA_V3), (4, SCHEMA_V4)]

--- a/src/bookery/metadata/openlibrary.py
+++ b/src/bookery/metadata/openlibrary.py
@@ -169,6 +169,7 @@ class OpenLibraryProvider:
                 if not works_key:
                     return None
 
+            assert works_key is not None  # narrow for type checker
             if edition_key:
                 return self._lookup_by_edition(works_key, edition_key)
             return self._lookup_by_works(works_key)
@@ -236,14 +237,19 @@ class OpenLibraryProvider:
         )
 
     def _lookup_by_works(self, works_key: str) -> MetadataCandidate:
-        """Fetch metadata from works endpoint only (no edition data)."""
+        """Fetch metadata from works endpoint only (no edition data).
+
+        Author OLIDs captured by :func:`parse_works_metadata` are preserved
+        on the returned metadata — they're the most reliable author
+        disambiguator and survive into the catalog for future rematches.
+        """
         works_data = self._http.get(f"{_OL_BASE}{works_key}.json")
         metadata = parse_works_metadata(works_data)
 
-        # Resolve author names from author keys stored by parse_works_metadata
+        # Resolve author names from author keys stored by parse_works_metadata.
+        # Keep the keys in identifiers so downstream consumers can use them.
         author_keys_str = metadata.identifiers.get("openlibrary_author_keys", "")
         if author_keys_str:
-            del metadata.identifiers["openlibrary_author_keys"]
             authors: list[str] = []
             for author_key in author_keys_str.split(","):
                 try:
@@ -309,7 +315,11 @@ class OpenLibraryProvider:
     def _enrich_from_works(
         self, metadata: BookMetadata, isbn_data: dict[str, Any]
     ) -> BookMetadata:
-        """Fetch description from the works endpoint if available."""
+        """Fetch description, subjects, and first-publish date from the works endpoint.
+
+        Also fills ``original_publication_date`` and a work-level cover URL
+        when the edition-level cover wasn't available.
+        """
         works = isbn_data.get("works", [])
         if not works:
             return metadata
@@ -330,6 +340,14 @@ class OpenLibraryProvider:
         subjects = parse_works_subjects(works_data)
         if subjects:
             metadata.subjects = subjects
+
+        first_publish = works_data.get("first_publish_date")
+        if first_publish and not metadata.original_publication_date:
+            metadata.original_publication_date = first_publish
+
+        if not metadata.cover_url:
+            from bookery.metadata.openlibrary_parser import _cover_url_from_covers
+            metadata.cover_url = _cover_url_from_covers(works_data.get("covers"))
 
         return metadata
 

--- a/src/bookery/metadata/openlibrary.py
+++ b/src/bookery/metadata/openlibrary.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs, urlparse
 from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.http import HttpClient, MetadataFetchError
 from bookery.metadata.openlibrary_parser import (
+    cover_url_from_covers,
     parse_author_name,
     parse_isbn_response,
     parse_search_results,
@@ -346,8 +347,7 @@ class OpenLibraryProvider:
             metadata.original_publication_date = first_publish
 
         if not metadata.cover_url:
-            from bookery.metadata.openlibrary_parser import _cover_url_from_covers
-            metadata.cover_url = _cover_url_from_covers(works_data.get("covers"))
+            metadata.cover_url = cover_url_from_covers(works_data.get("covers"))
 
         return metadata
 

--- a/src/bookery/metadata/openlibrary_parser.py
+++ b/src/bookery/metadata/openlibrary_parser.py
@@ -8,7 +8,7 @@ from bookery.metadata.types import BookMetadata
 _COVERS_BASE_URL = "https://covers.openlibrary.org/b/isbn"
 
 
-def _cover_url_from_covers(covers: Any, size: str = "L") -> str | None:
+def cover_url_from_covers(covers: Any, size: str = "L") -> str | None:
     """Build a cover URL from the ``covers`` array of an OL edition/work.
 
     OL ignores the `-1` sentinel cover ID it sometimes returns; treat it
@@ -53,7 +53,7 @@ def parse_isbn_response(data: dict[str, Any]) -> BookMetadata:
     page_count_raw = data.get("number_of_pages")
     page_count = int(page_count_raw) if isinstance(page_count_raw, (int, float)) else None
 
-    cover_url = _cover_url_from_covers(data.get("covers")) or (
+    cover_url = cover_url_from_covers(data.get("covers")) or (
         build_cover_url(isbn) if isbn else None
     )
 
@@ -122,7 +122,7 @@ def parse_works_metadata(data: dict[str, Any]) -> BookMetadata:
         identifiers["openlibrary_author_keys"] = ",".join(author_keys)
 
     original_publication_date = data.get("first_publish_date")
-    cover_url = _cover_url_from_covers(data.get("covers"))
+    cover_url = cover_url_from_covers(data.get("covers"))
 
     return BookMetadata(
         title=title,

--- a/src/bookery/metadata/openlibrary_parser.py
+++ b/src/bookery/metadata/openlibrary_parser.py
@@ -8,11 +8,26 @@ from bookery.metadata.types import BookMetadata
 _COVERS_BASE_URL = "https://covers.openlibrary.org/b/isbn"
 
 
+def _cover_url_from_covers(covers: Any, size: str = "L") -> str | None:
+    """Build a cover URL from the ``covers`` array of an OL edition/work.
+
+    OL ignores the `-1` sentinel cover ID it sometimes returns; treat it
+    as missing. Returns None if no usable cover ID is found.
+    """
+    if not isinstance(covers, list):
+        return None
+    for cover_id in covers:
+        if isinstance(cover_id, int) and cover_id > 0:
+            return f"https://covers.openlibrary.org/b/id/{cover_id}-{size}.jpg"
+    return None
+
+
 def parse_isbn_response(data: dict[str, Any]) -> BookMetadata:
     """Parse an Open Library ISBN endpoint response into BookMetadata.
 
     The ISBN endpoint returns edition-level data with fields like
-    title, publishers, isbn_13, languages, works, etc.
+    title, publishers, isbn_13, languages, works, publish_date,
+    number_of_pages, and covers.
     """
     title = data.get("title", "Unknown")
 
@@ -34,12 +49,23 @@ def parse_isbn_response(data: dict[str, Any]) -> BookMetadata:
     if works:
         identifiers["openlibrary_work"] = works[0]["key"]
 
+    published_date = data.get("publish_date")
+    page_count_raw = data.get("number_of_pages")
+    page_count = int(page_count_raw) if isinstance(page_count_raw, (int, float)) else None
+
+    cover_url = _cover_url_from_covers(data.get("covers")) or (
+        build_cover_url(isbn) if isbn else None
+    )
+
     return BookMetadata(
         title=title,
         publisher=publisher,
         isbn=isbn,
         language=language,
         identifiers=identifiers,
+        published_date=published_date,
+        page_count=page_count,
+        cover_url=cover_url,
     )
 
 
@@ -70,9 +96,10 @@ def parse_works_subjects(data: dict[str, Any]) -> list[str]:
 def parse_works_metadata(data: dict[str, Any]) -> BookMetadata:
     """Parse an Open Library Works endpoint response into BookMetadata.
 
-    Extracts title, description, subjects, works key, and author keys from
-    the works response. Author keys are stored in identifiers for later
-    resolution via the author endpoint.
+    Extracts title, description, subjects, works key, author keys, the
+    work's first publication date, and a cover URL (if the work carries
+    cover IDs). Author keys are stored in identifiers for later resolution
+    via the author endpoint and are preserved on the final record.
     """
     title = data.get("title", "Unknown")
     description = parse_works_response(data)
@@ -94,11 +121,16 @@ def parse_works_metadata(data: dict[str, Any]) -> BookMetadata:
     if author_keys:
         identifiers["openlibrary_author_keys"] = ",".join(author_keys)
 
+    original_publication_date = data.get("first_publish_date")
+    cover_url = _cover_url_from_covers(data.get("covers"))
+
     return BookMetadata(
         title=title,
         description=description,
         subjects=subjects,
         identifiers=identifiers,
+        original_publication_date=original_publication_date,
+        cover_url=cover_url,
     )
 
 
@@ -110,7 +142,8 @@ def parse_author_name(data: dict[str, Any]) -> str:
 def parse_search_results(data: dict[str, Any]) -> list[BookMetadata]:
     """Parse an Open Library Search API response into a list of BookMetadata.
 
-    Each doc in the search results contains title, author_name, isbn, etc.
+    Each doc in the search results contains title, author_name, isbn,
+    first_publish_year, cover_i, number_of_pages_median, etc.
     """
     docs = data.get("docs", [])
     results: list[BookMetadata] = []
@@ -134,6 +167,25 @@ def parse_search_results(data: dict[str, Any]) -> list[BookMetadata]:
         if work_key:
             identifiers["openlibrary_work"] = work_key
 
+        author_keys = doc.get("author_key", [])
+        if author_keys:
+            identifiers["openlibrary_author_keys"] = ",".join(
+                f"/authors/{k}" for k in author_keys
+            )
+
+        first_year = doc.get("first_publish_year")
+        original_publication_date = str(first_year) if first_year else None
+
+        cover_id = doc.get("cover_i")
+        cover_url = (
+            f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
+            if isinstance(cover_id, int) and cover_id > 0
+            else None
+        )
+
+        pages_median = doc.get("number_of_pages_median")
+        page_count = int(pages_median) if isinstance(pages_median, (int, float)) else None
+
         results.append(
             BookMetadata(
                 title=title,
@@ -143,6 +195,9 @@ def parse_search_results(data: dict[str, Any]) -> list[BookMetadata]:
                 publisher=publisher,
                 subjects=subjects,
                 identifiers=identifiers,
+                original_publication_date=original_publication_date,
+                cover_url=cover_url,
+                page_count=page_count,
             )
         )
 

--- a/src/bookery/metadata/types.py
+++ b/src/bookery/metadata/types.py
@@ -26,6 +26,10 @@ class BookMetadata:
     subjects: list[str] = field(default_factory=list)
     identifiers: dict[str, str] = field(default_factory=dict)
     cover_image: bytes | None = None
+    cover_url: str | None = None
+    published_date: str | None = None
+    original_publication_date: str | None = None
+    page_count: int | None = None
     source_path: Path | None = None
 
     @property

--- a/tests/integration/test_migration_lifecycle.py
+++ b/tests/integration/test_migration_lifecycle.py
@@ -30,7 +30,7 @@ class TestMigrationLifecycle:
 
         # Step 2: Open with bookery to trigger migration
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 3
+        assert _get_schema_version(conn) == 4
 
         # Step 3: Verify the book survived and tags work
         catalog = LibraryCatalog(conn)
@@ -51,7 +51,7 @@ class TestMigrationLifecycle:
         # Open 3 times
         for _ in range(3):
             conn = open_library(db_path)
-            assert _get_schema_version(conn) == 3
+            assert _get_schema_version(conn) == 4
             conn.close()
 
         # Final open — add a book and tag it

--- a/tests/unit/test_bookmetadata_new_fields.py
+++ b/tests/unit/test_bookmetadata_new_fields.py
@@ -1,0 +1,111 @@
+# ABOUTME: Unit tests for BookMetadata's published_date, page_count, and cover_url.
+# ABOUTME: Covers dataclass defaults, DB round-trip, and OL parser population.
+
+from pathlib import Path
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.openlibrary_parser import (
+    parse_isbn_response,
+    parse_search_results,
+    parse_works_metadata,
+)
+from bookery.metadata.types import BookMetadata
+
+
+class TestBookMetadataDefaults:
+    def test_new_fields_default_to_none(self) -> None:
+        meta = BookMetadata(title="T")
+        assert meta.published_date is None
+        assert meta.original_publication_date is None
+        assert meta.page_count is None
+        assert meta.cover_url is None
+
+
+class TestCatalogRoundTrip:
+    def test_new_fields_survive_insert_and_read(self, tmp_path: Path) -> None:
+        conn = open_library(tmp_path / "lib.db")
+        try:
+            catalog = LibraryCatalog(conn)
+            meta = BookMetadata(
+                title="T",
+                authors=["A"],
+                isbn="9780151446476",
+                source_path=Path("/tmp/x.epub"),
+                published_date="2010-05",
+                original_publication_date="2010",
+                page_count=321,
+                cover_url="https://covers.openlibrary.org/b/id/99-L.jpg",
+            )
+            book_id = catalog.add_book(meta, file_hash="h" * 64)
+
+            record = catalog.get_by_id(book_id)
+            assert record is not None
+            assert record.metadata.published_date == "2010-05"
+            assert record.metadata.original_publication_date == "2010"
+            assert record.metadata.page_count == 321
+            assert record.metadata.cover_url == "https://covers.openlibrary.org/b/id/99-L.jpg"
+        finally:
+            conn.close()
+
+
+class TestOpenLibraryParserPopulation:
+    def test_isbn_response_populates_published_date_and_pages(self) -> None:
+        data = {
+            "title": "T",
+            "publish_date": "August 2010",
+            "number_of_pages": 321,
+            "covers": [42],
+        }
+        meta = parse_isbn_response(data)
+        assert meta.published_date == "August 2010"
+        assert meta.page_count == 321
+        assert meta.cover_url == "https://covers.openlibrary.org/b/id/42-L.jpg"
+
+    def test_isbn_response_falls_back_to_isbn_cover_when_no_covers(self) -> None:
+        data = {"title": "T", "isbn_13": ["9780151446476"]}
+        meta = parse_isbn_response(data)
+        assert meta.cover_url is not None
+        assert "9780151446476" in meta.cover_url
+
+    def test_works_metadata_populates_first_publish_date(self) -> None:
+        data = {
+            "key": "/works/OL1W",
+            "title": "T",
+            "first_publish_date": "1949",
+        }
+        meta = parse_works_metadata(data)
+        assert meta.original_publication_date == "1949"
+
+    def test_works_metadata_preserves_openlibrary_author_keys(self) -> None:
+        data = {
+            "key": "/works/OL1W",
+            "title": "T",
+            "authors": [{"author": {"key": "/authors/OL1A"}}],
+        }
+        meta = parse_works_metadata(data)
+        assert meta.identifiers["openlibrary_author_keys"] == "/authors/OL1A"
+
+    def test_search_result_populates_cover_and_first_year(self) -> None:
+        data = {
+            "docs": [
+                {
+                    "title": "T",
+                    "cover_i": 77,
+                    "first_publish_year": 1984,
+                    "number_of_pages_median": 250,
+                    "author_key": ["OL1A"],
+                }
+            ]
+        }
+        results = parse_search_results(data)
+        assert len(results) == 1
+        assert results[0].cover_url == "https://covers.openlibrary.org/b/id/77-L.jpg"
+        assert results[0].original_publication_date == "1984"
+        assert results[0].page_count == 250
+        assert results[0].identifiers["openlibrary_author_keys"] == "/authors/OL1A"
+
+    def test_cover_url_skips_sentinel_cover_ids(self) -> None:
+        data = {"title": "T", "covers": [-1, 88]}
+        meta = parse_isbn_response(data)
+        assert meta.cover_url == "https://covers.openlibrary.org/b/id/88-L.jpg"

--- a/tests/unit/test_db_mapping.py
+++ b/tests/unit/test_db_mapping.py
@@ -20,6 +20,8 @@ class TestMetadataToRow:
             "title", "authors", "author_sort", "language", "publisher",
             "isbn", "description", "series", "series_index", "identifiers",
             "subjects", "source_path", "output_path", "file_hash",
+            "cover_url", "published_date", "original_publication_date",
+            "page_count",
         }
         assert expected_keys == set(row.keys())
 

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -56,6 +56,10 @@ class TestOpenLibrary:
             "file_hash",
             "date_added",
             "date_modified",
+            "cover_url",
+            "published_date",
+            "original_publication_date",
+            "page_count",
         }
         assert expected == columns
 
@@ -75,7 +79,7 @@ class TestOpenLibrary:
         row = cursor.fetchone()
         conn.close()
         assert row is not None
-        assert row[0] == 3
+        assert row[0] == 4
 
     def test_creates_indexes(self, db_path: Path) -> None:
         """Expected indexes exist on the books table."""

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 3
+        assert version == 4
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -117,7 +117,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 3
+        assert version == 4
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")

--- a/tests/unit/test_openlibrary_preserves_author_keys.py
+++ b/tests/unit/test_openlibrary_preserves_author_keys.py
@@ -1,0 +1,34 @@
+# ABOUTME: Verifies that OpenLibraryProvider._lookup_by_works preserves openlibrary_author_keys.
+# ABOUTME: Regression guard against the old behavior of deleting author OLIDs after resolution.
+
+from typing import Any
+
+from bookery.metadata.openlibrary import OpenLibraryProvider
+
+
+class _StubHttpClient:
+    def __init__(self, responses: dict[str, dict[str, Any]]) -> None:
+        self._responses = responses
+
+    def get(self, url: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        # Strip host for lookup convenience
+        key = url.replace("https://openlibrary.org", "")
+        return self._responses[key]
+
+
+def test_lookup_by_works_keeps_author_keys_in_identifiers() -> None:
+    http = _StubHttpClient(
+        {
+            "/works/OL1W.json": {
+                "key": "/works/OL1W",
+                "title": "T",
+                "authors": [{"author": {"key": "/authors/OL1A"}}],
+            },
+            "/authors/OL1A.json": {"name": "Author Name"},
+        }
+    )
+    provider = OpenLibraryProvider(http_client=http)
+    candidate = provider._lookup_by_works("/works/OL1W")
+
+    assert candidate.metadata.authors == ["Author Name"]
+    assert candidate.metadata.identifiers.get("openlibrary_author_keys") == "/authors/OL1A"

--- a/tests/unit/test_schema_v3.py
+++ b/tests/unit/test_schema_v3.py
@@ -55,11 +55,11 @@ class TestV3MigrationTables:
         assert "subjects" in columns
 
     def test_schema_version_is_3(self, conn) -> None:
-        """Schema version is 3 after migration."""
+        """Schema version is at least 3 after applying the v3 migration."""
         cursor = conn.execute(
             "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
         )
-        assert cursor.fetchone()[0] == 3
+        assert cursor.fetchone()[0] >= 3
 
 
 class TestMappingSubjects:


### PR DESCRIPTION
Closes #87.

## Summary
- Extends `BookMetadata` with `published_date`, `original_publication_date`, `page_count`, and `cover_url`.
- Schema v4 migration: adds matching columns to the `books` table.
- `OpenLibraryProvider` parsers populate the new fields from ISBN-endpoint, works-endpoint, and search responses. Cover URL prefers the `covers` array (by ID), falling back to the ISBN-based URL.
- `_lookup_by_works` no longer deletes `openlibrary_author_keys` — OLIDs survive into the catalog as the only reliable author disambiguator.
- `bookery info` displays the new fields when present.
- Cover *bytes* are still carried via the existing `cover_image` field; the ISBN-based cover URL fallback keeps current consumers working. A future cleanup can drop `cover_image` from the interchange once the EPUB writer and web view are migrated to the URL + file-cache path.

## Test plan
- [x] `uv run pytest tests/` — 1140 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright` — clean (includes a narrowing `assert` for a pre-existing Optional-str path in `lookup_by_url`)
- [x] New tests: `test_bookmetadata_new_fields.py`, `test_openlibrary_preserves_author_keys.py`
- [x] Updated schema/migration tests to expect schema version 4