### PR TITLE
Fix: rematch now writes the #87 enrichment fields

### DIFF
--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -96,6 +96,16 @@ def _metadata_to_update_fields(metadata: BookMetadata) -> dict:
         fields["series"] = metadata.series
     if metadata.series_index is not None:
         fields["series_index"] = metadata.series_index
+    if metadata.subjects:
+        fields["subjects"] = metadata.subjects
+    if metadata.published_date:
+        fields["published_date"] = metadata.published_date
+    if metadata.original_publication_date:
+        fields["original_publication_date"] = metadata.original_publication_date
+    if metadata.page_count is not None:
+        fields["page_count"] = metadata.page_count
+    if metadata.cover_url:
+        fields["cover_url"] = metadata.cover_url
     return fields
 
 

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -222,6 +222,8 @@ class LibraryCatalog:
             fields["authors"] = json.dumps(fields["authors"])
         if "identifiers" in fields:
             fields["identifiers"] = json.dumps(fields["identifiers"])
+        if "subjects" in fields:
+            fields["subjects"] = json.dumps(fields["subjects"])
         if fields.get("isbn"):
             isbn_val = fields["isbn"]
             if isinstance(isbn_val, str):
@@ -554,7 +556,7 @@ class LibraryCatalog:
 
     def store_subjects(self, book_id: int, subjects: list[str]) -> None:
         """Update the subjects JSON column for a book."""
-        self.update_book(book_id, subjects=json.dumps(subjects))
+        self.update_book(book_id, subjects=subjects)
 
     def get_books_with_subjects(self) -> list[tuple[int, str, list[str]]]:
         """Get all books that have subjects, regardless of genre status.


### PR DESCRIPTION
## Summary
When #87 added `subjects`, `published_date`, `original_publication_date`, `page_count`, and `cover_url` to `BookMetadata`, the mapper in `rematch_cmd._metadata_to_update_fields` wasn't updated — so `rematch` matched candidates but silently dropped those columns. With Google Books now enabled via consensus (PR #92), this became visible: rematches succeed and provenance is recorded, but the enriched columns stay NULL.

## Changes
- `rematch_cmd._metadata_to_update_fields`: include the five new fields
- `catalog.update_book`: JSON-serialize `subjects` like `authors`/`identifiers`
- `catalog.store_subjects`: pass the list through (update_book handles serialization)

## Test plan
- [x] Full suite 1213 passing
- [x] Manual: rematch on a book previously missing page_count/published_date/cover_url and confirm the columns populate