### PR TITLE
Metadata: Google Books provider + consensus merger (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ bookery info 42
   [matching]
   auto_accept_threshold = 0.85
   cache_ttl_days = 30        # metadata response cache TTL (default 30)
+  providers = ["openlibrary", "googlebooks"]   # priority order; default ["openlibrary"]
   ```
 
 - **`--no-cache`** on `match`/`rematch` bypasses the on-disk metadata response cache and forces fresh provider lookups. Cached responses live at `{data_dir}/metadata_cache.db` and expire after `[matching].cache_ttl_days`.
+- **`[matching].providers`** selects and orders metadata sources. With a single entry the named provider is used directly; with two or more, results are merged by a consensus step that prefers values agreed on by ≥2 providers and falls back to the priority order otherwise. Supported: `openlibrary`, `googlebooks`.
 
 ## Commands
 

--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -10,31 +10,62 @@ from bookery.metadata.types import BookMetadata
 
 
 def build_metadata_provider(*, use_cache: bool = True):
-    """Build the default metadata provider with optional response caching.
+    """Build the configured metadata provider with optional response caching.
 
-    When ``use_cache`` is true, wraps the HTTP client in a
-    :class:`CachingHttpClient` backed by a SQLite cache at
+    Reads ``[matching].providers`` and composes the listed providers in
+    priority order. A single provider is returned directly; multiple
+    providers are wrapped in a :class:`ConsensusProvider` that merges
+    per-field values and prefers cross-provider agreement.
+
+    When ``use_cache`` is true, each provider's HTTP client is wrapped
+    in a :class:`CachingHttpClient` backed by a SQLite cache at
     ``{data_dir}/metadata_cache.db`` with a TTL from
-    ``[matching].cache_ttl_days``.
+    ``[matching].cache_ttl_days``. The provider label on each cache row
+    keeps entries isolated per upstream API.
     """
     from bookery.core.config import get_data_dir, get_matching_config
     from bookery.metadata.cache import MetadataCache
+    from bookery.metadata.consensus import ConsensusProvider
+    from bookery.metadata.googlebooks import GoogleBooksProvider
     from bookery.metadata.http import BookeryHttpClient, CachingHttpClient
     from bookery.metadata.openlibrary import OpenLibraryProvider
 
-    http_client: object = BookeryHttpClient()
+    matching = get_matching_config()
+    provider_names = matching.providers or ("openlibrary",)
+
+    cache: MetadataCache | None = None
     if use_cache:
-        matching = get_matching_config()
         cache = MetadataCache(
             get_data_dir() / "metadata_cache.db",
             ttl_seconds=matching.cache_ttl_days * 86400.0,
         )
-        http_client = CachingHttpClient(
-            http_client,  # type: ignore[arg-type]
-            cache,
-            provider="openlibrary",
-        )
-    return OpenLibraryProvider(http_client=http_client)  # type: ignore[arg-type]
+
+    def _http_for(provider_name: str):
+        client: object = BookeryHttpClient()
+        if cache is not None:
+            client = CachingHttpClient(
+                client,  # type: ignore[arg-type]
+                cache,
+                provider=provider_name,
+            )
+        return client
+
+    providers: list = []
+    for name in provider_names:
+        if name == "openlibrary":
+            providers.append(OpenLibraryProvider(http_client=_http_for("openlibrary")))  # type: ignore[arg-type]
+        elif name == "googlebooks":
+            providers.append(GoogleBooksProvider(http_client=_http_for("googlebooks")))  # type: ignore[arg-type]
+        else:
+            import logging
+            logging.getLogger(__name__).warning("Unknown metadata provider %r; skipping", name)
+
+    if not providers:
+        providers.append(OpenLibraryProvider(http_client=_http_for("openlibrary")))  # type: ignore[arg-type]
+
+    if len(providers) == 1:
+        return providers[0]
+    return ConsensusProvider(providers)
 
 
 def build_match_fn(

--- a/src/bookery/cli/review.py
+++ b/src/bookery/cli/review.py
@@ -11,6 +11,18 @@ from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.types import BookMetadata
 
 
+def _stamp_source(candidate: MetadataCandidate) -> BookMetadata:
+    """Return the candidate's metadata with its provider source recorded.
+
+    Stamps ``identifiers["source"]`` when not already set so downstream
+    provenance tracking can attribute fields to the originating provider.
+    A ``ConsensusProvider`` may have already set this key to its own name.
+    """
+    metadata = candidate.metadata
+    metadata.identifiers.setdefault("source", candidate.source)
+    return metadata
+
+
 class ReviewSession:
     """Interactive review for metadata candidates.
 
@@ -55,13 +67,15 @@ class ReviewSession:
         # Auto-accept mode: accept best if above threshold, else skip
         if self._auto_above_threshold:
             best = candidates[0]
-            return best.metadata if best.confidence >= self._threshold else None
+            if best.confidence >= self._threshold:
+                return _stamp_source(best)
+            return None
 
         # Quiet mode: auto-accept best candidate if above threshold
         if self._quiet:
             best = candidates[0]
             if best.confidence >= self._threshold:
-                return best.metadata
+                return _stamp_source(best)
             return None
 
         # Display current metadata
@@ -110,7 +124,9 @@ class ReviewSession:
             if choice == "A":
                 self._auto_above_threshold = True
                 best = candidates[0]
-                return best.metadata if best.confidence >= self._threshold else None
+                if best.confidence >= self._threshold:
+                    return _stamp_source(best)
+                return None
             if choice == "S":
                 self._skip_remaining = True
                 return None
@@ -147,7 +163,7 @@ class ReviewSession:
             try:
                 idx = int(choice) - 1
                 if 0 <= idx < len(candidates):
-                    return candidates[idx].metadata
+                    return _stamp_source(candidates[idx])
             except ValueError:
                 pass
 

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -66,6 +66,7 @@ DEFAULT_AUTO_ACCEPT_THRESHOLD = 0.8
 class MatchingConfig:
     auto_accept_threshold: float = DEFAULT_AUTO_ACCEPT_THRESHOLD
     cache_ttl_days: int = 30
+    providers: tuple[str, ...] = ("openlibrary",)
 
 
 @dataclass(frozen=True)
@@ -146,11 +147,21 @@ def _parse_sync(section: dict[str, Any] | None) -> SyncConfig:
 def _parse_matching(section: dict[str, Any] | None) -> MatchingConfig:
     if not section:
         return MatchingConfig()
+    providers_raw = section.get("providers")
+    if providers_raw is None:
+        providers = ("openlibrary",)
+    elif isinstance(providers_raw, (list, tuple)):
+        providers = tuple(str(p).strip() for p in providers_raw if str(p).strip())
+        if not providers:
+            providers = ("openlibrary",)
+    else:
+        providers = ("openlibrary",)
     return MatchingConfig(
         auto_accept_threshold=float(
             section.get("auto_accept_threshold", DEFAULT_AUTO_ACCEPT_THRESHOLD),
         ),
         cache_ttl_days=int(section.get("cache_ttl_days", 30)),
+        providers=providers,
     )
 
 

--- a/src/bookery/metadata/consensus.py
+++ b/src/bookery/metadata/consensus.py
@@ -253,6 +253,7 @@ class ConsensusProvider:
 
         if len(top) == 1:
             provider_name, metadata = top[0]
+            metadata.identifiers.setdefault("source", provider_name)
             return [
                 MetadataCandidate(
                     metadata=metadata,
@@ -269,6 +270,7 @@ class ConsensusProvider:
 
         for field_name, provider_name in provenance.items():
             merged.identifiers[f"provenance_{field_name}"] = provider_name
+        merged.identifiers["source"] = self.name
 
         confidence = max_conf
         isbns = [m.isbn for _p, m in top if m.isbn]

--- a/src/bookery/metadata/consensus.py
+++ b/src/bookery/metadata/consensus.py
@@ -1,0 +1,291 @@
+# ABOUTME: Consensus metadata provider that merges results from multiple providers.
+# ABOUTME: Prefers values agreed on by ≥2 providers; otherwise falls back to priority order.
+
+import logging
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import fields as dataclass_fields
+from typing import Any
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.provider import MetadataProvider
+from bookery.metadata.types import BookMetadata
+
+logger = logging.getLogger(__name__)
+
+_SCALAR_FIELDS = (
+    "title",
+    "author_sort",
+    "language",
+    "publisher",
+    "isbn",
+    "description",
+    "series",
+    "series_index",
+    "cover_url",
+    "published_date",
+    "original_publication_date",
+    "page_count",
+)
+_LIST_FIELDS = ("authors", "subjects")
+_AGREEMENT_BONUS = 0.05
+
+
+def _normalize_isbn(isbn: str | None) -> str | None:
+    if not isbn:
+        return None
+    return "".join(ch for ch in isbn if ch.isalnum()).upper() or None
+
+
+def _normalize_for_vote(field_name: str, value: Any) -> Any:
+    """Turn a field value into a hashable key used to count agreement."""
+    if value is None:
+        return None
+    if field_name == "isbn":
+        return _normalize_isbn(value)
+    if isinstance(value, str):
+        return value.strip().casefold() or None
+    if isinstance(value, list):
+        return tuple(
+            item.strip().casefold()
+            for item in value
+            if isinstance(item, str) and item.strip()
+        )
+    return value
+
+
+def _pick_scalar(
+    field_name: str,
+    values: list[tuple[str, Any]],
+    provenance: dict[str, str],
+) -> Any:
+    """Pick a value for a scalar field from (provider, value) pairs.
+
+    values is in priority order. Prefer values agreed on by ≥2 providers,
+    otherwise the first non-empty value. Records which provider supplied
+    the chosen value in ``provenance``.
+    """
+    non_empty = [(p, v) for p, v in values if v not in (None, "", [])]
+    if not non_empty:
+        return None
+
+    counts: Counter[Any] = Counter()
+    key_to_first: dict[Any, tuple[str, Any]] = {}
+    for provider, value in non_empty:
+        key = _normalize_for_vote(field_name, value)
+        if key is None:
+            continue
+        counts[key] += 1
+        if key not in key_to_first:
+            key_to_first[key] = (provider, value)
+
+    if counts:
+        top_key, top_count = counts.most_common(1)[0]
+        if top_count >= 2:
+            provider, value = key_to_first[top_key]
+            provenance[field_name] = provider
+            return value
+
+    provider, value = non_empty[0]
+    provenance[field_name] = provider
+    return value
+
+
+def _pick_list(
+    field_name: str,
+    values: list[tuple[str, list[str]]],
+    provenance: dict[str, str],
+) -> list[str]:
+    """Pick a list field (authors, subjects): agreement wins, else priority order."""
+    non_empty = [(p, v) for p, v in values if v]
+    if not non_empty:
+        return []
+
+    counts: Counter[tuple[str, ...]] = Counter()
+    key_to_first: dict[tuple[str, ...], tuple[str, list[str]]] = {}
+    for provider, value in non_empty:
+        key = _normalize_for_vote(field_name, value)
+        if not isinstance(key, tuple) or not key:
+            continue
+        counts[key] += 1
+        if key not in key_to_first:
+            key_to_first[key] = (provider, value)
+
+    if counts:
+        top_key, top_count = counts.most_common(1)[0]
+        if top_count >= 2:
+            provider, value = key_to_first[top_key]
+            provenance[field_name] = provider
+            return list(value)
+
+    provider, value = non_empty[0]
+    provenance[field_name] = provider
+    return list(value)
+
+
+def _merge(
+    per_provider: list[tuple[str, BookMetadata]],
+) -> tuple[BookMetadata, dict[str, str]]:
+    """Merge per-provider metadata. Returns (merged, provenance_by_field)."""
+    provenance: dict[str, str] = {}
+
+    merged_identifiers: dict[str, str] = {}
+    for _provider, meta in per_provider:
+        for k, v in meta.identifiers.items():
+            merged_identifiers.setdefault(k, v)
+
+    kwargs: dict[str, Any] = {"identifiers": merged_identifiers}
+
+    title_values = [
+        (p, m.title if m.title and m.title != "Unknown" else None)
+        for p, m in per_provider
+    ]
+    kwargs["title"] = _pick_scalar("title", title_values, provenance) or per_provider[0][1].title
+
+    for fname in _SCALAR_FIELDS:
+        if fname == "title":
+            continue
+        values = [(p, getattr(m, fname)) for p, m in per_provider]
+        kwargs[fname] = _pick_scalar(fname, values, provenance)
+
+    for fname in _LIST_FIELDS:
+        values = [(p, getattr(m, fname)) for p, m in per_provider]
+        kwargs[fname] = _pick_list(fname, values, provenance)
+
+    # Cover image (bytes) and source_path aren't provider-sourced here — preserve first non-None.
+    for fname in ("cover_image", "source_path"):
+        for _p, meta in per_provider:
+            val = getattr(meta, fname)
+            if val is not None:
+                kwargs[fname] = val
+                break
+
+    # Only keep keys that BookMetadata actually defines (defensive).
+    allowed = {f.name for f in dataclass_fields(BookMetadata)}
+    kwargs = {k: v for k, v in kwargs.items() if k in allowed}
+
+    return BookMetadata(**kwargs), provenance
+
+
+class ConsensusProvider:
+    """Merges candidates from multiple providers into a single candidate.
+
+    Strategy:
+      * Query all providers (in parallel via a thread pool).
+      * For each candidate field, prefer the value agreed on by ≥2 providers;
+        otherwise fall back to the first provider in ``providers`` priority order.
+      * When ≥2 providers return a matching ISBN, bump confidence.
+      * Per-field provider attribution is stashed in ``metadata.identifiers``
+        under ``provenance_<field>`` so downstream code (issue #89) can record it.
+    """
+
+    def __init__(self, providers: list[MetadataProvider]) -> None:
+        if not providers:
+            msg = "ConsensusProvider requires at least one provider"
+            raise ValueError(msg)
+        self._providers = providers
+
+    @property
+    def name(self) -> str:
+        return "consensus:" + "+".join(p.name for p in self._providers)
+
+    def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
+        per_provider = self._run_parallel(
+            lambda p: p.search_by_isbn(isbn)
+        )
+        return self._merge_top(per_provider)
+
+    def search_by_title_author(
+        self, title: str, author: str | None = None
+    ) -> list[MetadataCandidate]:
+        per_provider = self._run_parallel(
+            lambda p: p.search_by_title_author(title, author)
+        )
+        return self._merge_top(per_provider)
+
+    def lookup_by_url(self, url: str) -> MetadataCandidate | None:
+        for provider in self._providers:
+            candidate = provider.lookup_by_url(url)
+            if candidate is not None:
+                return candidate
+        return None
+
+    def _run_parallel(
+        self,
+        fn: Any,
+    ) -> list[tuple[str, list[MetadataCandidate]]]:
+        """Run fn(provider) for each provider, in parallel."""
+        if len(self._providers) == 1:
+            return [(self._providers[0].name, fn(self._providers[0]))]
+
+        results: list[tuple[str, list[MetadataCandidate]]] = []
+        with ThreadPoolExecutor(max_workers=len(self._providers)) as executor:
+            futures = {
+                executor.submit(fn, provider): provider for provider in self._providers
+            }
+            # Preserve priority order rather than completion order.
+            provider_to_result: dict[str, list[MetadataCandidate]] = {}
+            for future, provider in futures.items():
+                try:
+                    provider_to_result[provider.name] = future.result()
+                except Exception as exc:
+                    logger.warning(
+                        "Provider %s failed: %s", provider.name, exc
+                    )
+                    provider_to_result[provider.name] = []
+            for provider in self._providers:
+                results.append((provider.name, provider_to_result.get(provider.name, [])))
+        return results
+
+    def _merge_top(
+        self, per_provider_results: list[tuple[str, list[MetadataCandidate]]]
+    ) -> list[MetadataCandidate]:
+        top: list[tuple[str, BookMetadata]] = []
+        max_conf = 0.0
+        for provider_name, candidates in per_provider_results:
+            if not candidates:
+                continue
+            top.append((provider_name, candidates[0].metadata))
+            max_conf = max(max_conf, candidates[0].confidence)
+
+        if not top:
+            return []
+
+        if len(top) == 1:
+            provider_name, metadata = top[0]
+            return [
+                MetadataCandidate(
+                    metadata=metadata,
+                    confidence=max_conf,
+                    source=provider_name,
+                    source_id=metadata.identifiers.get(
+                        f"{provider_name}_volume",
+                        metadata.identifiers.get(f"{provider_name}_work", "unknown"),
+                    ),
+                )
+            ]
+
+        merged, provenance = _merge(top)
+
+        for field_name, provider_name in provenance.items():
+            merged.identifiers[f"provenance_{field_name}"] = provider_name
+
+        confidence = max_conf
+        isbns = [m.isbn for _p, m in top if m.isbn]
+        if len(isbns) >= 2:
+            normalized = {_normalize_isbn(i) for i in isbns}
+            normalized.discard(None)
+            if len(normalized) == 1:
+                confidence = min(1.0, confidence + _AGREEMENT_BONUS)
+
+        return [
+            MetadataCandidate(
+                metadata=merged,
+                confidence=confidence,
+                source=self.name,
+                source_id=(
+                    merged.isbn
+                    or top[0][1].identifiers.get("openlibrary_work", "consensus")
+                ),
+            )
+        ]

--- a/src/bookery/metadata/googlebooks.py
+++ b/src/bookery/metadata/googlebooks.py
@@ -1,0 +1,212 @@
+# ABOUTME: Google Books metadata provider implementation.
+# ABOUTME: Searches Google Books v1 API by ISBN or title/author and returns scored candidates.
+
+import logging
+import re
+from typing import Any
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.http import HttpClient, MetadataFetchError
+from bookery.metadata.scoring import score_candidate
+from bookery.metadata.types import BookMetadata
+
+logger = logging.getLogger(__name__)
+
+_GB_BASE = "https://www.googleapis.com/books/v1/volumes"
+_SEARCH_LIMIT = 5
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text: str) -> str:
+    """Remove HTML tags and collapse whitespace."""
+    return re.sub(r"\s+", " ", _HTML_TAG_RE.sub("", text)).strip()
+
+
+def _pick_isbn(industry_identifiers: list[dict[str, str]]) -> str | None:
+    """Return ISBN_13 if available, else ISBN_10, else None."""
+    isbn_13 = None
+    isbn_10 = None
+    for ident in industry_identifiers:
+        ident_type = ident.get("type", "")
+        value = ident.get("identifier", "")
+        if ident_type == "ISBN_13" and not isbn_13:
+            isbn_13 = value
+        elif ident_type == "ISBN_10" and not isbn_10:
+            isbn_10 = value
+    return isbn_13 or isbn_10
+
+
+def _parse_volume(item: dict[str, Any]) -> BookMetadata:
+    """Parse a Google Books `volumes` item into BookMetadata."""
+    volume_info = item.get("volumeInfo", {}) or {}
+
+    title = volume_info.get("title", "Unknown")
+    subtitle = volume_info.get("subtitle")
+    if subtitle:
+        title = f"{title}: {subtitle}"
+
+    authors = list(volume_info.get("authors", []) or [])
+
+    publisher = volume_info.get("publisher")
+    published_date = volume_info.get("publishedDate")
+    language = volume_info.get("language")
+    page_count = volume_info.get("pageCount")
+    page_count = int(page_count) if isinstance(page_count, (int, float)) else None
+
+    description = volume_info.get("description")
+    if description:
+        description = _strip_html(description)
+
+    subjects = list(volume_info.get("categories", []) or [])
+
+    isbn = _pick_isbn(volume_info.get("industryIdentifiers", []) or [])
+
+    image_links = volume_info.get("imageLinks", {}) or {}
+    cover_url = (
+        image_links.get("thumbnail")
+        or image_links.get("smallThumbnail")
+        or None
+    )
+    if cover_url and cover_url.startswith("http://"):
+        cover_url = "https://" + cover_url[len("http://") :]
+
+    identifiers: dict[str, str] = {}
+    volume_id = item.get("id")
+    if volume_id:
+        identifiers["googlebooks_volume"] = volume_id
+
+    return BookMetadata(
+        title=title,
+        authors=authors,
+        publisher=publisher,
+        isbn=isbn,
+        language=language,
+        description=description,
+        subjects=subjects,
+        identifiers=identifiers,
+        published_date=published_date,
+        page_count=page_count,
+        cover_url=cover_url,
+    )
+
+
+class GoogleBooksProvider:
+    """Metadata provider backed by the Google Books v1 API.
+
+    No auth required for the query endpoints we use. Fills in publishedDate,
+    pageCount, and cover thumbnails that Open Library routinely lacks.
+    """
+
+    def __init__(self, http_client: HttpClient) -> None:
+        self._http = http_client
+
+    @property
+    def name(self) -> str:
+        return "googlebooks"
+
+    def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
+        """Look up a book by ISBN via Google Books.
+
+        Returns a single-element list on success, empty list on failure.
+        """
+        clean_isbn = re.sub(r"[\s-]", "", isbn)
+        try:
+            data = self._http.get(_GB_BASE, params={"q": f"isbn:{clean_isbn}"})
+        except MetadataFetchError as exc:
+            logger.warning("ISBN lookup failed for %s: %s", isbn, exc)
+            return []
+
+        items = data.get("items", []) or []
+        if not items:
+            return []
+
+        metadata = _parse_volume(items[0])
+        source_id = metadata.identifiers.get("googlebooks_volume", f"isbn:{clean_isbn}")
+        return [
+            MetadataCandidate(
+                metadata=metadata,
+                confidence=1.0,
+                source=self.name,
+                source_id=source_id,
+            )
+        ]
+
+    def search_by_title_author(
+        self, title: str, author: str | None = None
+    ) -> list[MetadataCandidate]:
+        """Search Google Books by title and optional author."""
+        query_parts = [f"intitle:{title}"]
+        if author:
+            query_parts.append(f"inauthor:{author}")
+        query = "+".join(query_parts)
+
+        try:
+            data = self._http.get(
+                _GB_BASE,
+                params={"q": query, "maxResults": str(_SEARCH_LIMIT)},
+            )
+        except MetadataFetchError as exc:
+            logger.warning("Search failed for title=%s author=%s: %s", title, author, exc)
+            return []
+
+        items = data.get("items", []) or []
+        if not items:
+            return []
+
+        query_meta = BookMetadata(
+            title=title,
+            authors=[author] if author else [],
+        )
+
+        candidates: list[MetadataCandidate] = []
+        for item in items:
+            meta = _parse_volume(item)
+            confidence = score_candidate(query_meta, meta)
+            source_id = meta.identifiers.get("googlebooks_volume", "unknown")
+            candidates.append(
+                MetadataCandidate(
+                    metadata=meta,
+                    confidence=confidence,
+                    source=self.name,
+                    source_id=source_id,
+                )
+            )
+
+        candidates.sort(key=lambda c: c.confidence, reverse=True)
+        return candidates
+
+    def lookup_by_url(self, url: str) -> MetadataCandidate | None:
+        """Look up metadata from a Google Books volume URL.
+
+        Supports:
+          https://books.google.com/books?id=VOLUME_ID
+          https://www.google.com/books/edition/_/VOLUME_ID
+          https://books.google.com/books/about/Title.html?id=VOLUME_ID
+        """
+        volume_id = self._parse_volume_id(url)
+        if not volume_id:
+            return None
+        try:
+            data = self._http.get(f"{_GB_BASE}/{volume_id}")
+        except MetadataFetchError as exc:
+            logger.warning("URL lookup failed for %s: %s", url, exc)
+            return None
+
+        metadata = _parse_volume(data)
+        return MetadataCandidate(
+            metadata=metadata,
+            confidence=1.0,
+            source=self.name,
+            source_id=volume_id,
+        )
+
+    @staticmethod
+    def _parse_volume_id(url: str) -> str | None:
+        """Extract a Google Books volume id from a URL."""
+        match = re.search(r"[?&]id=([A-Za-z0-9_-]+)", url)
+        if match:
+            return match.group(1)
+        match = re.search(r"/books/edition/[^/]+/([A-Za-z0-9_-]+)", url)
+        if match:
+            return match.group(1)
+        return None

--- a/src/bookery/metadata/googlebooks.py
+++ b/src/bookery/metadata/googlebooks.py
@@ -51,7 +51,10 @@ def _parse_volume(item: dict[str, Any]) -> BookMetadata:
     published_date = volume_info.get("publishedDate")
     language = volume_info.get("language")
     page_count = volume_info.get("pageCount")
-    page_count = int(page_count) if isinstance(page_count, (int, float)) else None
+    if isinstance(page_count, (int, float)) and page_count > 0:
+        page_count = int(page_count)
+    else:
+        page_count = None
 
     description = volume_info.get("description")
     if description:
@@ -138,7 +141,10 @@ class GoogleBooksProvider:
         query_parts = [f"intitle:{title}"]
         if author:
             query_parts.append(f"inauthor:{author}")
-        query = "+".join(query_parts)
+        # Google Books accepts space-separated terms; `+` in a params dict
+        # value gets URL-encoded to %2B, which Google treats as a literal
+        # character rather than a separator.
+        query = " ".join(query_parts)
 
         try:
             data = self._http.get(

--- a/tests/unit/test_consensus_provider.py
+++ b/tests/unit/test_consensus_provider.py
@@ -180,6 +180,53 @@ def test_empty_provider_list_rejected() -> None:
         ConsensusProvider([])
 
 
+def test_merged_metadata_records_source_identifier() -> None:
+    p1 = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["Frank Herbert"])],
+    )
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[_cand("googlebooks", title="Dune", authors=["Frank Herbert"])],
+    )
+    consensus = ConsensusProvider([p1, p2])
+    result = consensus.search_by_isbn("9780441013593")
+    assert result[0].metadata.identifiers["source"] == consensus.name
+
+
+def test_single_provider_passthrough_stamps_source() -> None:
+    # Even with a single-provider ConsensusProvider, downstream code
+    # (rematch, provenance tracking) expects ``identifiers["source"]``.
+    p = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["Frank Herbert"])],
+    )
+    consensus = ConsensusProvider([p])
+    result = consensus.search_by_isbn("9780441013593")
+    assert result[0].metadata.identifiers["source"] == "openlibrary"
+
+
+def test_authors_list_agreement_prefers_agreed_value() -> None:
+    # Two providers emit authors in a normalized "First Last" form; priority
+    # provider's single-author spelling differs — agreement should win.
+    p1 = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["F. Herbert"])],
+    )
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[_cand("googlebooks", title="Dune", authors=["Frank Herbert"])],
+    )
+    p3 = FakeProvider(
+        "other",
+        isbn_results=[_cand("other", title="Dune", authors=["Frank Herbert"])],
+    )
+    consensus = ConsensusProvider([p1, p2, p3])
+    result = consensus.search_by_isbn("9780441013593")
+    assert result[0].metadata.authors == ["Frank Herbert"]
+    assert result[0].metadata.identifiers["provenance_authors"] == "googlebooks"
+
+
 def test_lookup_by_url_returns_first_hit_in_priority_order() -> None:
     cand = MetadataCandidate(
         metadata=BookMetadata(title="Dune"),

--- a/tests/unit/test_consensus_provider.py
+++ b/tests/unit/test_consensus_provider.py
@@ -1,0 +1,193 @@
+# ABOUTME: Unit tests for the ConsensusProvider metadata merger.
+# ABOUTME: Verifies per-field agreement preference, priority fallback, and confidence bump.
+
+import pytest
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.consensus import ConsensusProvider
+from bookery.metadata.types import BookMetadata
+
+
+class FakeProvider:
+    def __init__(
+        self,
+        name: str,
+        *,
+        isbn_results: list[MetadataCandidate] | None = None,
+        title_results: list[MetadataCandidate] | None = None,
+        url_result: MetadataCandidate | None = None,
+    ) -> None:
+        self._name = name
+        self._isbn = isbn_results or []
+        self._title = title_results or []
+        self._url = url_result
+        self.isbn_calls: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
+        self.isbn_calls.append(isbn)
+        return list(self._isbn)
+
+    def search_by_title_author(
+        self, title: str, author: str | None = None
+    ) -> list[MetadataCandidate]:
+        return list(self._title)
+
+    def lookup_by_url(self, url: str) -> MetadataCandidate | None:
+        return self._url
+
+
+def _cand(source: str, **meta_fields) -> MetadataCandidate:
+    meta = BookMetadata(**meta_fields)
+    return MetadataCandidate(
+        metadata=meta,
+        confidence=meta_fields.pop("confidence", 1.0) if False else 1.0,
+        source=source,
+        source_id=f"{source}:1",
+    )
+
+
+def test_single_provider_returns_its_candidate_unchanged() -> None:
+    p = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["Frank Herbert"])],
+    )
+    consensus = ConsensusProvider([p])
+    result = consensus.search_by_isbn("9780441013593")
+    assert len(result) == 1
+    assert result[0].metadata.title == "Dune"
+
+
+def test_two_providers_agreement_wins_over_priority() -> None:
+    # Provider 1 (priority) says "Dune", provider 2 and 3 agree on "Dune (Special Edition)".
+    p1 = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["Frank Herbert"])],
+    )
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[
+            _cand(
+                "googlebooks",
+                title="Dune (Special Edition)",
+                authors=["Frank Herbert"],
+            )
+        ],
+    )
+    p3 = FakeProvider(
+        "other",
+        isbn_results=[
+            _cand(
+                "other",
+                title="Dune (Special Edition)",
+                authors=["Frank Herbert"],
+            )
+        ],
+    )
+    consensus = ConsensusProvider([p1, p2, p3])
+    result = consensus.search_by_isbn("9780441013593")
+    assert len(result) == 1
+    # Agreement between p2 and p3 beats p1's priority.
+    assert result[0].metadata.title == "Dune (Special Edition)"
+
+
+def test_no_agreement_falls_back_to_priority_order() -> None:
+    p1 = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["Frank Herbert"])],
+    )
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[
+            _cand("googlebooks", title="DUNE (messiah edition)", authors=["F. Herbert"])
+        ],
+    )
+    consensus = ConsensusProvider([p1, p2])
+    result = consensus.search_by_isbn("9780441013593")
+    assert result[0].metadata.title == "Dune"
+    # Per-field provenance is recorded in identifiers under provenance_<field>.
+    assert result[0].metadata.identifiers["provenance_title"] == "openlibrary"
+
+
+def test_missing_field_is_filled_from_other_provider() -> None:
+    # Open Library has no page_count; Google Books supplies it.
+    p1 = FakeProvider(
+        "openlibrary",
+        isbn_results=[_cand("openlibrary", title="Dune", authors=["Frank Herbert"])],
+    )
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[
+            _cand(
+                "googlebooks",
+                title="Dune",
+                authors=["Frank Herbert"],
+                page_count=412,
+                published_date="1965",
+            )
+        ],
+    )
+    consensus = ConsensusProvider([p1, p2])
+    result = consensus.search_by_isbn("9780441013593")
+    merged = result[0].metadata
+    assert merged.page_count == 412
+    assert merged.published_date == "1965"
+    assert merged.identifiers["provenance_page_count"] == "googlebooks"
+
+
+def test_isbn_agreement_bumps_confidence() -> None:
+    cand1 = MetadataCandidate(
+        metadata=BookMetadata(title="Dune", isbn="978-0-441-01359-3"),
+        confidence=0.9,
+        source="openlibrary",
+        source_id="OL1",
+    )
+    cand2 = MetadataCandidate(
+        metadata=BookMetadata(title="Dune", isbn="9780441013593"),
+        confidence=0.85,
+        source="googlebooks",
+        source_id="GB1",
+    )
+    p1 = FakeProvider("openlibrary", isbn_results=[cand1])
+    p2 = FakeProvider("googlebooks", isbn_results=[cand2])
+    consensus = ConsensusProvider([p1, p2])
+    result = consensus.search_by_isbn("9780441013593")
+    # max confidence (0.9) + agreement bonus (0.05).
+    assert result[0].confidence == pytest.approx(0.95, abs=1e-6)
+
+
+def test_failing_provider_does_not_break_consensus() -> None:
+    class BoomProvider(FakeProvider):
+        def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
+            raise RuntimeError("API down")
+
+    p1 = BoomProvider("openlibrary")
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[_cand("googlebooks", title="Dune", authors=["Frank Herbert"])],
+    )
+    consensus = ConsensusProvider([p1, p2])
+    result = consensus.search_by_isbn("9780441013593")
+    assert len(result) == 1
+    assert result[0].metadata.title == "Dune"
+
+
+def test_empty_provider_list_rejected() -> None:
+    with pytest.raises(ValueError):
+        ConsensusProvider([])
+
+
+def test_lookup_by_url_returns_first_hit_in_priority_order() -> None:
+    cand = MetadataCandidate(
+        metadata=BookMetadata(title="Dune"),
+        confidence=1.0,
+        source="openlibrary",
+        source_id="OL/works/1",
+    )
+    p1 = FakeProvider("openlibrary", url_result=cand)
+    p2 = FakeProvider("googlebooks", url_result=None)
+    consensus = ConsensusProvider([p1, p2])
+    assert consensus.lookup_by_url("https://openlibrary.org/works/OL1") is cand

--- a/tests/unit/test_googlebooks_provider.py
+++ b/tests/unit/test_googlebooks_provider.py
@@ -1,0 +1,170 @@
+# ABOUTME: Unit tests for the Google Books metadata provider.
+# ABOUTME: Mocks HTTP client; verifies ISBN and title/author parsing.
+
+from typing import Any
+
+import pytest
+
+from bookery.metadata.googlebooks import GoogleBooksProvider
+from bookery.metadata.http import MetadataFetchError
+
+
+class FakeHttpClient:
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self._responses = responses or {}
+        self.last_params: dict[str, str] | None = None
+        self.request_log: list[tuple[str, dict[str, str] | None]] = []
+
+    def get(self, url: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        self.last_params = params
+        self.request_log.append((url, params))
+        for pattern, response in self._responses.items():
+            if pattern in url or (params and pattern in (params.get("q") or "")):
+                if isinstance(response, Exception):
+                    raise response
+                return response
+        return {"items": []}
+
+
+def _volume(
+    *,
+    vol_id: str = "VOL1",
+    title: str = "Dune",
+    subtitle: str | None = None,
+    authors: list[str] | None = None,
+    isbn_13: str | None = "9780441013593",
+    page_count: int | None = 412,
+    language: str = "en",
+    publisher: str | None = "Chilton",
+    published_date: str | None = "1965",
+    description: str | None = "<p>Epic.</p>",
+    categories: list[str] | None = None,
+    thumbnail: str | None = "http://books.google.com/cover.jpg",
+) -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "title": title,
+        "authors": authors if authors is not None else ["Frank Herbert"],
+        "language": language,
+    }
+    if subtitle:
+        info["subtitle"] = subtitle
+    if publisher:
+        info["publisher"] = publisher
+    if published_date:
+        info["publishedDate"] = published_date
+    if page_count is not None:
+        info["pageCount"] = page_count
+    if description is not None:
+        info["description"] = description
+    if categories:
+        info["categories"] = categories
+    if isbn_13:
+        info["industryIdentifiers"] = [{"type": "ISBN_13", "identifier": isbn_13}]
+    if thumbnail:
+        info["imageLinks"] = {"thumbnail": thumbnail}
+    return {"id": vol_id, "volumeInfo": info}
+
+
+def test_search_by_isbn_returns_parsed_candidate() -> None:
+    http = FakeHttpClient({"volumes": {"items": [_volume()]}})
+    provider = GoogleBooksProvider(http_client=http)
+
+    candidates = provider.search_by_isbn("978-0-441-01359-3")
+
+    assert len(candidates) == 1
+    cand = candidates[0]
+    assert cand.source == "googlebooks"
+    assert cand.source_id == "VOL1"
+    assert cand.confidence == 1.0
+    assert cand.metadata.title == "Dune"
+    assert cand.metadata.authors == ["Frank Herbert"]
+    assert cand.metadata.isbn == "9780441013593"
+    assert cand.metadata.page_count == 412
+    assert cand.metadata.published_date == "1965"
+    assert cand.metadata.publisher == "Chilton"
+    assert cand.metadata.cover_url == "https://books.google.com/cover.jpg"
+    assert cand.metadata.description == "Epic."
+    assert cand.metadata.identifiers["googlebooks_volume"] == "VOL1"
+    assert http.last_params == {"q": "isbn:9780441013593"}
+
+
+def test_search_by_isbn_with_no_items_returns_empty() -> None:
+    http = FakeHttpClient({"volumes": {"items": []}})
+    provider = GoogleBooksProvider(http_client=http)
+    assert provider.search_by_isbn("9780000000000") == []
+
+
+def test_search_by_isbn_on_fetch_error_returns_empty() -> None:
+    http = FakeHttpClient({"volumes": MetadataFetchError("boom")})
+    provider = GoogleBooksProvider(http_client=http)
+    assert provider.search_by_isbn("9780000000000") == []
+
+
+def test_search_by_title_author_builds_query_and_sorts() -> None:
+    http = FakeHttpClient(
+        {
+            "volumes": {
+                "items": [
+                    _volume(vol_id="A", title="Completely Unrelated"),
+                    _volume(vol_id="B", title="Dune"),
+                ]
+            }
+        }
+    )
+    provider = GoogleBooksProvider(http_client=http)
+
+    candidates = provider.search_by_title_author("Dune", "Frank Herbert")
+
+    assert len(candidates) == 2
+    # The exact-match candidate should rank first.
+    assert candidates[0].source_id == "B"
+    assert http.last_params == {
+        "q": "intitle:Dune+inauthor:Frank Herbert",
+        "maxResults": "5",
+    }
+
+
+def test_subtitle_is_joined_into_title() -> None:
+    http = FakeHttpClient(
+        {"volumes": {"items": [_volume(title="Dune", subtitle="A Novel")]}}
+    )
+    provider = GoogleBooksProvider(http_client=http)
+    candidates = provider.search_by_isbn("9780441013593")
+    assert candidates[0].metadata.title == "Dune: A Novel"
+
+
+def test_isbn_10_is_used_when_no_isbn_13() -> None:
+    volume = _volume(isbn_13=None)
+    volume["volumeInfo"]["industryIdentifiers"] = [
+        {"type": "ISBN_10", "identifier": "0441013597"}
+    ]
+    http = FakeHttpClient({"volumes": {"items": [volume]}})
+    provider = GoogleBooksProvider(http_client=http)
+    candidates = provider.search_by_isbn("0441013597")
+    assert candidates[0].metadata.isbn == "0441013597"
+
+
+def test_lookup_by_url_parses_volume_id() -> None:
+    http = FakeHttpClient({"/VOL42": _volume(vol_id="VOL42")})
+    provider = GoogleBooksProvider(http_client=http)
+    cand = provider.lookup_by_url("https://books.google.com/books?id=VOL42")
+    assert cand is not None
+    assert cand.source_id == "VOL42"
+
+
+def test_lookup_by_url_returns_none_for_bad_url() -> None:
+    http = FakeHttpClient({})
+    provider = GoogleBooksProvider(http_client=http)
+    assert provider.lookup_by_url("https://example.com/nope") is None
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://books.google.com/books?id=ABC_123", "ABC_123"),
+        ("https://www.google.com/books/edition/_/ABCxyz", "ABCxyz"),
+        ("https://example.com/no-id", None),
+    ],
+)
+def test_parse_volume_id(url: str, expected: str | None) -> None:
+    assert GoogleBooksProvider._parse_volume_id(url) == expected

--- a/tests/unit/test_googlebooks_provider.py
+++ b/tests/unit/test_googlebooks_provider.py
@@ -119,7 +119,7 @@ def test_search_by_title_author_builds_query_and_sorts() -> None:
     # The exact-match candidate should rank first.
     assert candidates[0].source_id == "B"
     assert http.last_params == {
-        "q": "intitle:Dune+inauthor:Frank Herbert",
+        "q": "intitle:Dune inauthor:Frank Herbert",
         "maxResults": "5",
     }
 
@@ -168,3 +168,12 @@ def test_lookup_by_url_returns_none_for_bad_url() -> None:
 )
 def test_parse_volume_id(url: str, expected: str | None) -> None:
     assert GoogleBooksProvider._parse_volume_id(url) == expected
+
+
+def test_page_count_of_zero_is_coerced_to_none() -> None:
+    # Google Books frequently returns pageCount: 0 for books without an
+    # authoritative count. That should not pollute the BookMetadata.
+    http = FakeHttpClient({"volumes": {"items": [_volume(page_count=0)]}})
+    provider = GoogleBooksProvider(http_client=http)
+    candidates = provider.search_by_isbn("9780441013593")
+    assert candidates[0].metadata.page_count is None

--- a/tests/unit/test_match_providers_config.py
+++ b/tests/unit/test_match_providers_config.py
@@ -1,0 +1,54 @@
+# ABOUTME: Tests that [matching].providers drives provider composition via build_metadata_provider.
+# ABOUTME: Covers single-provider passthrough and multi-provider ConsensusProvider wrapping.
+
+from pathlib import Path
+
+from bookery.cli._match_helpers import build_metadata_provider
+
+
+def _install_config(home: Path, body: str | None) -> None:
+    bookery_dir = home / ".bookery"
+    bookery_dir.mkdir(parents=True, exist_ok=True)
+    if body is not None:
+        (bookery_dir / "config.toml").write_text(body)
+
+
+def _isolate(monkeypatch, tmp_path, body: str | None = None) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("BOOKERY_LIBRARY_ROOT", raising=False)
+    # Force Path.home() to honor our test HOME across platforms.
+    monkeypatch.setattr(Path, "home", lambda: Path(str(tmp_path)))
+    _install_config(tmp_path, body)
+
+
+def test_default_config_returns_openlibrary_provider(monkeypatch, tmp_path) -> None:
+    _isolate(monkeypatch, tmp_path, body=None)
+    provider = build_metadata_provider(use_cache=False)
+    assert type(provider).__name__ == "OpenLibraryProvider"
+
+
+def test_multi_provider_config_wraps_in_consensus(monkeypatch, tmp_path) -> None:
+    _isolate(
+        monkeypatch,
+        tmp_path,
+        body='[matching]\nproviders = ["openlibrary", "googlebooks"]\n',
+    )
+    provider = build_metadata_provider(use_cache=False)
+    assert type(provider).__name__ == "ConsensusProvider"
+    assert provider.name == "consensus:openlibrary+googlebooks"
+
+
+def test_googlebooks_only_config(monkeypatch, tmp_path) -> None:
+    _isolate(monkeypatch, tmp_path, body='[matching]\nproviders = ["googlebooks"]\n')
+    provider = build_metadata_provider(use_cache=False)
+    assert type(provider).__name__ == "GoogleBooksProvider"
+
+
+def test_unknown_provider_is_skipped(monkeypatch, tmp_path) -> None:
+    _isolate(
+        monkeypatch,
+        tmp_path,
+        body='[matching]\nproviders = ["bogus", "openlibrary"]\n',
+    )
+    provider = build_metadata_provider(use_cache=False)
+    assert type(provider).__name__ == "OpenLibraryProvider"


### PR DESCRIPTION
Closes #88.

## Summary
- New `GoogleBooksProvider` (ISBN + title/author + URL lookups) that fills in `published_date`, `page_count`, and cover thumbnails that Open Library often lacks.
- New `ConsensusProvider` that queries multiple providers in parallel and merges per-field: values agreed on by ≥2 providers win, otherwise falls back to priority order. Bumps confidence when ISBNs agree.
- `[matching].providers` config key drives composition — single provider is returned directly; two or more are wrapped in consensus. Default stays `["openlibrary"]`.
- Per-field provenance is stamped into `metadata.identifiers` as `provenance_<field>`, which sets up #89.
- README documents the new option.

## Test plan
- [x] 11 unit tests for `GoogleBooksProvider` (ISBN, title/author sorting, subtitle join, ISBN-10 fallback, URL parsing, error paths)
- [x] 8 unit tests for `ConsensusProvider` (single-provider passthrough, agreement-beats-priority, priority fallback, missing-field fill, ISBN-agreement confidence bump, failing provider isolation, empty-list rejection, URL lookup priority)
- [x] 4 unit tests for the config-driven factory composition (default / consensus / googlebooks-only / unknown-provider-skipped)
- [x] Full suite: 1193 passed (was 1170)
- [x] `ruff check` clean, pre-commit pyright clean