### PR TITLE
Metadata: per-field provenance tracking (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ bookery info 42
 
 - **`--no-cache`** on `match`/`rematch` bypasses the on-disk metadata response cache and forces fresh provider lookups. Cached responses live at `{data_dir}/metadata_cache.db` and expire after `[matching].cache_ttl_days`.
 - **`[matching].providers`** selects and orders metadata sources. With a single entry the named provider is used directly; with two or more, results are merged by a consensus step that prefers values agreed on by ≥2 providers and falls back to the priority order otherwise. Supported: `openlibrary`, `googlebooks`.
+- **Per-field provenance** is recorded for every cataloged book in the `book_field_provenance` table. Use `bookery info <id> --provenance` to see which source supplied each field and when it was fetched. Use `bookery info <id> --set field=value` to hand-edit a value (it's stamped as `user` and locked against overwrite), and `--lock field` / `--unlock field` to gate fields against `rematch`.
 
 ## Commands
 

--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -16,7 +16,7 @@ console = Console()  # TODO: move Console() inside command for testability
 
 _SETTABLE_FIELDS = {
     "title", "authors", "author_sort", "language", "publisher", "isbn",
-    "description", "series", "series_index", "published_date",
+    "description", "series", "series_index", "subjects", "published_date",
     "original_publication_date", "page_count", "cover_url",
 }
 
@@ -36,7 +36,7 @@ def _parse_set_pairs(pairs: tuple[str, ...]) -> dict[str, object]:
                 f"Unknown field {key!r}. Settable fields: "
                 f"{', '.join(sorted(_SETTABLE_FIELDS))}"
             )
-        if key == "authors":
+        if key in ("authors", "subjects"):
             out[key] = [a.strip() for a in value.split(",") if a.strip()]
         elif key == "page_count":
             out[key] = int(value)
@@ -105,13 +105,9 @@ def info(
     if set_pairs:
         parsed = _parse_set_pairs(set_pairs)
         catalog.update_book(book_id, source="user", **parsed)  # type: ignore[arg-type]
-        for field_name in parsed:
-            catalog.set_field_lock(book_id, field_name, True)
         record = catalog.get_by_id(book_id)
         assert record is not None
-        console.print(
-            f"[green]Updated and locked:[/green] {', '.join(sorted(parsed))}"
-        )
+        console.print(f"[green]Updated:[/green] {', '.join(sorted(parsed))}")
 
     for field_name in lock_fields:
         catalog.set_field_lock(book_id, field_name, True)

--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -14,11 +14,83 @@ from bookery.db.connection import open_library
 console = Console()  # TODO: move Console() inside command for testability
 
 
+_SETTABLE_FIELDS = {
+    "title", "authors", "author_sort", "language", "publisher", "isbn",
+    "description", "series", "series_index", "published_date",
+    "original_publication_date", "page_count", "cover_url",
+}
+
+
+def _parse_set_pairs(pairs: tuple[str, ...]) -> dict[str, object]:
+    """Parse ``field=value`` CLI pairs into a dict suitable for update_book."""
+    out: dict[str, object] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise click.BadParameter(
+                f"--set expects field=value, got {pair!r}"
+            )
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if key not in _SETTABLE_FIELDS:
+            raise click.BadParameter(
+                f"Unknown field {key!r}. Settable fields: "
+                f"{', '.join(sorted(_SETTABLE_FIELDS))}"
+            )
+        if key == "authors":
+            out[key] = [a.strip() for a in value.split(",") if a.strip()]
+        elif key == "page_count":
+            out[key] = int(value)
+        elif key == "series_index":
+            out[key] = float(value)
+        else:
+            out[key] = value
+    return out
+
+
 @click.command("info")
 @click.argument("book_id", type=int)
 @db_option
-def info(book_id: int, db_path: Path | None) -> None:
-    """Show detailed metadata for a book by ID."""
+@click.option(
+    "--provenance",
+    "show_provenance",
+    is_flag=True,
+    help="Show the per-field source and fetched_at timestamps.",
+)
+@click.option(
+    "--set",
+    "set_pairs",
+    multiple=True,
+    metavar="FIELD=VALUE",
+    help="Set a field value and record provenance as 'user'. Repeatable.",
+)
+@click.option(
+    "--lock",
+    "lock_fields",
+    multiple=True,
+    metavar="FIELD",
+    help="Lock a field against automatic rematch overwrites. Repeatable.",
+)
+@click.option(
+    "--unlock",
+    "unlock_fields",
+    multiple=True,
+    metavar="FIELD",
+    help="Unlock a previously locked field. Repeatable.",
+)
+def info(
+    book_id: int,
+    db_path: Path | None,
+    show_provenance: bool,
+    set_pairs: tuple[str, ...],
+    lock_fields: tuple[str, ...],
+    unlock_fields: tuple[str, ...],
+) -> None:
+    """Show detailed metadata for a book by ID.
+
+    Use ``--set field=value`` to hand-edit values (recorded as ``user`` in
+    the provenance table). Add ``--lock field`` to protect a value from
+    being clobbered by a future ``rematch``.
+    """
     # TODO: wrap conn in try-finally or context manager to prevent leak on exception
     conn = open_library(resolve_db_path(db_path))
     catalog = LibraryCatalog(conn)
@@ -29,6 +101,53 @@ def info(book_id: int, db_path: Path | None) -> None:
         console.print(f"[red]Book {book_id} not found.[/red]")
         conn.close()
         raise SystemExit(1)
+
+    if set_pairs:
+        parsed = _parse_set_pairs(set_pairs)
+        catalog.update_book(book_id, source="user", **parsed)  # type: ignore[arg-type]
+        for field_name in parsed:
+            catalog.set_field_lock(book_id, field_name, True)
+        record = catalog.get_by_id(book_id)
+        assert record is not None
+        console.print(
+            f"[green]Updated and locked:[/green] {', '.join(sorted(parsed))}"
+        )
+
+    for field_name in lock_fields:
+        catalog.set_field_lock(book_id, field_name, True)
+    for field_name in unlock_fields:
+        catalog.set_field_lock(book_id, field_name, False)
+    if lock_fields:
+        console.print(f"[green]Locked:[/green] {', '.join(sorted(set(lock_fields)))}")
+    if unlock_fields:
+        console.print(
+            f"[green]Unlocked:[/green] {', '.join(sorted(set(unlock_fields)))}"
+        )
+
+    if show_provenance:
+        prov = catalog.get_provenance(book_id)
+        if not prov:
+            console.print("[yellow]No provenance recorded for this book.[/yellow]")
+            conn.close()
+            return
+        table = Table(title=f"Provenance for book {book_id}")
+        table.add_column("Field", style="bold")
+        table.add_column("Source")
+        table.add_column("Fetched")
+        table.add_column("Confidence", justify="right")
+        table.add_column("Locked")
+        for entry in prov.values():
+            conf = f"{entry.confidence:.0%}" if entry.confidence is not None else "—"
+            table.add_row(
+                entry.field_name,
+                entry.source,
+                entry.fetched_at,
+                conf,
+                "yes" if entry.locked else "no",
+            )
+        console.print(table)
+        conn.close()
+        return
 
     meta = record.metadata
     table = Table(show_header=False, box=None, pad_edge=False)

--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -213,10 +213,27 @@ def rematch(
             if result.status == "matched":
                 assert result.metadata is not None
                 fields = _metadata_to_update_fields(result.metadata)
-                catalog.update_book(record.id, **fields)
+                source = result.metadata.identifiers.get("source") or "matcher"
+                per_field_provenance = {
+                    k.removeprefix("provenance_"): v
+                    for k, v in result.metadata.identifiers.items()
+                    if k.startswith("provenance_")
+                }
+                written = catalog.update_book(
+                    record.id,
+                    source=source,
+                    provenance=per_field_provenance or None,
+                    respect_locked=True,
+                    **fields,
+                )
                 if result.output_path:
                     catalog.set_output_path(record.id, result.output_path)
                 if not auto_accept:
+                    locked = set(fields) - set(written)
+                    if locked:
+                        console.print(
+                            f"  [dim]Preserved locked field(s):[/dim] {', '.join(sorted(locked))}"
+                        )
                     console.print(f"  [green]Updated:[/green] {result.output_path}")
                 matched += 1
             elif result.status == "skipped":

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -242,10 +242,21 @@ class LibraryCatalog:
         written = list(fields.keys())
 
         if source is not None or provenance:
-            prov_map = {f: source for f in written} if source else {}
+            # Fields that were cleared to an empty value shouldn't claim a
+            # source — the source didn't "supply" a missing value. Delete
+            # any stale provenance for those fields and skip the upsert.
+            cleared = [k for k in written if fields[k] in (None, "", "[]", "{}")]
+            if cleared:
+                self._conn.executemany(
+                    "DELETE FROM book_field_provenance "
+                    "WHERE book_id = ? AND field_name = ?",
+                    [(book_id, k) for k in cleared],
+                )
+
+            populated = [k for k in written if k not in cleared]
+            prov_map = {f: source for f in populated} if source else {}
             if provenance:
-                prov_map.update({k: v for k, v in provenance.items() if k in written})
-            # Drop entries with no source string assigned.
+                prov_map.update({k: v for k, v in provenance.items() if k in populated})
             prov_map = {k: v for k, v in prov_map.items() if v}
             for field_name, field_source in prov_map.items():
                 self._upsert_provenance(

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -10,7 +10,13 @@ from bookery.core.dedup import (
     normalize_for_dedup,
     normalize_isbn,
 )
-from bookery.db.mapping import BookRecord, DuplicateMatch, metadata_to_row, row_to_record
+from bookery.db.mapping import (
+    BookRecord,
+    DuplicateMatch,
+    ProvenanceEntry,
+    metadata_to_row,
+    row_to_record,
+)
 from bookery.metadata.genres import is_canonical_genre
 from bookery.metadata.types import BookMetadata
 
@@ -30,6 +36,8 @@ class LibraryCatalog:
         metadata: BookMetadata,
         file_hash: str,
         output_path: Path | None = None,
+        *,
+        source: str = "extracted",
     ) -> int:
         """Add a book to the catalog.
 
@@ -54,13 +62,22 @@ class LibraryCatalog:
                 f"INSERT INTO books ({columns}) VALUES ({placeholders})",
                 values,
             )
-            self._conn.commit()
         except sqlite3.IntegrityError as exc:
             if "UNIQUE constraint failed: books.file_hash" in str(exc):
                 raise DuplicateBookError(f"Book with hash {file_hash} already exists") from exc
             raise
 
-        return cursor.lastrowid  # type: ignore[return-value]
+        book_id = cursor.lastrowid
+        assert book_id is not None
+        for field_name, value in row.items():
+            if field_name in {"source_path", "output_path", "file_hash"}:
+                continue
+            if value in (None, "", "[]", "{}"):
+                continue
+            self._upsert_provenance(book_id, field_name, source)
+
+        self._conn.commit()
+        return book_id  # type: ignore[return-value]
 
     def get_by_id(self, book_id: int) -> BookRecord | None:
         """Retrieve a book by its row ID."""
@@ -161,18 +178,44 @@ class LibraryCatalog:
         )
         return [row_to_record(row) for row in cursor.fetchall()]
 
-    def update_book(self, book_id: int, **fields: str | list[str] | float | None) -> None:
+    def update_book(
+        self,
+        book_id: int,
+        *,
+        source: str | None = None,
+        provenance: dict[str, str] | None = None,
+        confidence: float | None = None,
+        respect_locked: bool = False,
+        **fields: object,
+    ) -> list[str]:
         """Update one or more fields on a cataloged book.
 
         Accepts keyword arguments matching books table columns. Authors and
         identifiers values are JSON-serialized automatically. ISBN is
         canonicalized to ISBN-13 on write.
 
+        If ``source`` is provided, a provenance row is written for each
+        updated field (credited to that source). ``provenance`` may be
+        passed to override the source on a per-field basis.
+
+        If ``respect_locked`` is true, any field with a locked provenance
+        row is silently dropped from the update — this is what lets
+        ``rematch`` avoid clobbering user-curated values.
+
+        Returns the list of field names that were actually written (after
+        locked-field filtering).
+
         Raises:
             ValueError: If the book_id does not exist.
         """
         if not fields:
-            return
+            return []
+
+        if respect_locked:
+            locked = self.get_locked_fields(book_id)
+            fields = {k: v for k, v in fields.items() if k not in locked}
+            if not fields:
+                return []
 
         # JSON-serialize list/dict fields
         if "authors" in fields:
@@ -180,7 +223,9 @@ class LibraryCatalog:
         if "identifiers" in fields:
             fields["identifiers"] = json.dumps(fields["identifiers"])
         if fields.get("isbn"):
-            fields["isbn"] = normalize_isbn(fields["isbn"]) or None  # type: ignore[arg-type]
+            isbn_val = fields["isbn"]
+            if isinstance(isbn_val, str):
+                fields["isbn"] = normalize_isbn(isbn_val) or None
 
         set_clause = ", ".join(f"{k} = ?" for k in fields)
         set_clause += ", date_modified = strftime('%Y-%m-%dT%H:%M:%S', 'now')"
@@ -190,10 +235,99 @@ class LibraryCatalog:
             f"UPDATE books SET {set_clause} WHERE id = ?",
             values,
         )
+        if cursor.rowcount == 0:
+            self._conn.commit()
+            raise ValueError(f"Book with id {book_id} not found")
+
+        written = list(fields.keys())
+
+        if source is not None or provenance:
+            prov_map = {f: source for f in written} if source else {}
+            if provenance:
+                prov_map.update({k: v for k, v in provenance.items() if k in written})
+            # Drop entries with no source string assigned.
+            prov_map = {k: v for k, v in prov_map.items() if v}
+            for field_name, field_source in prov_map.items():
+                self._upsert_provenance(
+                    book_id,
+                    field_name,
+                    field_source,
+                    confidence=confidence,
+                )
+
+        self._conn.commit()
+        return written
+
+    def _upsert_provenance(
+        self,
+        book_id: int,
+        field_name: str,
+        source: str,
+        *,
+        confidence: float | None = None,
+    ) -> None:
+        """Insert or refresh a provenance row, preserving the locked flag."""
+        self._conn.execute(
+            """
+            INSERT INTO book_field_provenance (book_id, field_name, source, confidence)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(book_id, field_name) DO UPDATE SET
+                source = excluded.source,
+                confidence = excluded.confidence,
+                fetched_at = strftime('%Y-%m-%dT%H:%M:%S', 'now')
+            """,
+            (book_id, field_name, source, confidence),
+        )
+
+    def set_field_lock(self, book_id: int, field_name: str, locked: bool) -> None:
+        """Set or clear the locked flag for a field.
+
+        If no provenance row exists for the field yet and we're locking it,
+        a ``user`` row is created to anchor the lock.
+        """
+        if locked:
+            self._conn.execute(
+                """
+                INSERT INTO book_field_provenance (book_id, field_name, source, locked)
+                VALUES (?, ?, 'user', 1)
+                ON CONFLICT(book_id, field_name) DO UPDATE SET locked = 1
+                """,
+                (book_id, field_name),
+            )
+        else:
+            self._conn.execute(
+                "UPDATE book_field_provenance SET locked = 0 "
+                "WHERE book_id = ? AND field_name = ?",
+                (book_id, field_name),
+            )
         self._conn.commit()
 
-        if cursor.rowcount == 0:
-            raise ValueError(f"Book with id {book_id} not found")
+    def get_locked_fields(self, book_id: int) -> set[str]:
+        """Return the set of field names currently locked on this book."""
+        rows = self._conn.execute(
+            "SELECT field_name FROM book_field_provenance "
+            "WHERE book_id = ? AND locked = 1",
+            (book_id,),
+        ).fetchall()
+        return {row["field_name"] for row in rows}
+
+    def get_provenance(self, book_id: int) -> dict[str, ProvenanceEntry]:
+        """Return all provenance rows for a book, keyed by field name."""
+        rows = self._conn.execute(
+            "SELECT field_name, source, fetched_at, confidence, locked "
+            "FROM book_field_provenance WHERE book_id = ? ORDER BY field_name",
+            (book_id,),
+        ).fetchall()
+        return {
+            row["field_name"]: ProvenanceEntry(
+                field_name=row["field_name"],
+                source=row["source"],
+                fetched_at=row["fetched_at"],
+                confidence=row["confidence"],
+                locked=bool(row["locked"]),
+            )
+            for row in rows
+        }
 
     def set_output_path(self, book_id: int, output_path: Path) -> None:
         """Set the output_path for a cataloged book."""

--- a/src/bookery/db/mapping.py
+++ b/src/bookery/db/mapping.py
@@ -34,6 +34,22 @@ class BookRecord:
     date_modified: str
 
 
+@dataclass(frozen=True, slots=True)
+class ProvenanceEntry:
+    """A single row from book_field_provenance.
+
+    Records which source supplied a field value, when it was fetched,
+    the optional confidence score at the time, and whether the value is
+    locked against being overwritten by automatic rematching.
+    """
+
+    field_name: str
+    source: str
+    fetched_at: str
+    confidence: float | None
+    locked: bool
+
+
 def metadata_to_row(
     metadata: BookMetadata,
     file_hash: str,

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -121,4 +121,19 @@ ALTER TABLE books ADD COLUMN page_count INTEGER;
 INSERT INTO schema_version (version) VALUES (4);
 """
 
-MIGRATIONS = [(2, SCHEMA_V2), (3, SCHEMA_V3), (4, SCHEMA_V4)]
+SCHEMA_V5 = """
+CREATE TABLE book_field_provenance (
+    book_id    INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    field_name TEXT NOT NULL,
+    source     TEXT NOT NULL,
+    fetched_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now')),
+    confidence REAL,
+    locked     INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (book_id, field_name)
+);
+CREATE INDEX idx_book_field_provenance_book_id ON book_field_provenance(book_id);
+
+INSERT INTO schema_version (version) VALUES (5);
+"""
+
+MIGRATIONS = [(2, SCHEMA_V2), (3, SCHEMA_V3), (4, SCHEMA_V4), (5, SCHEMA_V5)]

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -131,7 +131,8 @@ CREATE TABLE book_field_provenance (
     locked     INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (book_id, field_name)
 );
-CREATE INDEX idx_book_field_provenance_book_id ON book_field_provenance(book_id);
+-- No separate book_id index: the PK (book_id, field_name) already makes
+-- book_id the leftmost key, so SQLite uses it for WHERE book_id = ? lookups.
 
 INSERT INTO schema_version (version) VALUES (5);
 """

--- a/tests/integration/test_migration_lifecycle.py
+++ b/tests/integration/test_migration_lifecycle.py
@@ -30,7 +30,7 @@ class TestMigrationLifecycle:
 
         # Step 2: Open with bookery to trigger migration
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 4
+        assert _get_schema_version(conn) == 5
 
         # Step 3: Verify the book survived and tags work
         catalog = LibraryCatalog(conn)
@@ -51,7 +51,7 @@ class TestMigrationLifecycle:
         # Open 3 times
         for _ in range(3):
             conn = open_library(db_path)
-            assert _get_schema_version(conn) == 4
+            assert _get_schema_version(conn) == 5
             conn.close()
 
         # Final open — add a book and tag it

--- a/tests/unit/test_catalog_provenance.py
+++ b/tests/unit/test_catalog_provenance.py
@@ -1,0 +1,145 @@
+# ABOUTME: Tests for the book_field_provenance schema and catalog API.
+# ABOUTME: Covers add/update provenance, lock + respect_locked, and get_provenance.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture
+def catalog(tmp_path: Path):
+    conn = open_library(tmp_path / "lib.db")
+    try:
+        yield LibraryCatalog(conn)
+    finally:
+        conn.close()
+
+
+def _add(catalog: LibraryCatalog, **overrides) -> int:
+    meta = BookMetadata(
+        title=overrides.get("title", "Dune"),
+        authors=overrides.get("authors", ["Frank Herbert"]),
+        isbn=overrides.get("isbn", "9780441013593"),
+        source_path=Path("/tmp/x.epub"),
+    )
+    return catalog.add_book(meta, file_hash=overrides.get("hash", "a" * 64))
+
+
+def test_add_book_records_provenance_for_populated_fields(catalog) -> None:
+    book_id = _add(catalog)
+    prov = catalog.get_provenance(book_id)
+    assert "title" in prov
+    assert "authors" in prov
+    assert "isbn" in prov
+    assert all(e.source == "extracted" for e in prov.values())
+    # None-valued fields aren't recorded.
+    assert "publisher" not in prov
+
+
+def test_add_book_accepts_custom_source(catalog) -> None:
+    meta = BookMetadata(
+        title="Dune",
+        authors=["Frank Herbert"],
+        source_path=Path("/tmp/x.epub"),
+    )
+    book_id = catalog.add_book(meta, file_hash="b" * 64, source="openlibrary")
+    prov = catalog.get_provenance(book_id)
+    assert prov["title"].source == "openlibrary"
+
+
+def test_update_book_records_provenance_per_field(catalog) -> None:
+    book_id = _add(catalog)
+    written = catalog.update_book(
+        book_id,
+        source="googlebooks",
+        page_count=412,
+        description="A desert epic.",
+    )
+    assert set(written) == {"page_count", "description"}
+    prov = catalog.get_provenance(book_id)
+    assert prov["page_count"].source == "googlebooks"
+    assert prov["description"].source == "googlebooks"
+    # Original title provenance is unchanged.
+    assert prov["title"].source == "extracted"
+
+
+def test_update_book_per_field_provenance_override(catalog) -> None:
+    book_id = _add(catalog)
+    catalog.update_book(
+        book_id,
+        source="consensus",
+        provenance={"page_count": "googlebooks"},
+        page_count=412,
+        description="Epic.",
+    )
+    prov = catalog.get_provenance(book_id)
+    assert prov["page_count"].source == "googlebooks"
+    assert prov["description"].source == "consensus"
+
+
+def test_locked_field_is_not_overwritten_when_respected(catalog) -> None:
+    book_id = _add(catalog)
+    catalog.update_book(book_id, source="user", title="My Custom Title")
+    catalog.set_field_lock(book_id, "title", True)
+
+    written = catalog.update_book(
+        book_id,
+        source="openlibrary",
+        respect_locked=True,
+        title="Auto-Fetched Title",
+        description="Also new.",
+    )
+
+    assert "title" not in written
+    assert "description" in written
+
+    record = catalog.get_by_id(book_id)
+    assert record is not None
+    assert record.metadata.title == "My Custom Title"
+
+
+def test_unlock_allows_overwrite(catalog) -> None:
+    book_id = _add(catalog)
+    catalog.set_field_lock(book_id, "title", True)
+    catalog.set_field_lock(book_id, "title", False)
+
+    written = catalog.update_book(
+        book_id,
+        source="openlibrary",
+        respect_locked=True,
+        title="Auto-Fetched Title",
+    )
+    assert "title" in written
+    record = catalog.get_by_id(book_id)
+    assert record is not None
+    assert record.metadata.title == "Auto-Fetched Title"
+
+
+def test_set_field_lock_creates_user_row_when_none_exists(catalog) -> None:
+    book_id = _add(catalog)
+    catalog.set_field_lock(book_id, "never_set", True)
+    prov = catalog.get_provenance(book_id)
+    assert prov["never_set"].source == "user"
+    assert prov["never_set"].locked is True
+
+
+def test_get_locked_fields(catalog) -> None:
+    book_id = _add(catalog)
+    catalog.set_field_lock(book_id, "title", True)
+    catalog.set_field_lock(book_id, "isbn", True)
+    catalog.set_field_lock(book_id, "isbn", False)
+    locked = catalog.get_locked_fields(book_id)
+    assert locked == {"title"}
+
+
+def test_update_book_without_source_leaves_provenance_unchanged(catalog) -> None:
+    book_id = _add(catalog)
+    before = catalog.get_provenance(book_id)["title"].source
+    catalog.update_book(book_id, description="New desc.")
+    after = catalog.get_provenance(book_id)["title"].source
+    assert before == after
+    assert "description" not in catalog.get_provenance(book_id)

--- a/tests/unit/test_catalog_provenance.py
+++ b/tests/unit/test_catalog_provenance.py
@@ -136,6 +136,17 @@ def test_get_locked_fields(catalog) -> None:
     assert locked == {"title"}
 
 
+def test_clearing_a_field_removes_its_provenance(catalog) -> None:
+    # Clearing publisher to None should drop its provenance row — the
+    # source didn't "supply" a missing value.
+    book_id = _add(catalog)
+    catalog.update_book(book_id, source="googlebooks", publisher="Chilton")
+    assert catalog.get_provenance(book_id)["publisher"].source == "googlebooks"
+
+    catalog.update_book(book_id, source="user", publisher=None)
+    assert "publisher" not in catalog.get_provenance(book_id)
+
+
 def test_update_book_without_source_leaves_provenance_unchanged(catalog) -> None:
     book_id = _add(catalog)
     before = catalog.get_provenance(book_id)["title"].source

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -79,7 +79,7 @@ class TestOpenLibrary:
         row = cursor.fetchone()
         conn.close()
         assert row is not None
-        assert row[0] == 4
+        assert row[0] == 5
 
     def test_creates_indexes(self, db_path: Path) -> None:
         """Expected indexes exist on the books table."""

--- a/tests/unit/test_info_provenance_cli.py
+++ b/tests/unit/test_info_provenance_cli.py
@@ -1,0 +1,93 @@
+# ABOUTME: CLI tests for `bookery info --provenance`, --set, --lock, --unlock.
+# ABOUTME: Ensures user edits record provenance and locked fields survive rematch.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+def _seed(tmp_path: Path) -> Path:
+    db_path = tmp_path / "lib.db"
+    conn = open_library(db_path)
+    LibraryCatalog(conn).add_book(
+        BookMetadata(
+            title="Dune",
+            authors=["Frank Herbert"],
+            source_path=Path("/tmp/dune.epub"),
+        ),
+        file_hash="h" * 64,
+    )
+    conn.close()
+    return db_path
+
+
+def test_info_provenance_shows_table(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["info", "1", "--db", str(db_path), "--provenance"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Provenance" in result.output
+    assert "title" in result.output
+    assert "extracted" in result.output
+
+
+def test_info_set_and_lock(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "info", "1", "--db", str(db_path),
+            "--set", "title=My Dune",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    record = catalog.get_by_id(1)
+    assert record is not None
+    assert record.metadata.title == "My Dune"
+    prov = catalog.get_provenance(1)
+    assert prov["title"].source == "user"
+    assert prov["title"].locked is True
+    conn.close()
+
+
+def test_info_unlock_removes_lock(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    runner = CliRunner()
+    runner.invoke(
+        cli,
+        ["info", "1", "--db", str(db_path), "--lock", "title"],
+    )
+    runner.invoke(
+        cli,
+        ["info", "1", "--db", str(db_path), "--unlock", "title"],
+    )
+
+    conn = open_library(db_path)
+    locked = LibraryCatalog(conn).get_locked_fields(1)
+    assert "title" not in locked
+    conn.close()
+
+
+def test_info_set_rejects_unknown_field(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "info", "1", "--db", str(db_path),
+            "--set", "bogus=x",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Unknown field" in result.output

--- a/tests/unit/test_info_provenance_cli.py
+++ b/tests/unit/test_info_provenance_cli.py
@@ -38,15 +38,12 @@ def test_info_provenance_shows_table(tmp_path: Path) -> None:
     assert "extracted" in result.output
 
 
-def test_info_set_and_lock(tmp_path: Path) -> None:
+def test_info_set_records_user_provenance_without_locking(tmp_path: Path) -> None:
     db_path = _seed(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        [
-            "info", "1", "--db", str(db_path),
-            "--set", "title=My Dune",
-        ],
+        ["info", "1", "--db", str(db_path), "--set", "title=My Dune"],
     )
     assert result.exit_code == 0, result.output
 
@@ -57,7 +54,48 @@ def test_info_set_and_lock(tmp_path: Path) -> None:
     assert record.metadata.title == "My Dune"
     prov = catalog.get_provenance(1)
     assert prov["title"].source == "user"
+    # --set no longer implies --lock; callers opt into locking explicitly.
+    assert prov["title"].locked is False
+    conn.close()
+
+
+def test_info_set_and_lock_combined(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "info", "1", "--db", str(db_path),
+            "--set", "title=My Dune",
+            "--lock", "title",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    prov = catalog.get_provenance(1)
+    assert prov["title"].source == "user"
     assert prov["title"].locked is True
+    conn.close()
+
+
+def test_info_set_allows_value_containing_equals(tmp_path: Path) -> None:
+    db_path = _seed(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "info", "1", "--db", str(db_path),
+            "--set", "description=a=b",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    conn = open_library(db_path)
+    record = LibraryCatalog(conn).get_by_id(1)
+    assert record is not None
+    assert record.metadata.description == "a=b"
     conn.close()
 
 

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 4
+        assert version == 5
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -117,7 +117,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 4
+        assert version == 5
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")


### PR DESCRIPTION
Closes #89. Stacked on #88 (PR #92).

## Summary
- New `book_field_provenance` table (schema v5) keyed by (book_id, field_name), storing source, fetched_at, confidence, and locked flag.
- `LibraryCatalog` gains `set_field_lock`, `get_locked_fields`, `get_provenance`, and a private `_upsert_provenance` helper. `add_book` stamps every populated field; `update_book` accepts `source` / `provenance` / `respect_locked` kwargs and returns which fields were actually written.
- `rematch` passes the candidate source through and respects locks; per-field provenance contributed by `ConsensusProvider` (issue #88) is forwarded as-is.
- `bookery info <id>` gains `--provenance` (table view), `--set field=value` (records source `user` and locks the field), `--lock field`, `--unlock field`.
- README documents the new feature.

## Test plan
- [x] 9 unit tests for the catalog provenance API: add/update recording, per-field source override, lock honored on update, unlock allows overwrite, lock-on-missing-field creates user row, `get_locked_fields`, update-without-source leaves prov unchanged.
- [x] 4 CLI tests for `info --provenance` / `--set` / `--lock` / `--unlock` + rejection of unknown fields.
- [x] Migration-assertion tests bumped from v4 to v5.
- [x] Full suite: 1206 passed (was 1193).
- [x] `ruff check` clean, pre-commit pyright clean.