### PR TITLE
Metadata: expand BookMetadata + auto-map subjects to genres (#95 #97)

### DIFF
--- a/src/bookery/cli/commands/genre_cmd.py
+++ b/src/bookery/cli/commands/genre_cmd.py
@@ -8,7 +8,10 @@ from rich.console import Console
 from rich.table import Table
 
 from bookery.cli.options import db_option, resolve_db_path
-from bookery.core.genre_applier import apply_genres
+from bookery.core.genre_applier import (
+    apply_genres,
+    collect_unmatched_subject_frequencies,
+)
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 
@@ -92,6 +95,32 @@ def genre_unmatched(db_path: Path | None) -> None:
     conn.close()
 
 
+@genre.command("stats")
+@click.option("--limit", type=int, default=25, show_default=True)
+@db_option
+def genre_stats(limit: int, db_path: Path | None) -> None:
+    """Show the most common subjects that don't map to a canonical genre."""
+    conn = open_library(resolve_db_path(db_path))
+    catalog = LibraryCatalog(conn)
+
+    freq = collect_unmatched_subject_frequencies(catalog)
+    if not freq:
+        console.print("[green]No unmatched subjects — every subject maps cleanly.[/green]")
+        conn.close()
+        return
+
+    table = Table(title="Unmatched subjects")
+    table.add_column("Subject")
+    table.add_column("Count", justify="right", style="dim")
+
+    for subject, count in freq[:limit]:
+        table.add_row(subject, str(count))
+    console.print(table)
+    if len(freq) > limit:
+        console.print(f"[dim]… {len(freq) - limit} more[/dim]")
+    conn.close()
+
+
 @genre.command("apply")
 @click.option("--dry-run", is_flag=True, help="Show what would be assigned without writing.")
 @click.option("--force", is_flag=True, help="Re-evaluate all books, even those with genres.")
@@ -124,3 +153,22 @@ def genre_apply(ctx: click.Context, dry_run: bool, force: bool, db_path: Path | 
         )
 
     conn.close()
+
+
+@genre.command("auto")
+@click.option("--all", "all_books", is_flag=True, help="Re-evaluate every book.")
+@click.option("--dry-run", is_flag=True, help="Show what would be assigned without writing.")
+@db_option
+@click.pass_context
+def genre_auto(
+    ctx: click.Context,
+    all_books: bool,
+    dry_run: bool,
+    db_path: Path | None,
+) -> None:
+    """Auto-map subjects to canonical genres across the catalog.
+
+    Without ``--all``, only books that don't yet have a genre are processed
+    (matches ``genre apply``). With ``--all``, every book is re-evaluated.
+    """
+    ctx.invoke(genre_apply, dry_run=dry_run, force=all_books, db_path=db_path)

--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -15,7 +15,7 @@ console = Console()  # TODO: move Console() inside command for testability
 
 
 _SETTABLE_FIELDS = {
-    "title", "authors", "author_sort", "language", "publisher", "isbn",
+    "title", "subtitle", "authors", "author_sort", "language", "publisher", "isbn",
     "description", "series", "series_index", "subjects", "published_date",
     "original_publication_date", "page_count", "cover_url",
 }
@@ -152,6 +152,8 @@ def info(
 
     table.add_row("ID", str(record.id))
     table.add_row("Title", meta.title)
+    if meta.subtitle:
+        table.add_row("Subtitle", meta.subtitle)
     table.add_row("Author", meta.author or "unknown")
     if meta.author_sort:
         table.add_row("Author Sort", meta.author_sort)
@@ -166,6 +168,10 @@ def info(
         table.add_row("First Published", meta.original_publication_date)
     if meta.page_count is not None:
         table.add_row("Pages", str(meta.page_count))
+    if meta.rating is not None:
+        count = meta.ratings_count
+        count_str = f" ({count:,} ratings)" if count else ""
+        table.add_row("Rating", f"⭐ {meta.rating:.1f}{count_str}")
     if meta.cover_url:
         table.add_row("Cover URL", meta.cover_url)
     if meta.description:

--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -80,6 +80,8 @@ def _metadata_to_update_fields(metadata: BookMetadata) -> dict:
     fields: dict = {}
     if metadata.title:
         fields["title"] = metadata.title
+    if metadata.subtitle:
+        fields["subtitle"] = metadata.subtitle
     if metadata.authors:
         fields["authors"] = metadata.authors
     if metadata.author_sort:
@@ -106,6 +108,14 @@ def _metadata_to_update_fields(metadata: BookMetadata) -> dict:
         fields["page_count"] = metadata.page_count
     if metadata.cover_url:
         fields["cover_url"] = metadata.cover_url
+    if metadata.rating is not None:
+        fields["rating"] = metadata.rating
+    if metadata.ratings_count is not None:
+        fields["ratings_count"] = metadata.ratings_count
+    if metadata.print_type:
+        fields["print_type"] = metadata.print_type
+    if metadata.maturity_rating:
+        fields["maturity_rating"] = metadata.maturity_rating
     return fields
 
 

--- a/src/bookery/core/genre_applier.py
+++ b/src/bookery/core/genre_applier.py
@@ -1,10 +1,14 @@
 # ABOUTME: Batch genre assignment for books already in the catalog.
 # ABOUTME: Runs normalize_subjects() across cataloged books and assigns genres.
 
+from collections import Counter
 from dataclasses import dataclass, field
 
 from bookery.db.catalog import LibraryCatalog
-from bookery.metadata.genres import normalize_subjects
+from bookery.metadata.genres import normalize_subject, normalize_subjects
+
+AUTO_SOURCE = "genres"
+PRIMARY_GENRE_FIELD = "genre_primary"
 
 
 @dataclass
@@ -55,3 +59,63 @@ def apply_genres(
                 catalog.set_primary_genre(book_id, genre_result.primary_genre)
 
     return result
+
+
+def auto_apply_for_book(
+    catalog: LibraryCatalog,
+    book_id: int,
+    subjects: list[str],
+) -> str | None:
+    """Assign genres for a single book from its subjects.
+
+    Runs the same normalization as ``apply_genres`` but for one book,
+    used as a hook after ``catalog.update_book`` writes fresh subjects.
+    Respects a locked ``genre_primary`` provenance row: when locked, the
+    primary genre is preserved even if a different genre would normally
+    win the vote. Non-primary genre memberships are still refreshed.
+
+    Returns the resolved primary genre name (or None if no matches).
+    """
+    if not subjects:
+        return None
+
+    result = normalize_subjects(subjects)
+    if not result.matches:
+        return None
+
+    # Honor a user-set lock on the primary genre.
+    provenance = catalog.get_provenance(book_id)
+    locked = provenance.get(PRIMARY_GENRE_FIELD)
+    primary_locked = bool(locked and locked.locked)
+
+    for match in result.matches:
+        catalog.add_genre(book_id, match.genre)
+
+    primary = result.primary_genre
+    if primary and not primary_locked:
+        catalog.set_primary_genre(book_id, primary)
+        # Record provenance for the primary so future locks can protect it.
+        catalog._upsert_provenance(book_id, PRIMARY_GENRE_FIELD, AUTO_SOURCE)
+        catalog._conn.commit()
+        return primary
+
+    if primary_locked:
+        existing = catalog.get_primary_genre(book_id)
+        return existing
+    return primary
+
+
+def collect_unmatched_subject_frequencies(
+    catalog: LibraryCatalog,
+) -> list[tuple[str, int]]:
+    """Return (subject, count) tuples for subjects that don't map to a genre.
+
+    Aggregates across the catalog and sorts by descending frequency.
+    Useful for ``bookery genre stats`` to surface mappings worth adding.
+    """
+    counts: Counter[str] = Counter()
+    for _book_id, _title, subjects in catalog.get_books_with_subjects():
+        for subj in subjects:
+            if normalize_subject(subj) is None:
+                counts[subj] += 1
+    return counts.most_common()

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -269,6 +269,26 @@ class LibraryCatalog:
                 )
 
         self._conn.commit()
+
+        # Auto-genre hook: only fires when a provider source is attached,
+        # so internal bookkeeping (e.g. store_subjects) doesn't clobber
+        # the separate genre-apply workflow.
+        if (
+            source is not None
+            and "subjects" in written
+            and fields.get("subjects") not in (None, "", "[]")
+        ):
+            try:
+                from bookery.core.genre_applier import auto_apply_for_book
+            except ImportError:  # pragma: no cover — defensive
+                return written
+            try:
+                subjects_written = json.loads(fields["subjects"])  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                subjects_written = []
+            if subjects_written:
+                auto_apply_for_book(self, book_id, list(subjects_written))
+
         return written
 
     def _upsert_provenance(

--- a/src/bookery/db/mapping.py
+++ b/src/bookery/db/mapping.py
@@ -62,6 +62,7 @@ def metadata_to_row(
     """
     return {
         "title": metadata.title,
+        "subtitle": metadata.subtitle,
         "authors": json.dumps(metadata.authors),
         "author_sort": metadata.author_sort,
         "language": metadata.language,
@@ -76,6 +77,10 @@ def metadata_to_row(
         "published_date": metadata.published_date,
         "original_publication_date": metadata.original_publication_date,
         "page_count": metadata.page_count,
+        "rating": metadata.rating,
+        "ratings_count": metadata.ratings_count,
+        "print_type": metadata.print_type,
+        "maturity_rating": metadata.maturity_rating,
         "source_path": str(metadata.source_path) if metadata.source_path else None,
         "output_path": str(output_path) if output_path else None,
         "file_hash": file_hash,
@@ -101,6 +106,7 @@ def row_to_metadata(row: Any) -> BookMetadata:
 
     return BookMetadata(
         title=row["title"],
+        subtitle=_opt("subtitle"),
         authors=json.loads(row["authors"]) if row["authors"] else [],
         author_sort=row["author_sort"],
         language=row["language"],
@@ -115,6 +121,10 @@ def row_to_metadata(row: Any) -> BookMetadata:
         published_date=_opt("published_date"),
         original_publication_date=_opt("original_publication_date"),
         page_count=_opt("page_count"),
+        rating=_opt("rating"),
+        ratings_count=_opt("ratings_count"),
+        print_type=_opt("print_type"),
+        maturity_rating=_opt("maturity_rating"),
         source_path=Path(source) if source else None,
     )
 

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -137,4 +137,20 @@ CREATE TABLE book_field_provenance (
 INSERT INTO schema_version (version) VALUES (5);
 """
 
-MIGRATIONS = [(2, SCHEMA_V2), (3, SCHEMA_V3), (4, SCHEMA_V4), (5, SCHEMA_V5)]
+SCHEMA_V6 = """
+ALTER TABLE books ADD COLUMN subtitle TEXT;
+ALTER TABLE books ADD COLUMN rating REAL;
+ALTER TABLE books ADD COLUMN ratings_count INTEGER;
+ALTER TABLE books ADD COLUMN print_type TEXT;
+ALTER TABLE books ADD COLUMN maturity_rating TEXT;
+
+INSERT INTO schema_version (version) VALUES (6);
+"""
+
+MIGRATIONS = [
+    (2, SCHEMA_V2),
+    (3, SCHEMA_V3),
+    (4, SCHEMA_V4),
+    (5, SCHEMA_V5),
+    (6, SCHEMA_V6),
+]

--- a/src/bookery/metadata/consensus.py
+++ b/src/bookery/metadata/consensus.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 _SCALAR_FIELDS = (
     "title",
+    "subtitle",
     "author_sort",
     "language",
     "publisher",
@@ -26,6 +27,10 @@ _SCALAR_FIELDS = (
     "published_date",
     "original_publication_date",
     "page_count",
+    "rating",
+    "ratings_count",
+    "print_type",
+    "maturity_rating",
 )
 _LIST_FIELDS = ("authors", "subjects")
 _AGREEMENT_BONUS = 0.05

--- a/src/bookery/metadata/googlebooks.py
+++ b/src/bookery/metadata/googlebooks.py
@@ -16,6 +16,16 @@ _GB_BASE = "https://www.googleapis.com/books/v1/volumes"
 _SEARCH_LIMIT = 5
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
+# Ordered from largest to smallest — we pick the first variant Google returns.
+_COVER_VARIANTS = (
+    "extraLarge",
+    "large",
+    "medium",
+    "small",
+    "thumbnail",
+    "smallThumbnail",
+)
+
 
 def _strip_html(text: str) -> str:
     """Remove HTML tags and collapse whitespace."""
@@ -36,14 +46,23 @@ def _pick_isbn(industry_identifiers: list[dict[str, str]]) -> str | None:
     return isbn_13 or isbn_10
 
 
+def _pick_cover(image_links: dict[str, Any]) -> str | None:
+    """Pick the largest available cover variant; upgrade http -> https."""
+    for key in _COVER_VARIANTS:
+        url = image_links.get(key)
+        if url:
+            if url.startswith("http://"):
+                url = "https://" + url[len("http://") :]
+            return url
+    return None
+
+
 def _parse_volume(item: dict[str, Any]) -> BookMetadata:
     """Parse a Google Books `volumes` item into BookMetadata."""
     volume_info = item.get("volumeInfo", {}) or {}
 
     title = volume_info.get("title", "Unknown")
-    subtitle = volume_info.get("subtitle")
-    if subtitle:
-        title = f"{title}: {subtitle}"
+    subtitle = volume_info.get("subtitle") or None
 
     authors = list(volume_info.get("authors", []) or [])
 
@@ -65,21 +84,31 @@ def _parse_volume(item: dict[str, Any]) -> BookMetadata:
     isbn = _pick_isbn(volume_info.get("industryIdentifiers", []) or [])
 
     image_links = volume_info.get("imageLinks", {}) or {}
-    cover_url = (
-        image_links.get("thumbnail")
-        or image_links.get("smallThumbnail")
-        or None
+    cover_url = _pick_cover(image_links)
+
+    average_rating = volume_info.get("averageRating")
+    rating = float(average_rating) if isinstance(average_rating, (int, float)) else None
+    ratings_count_raw = volume_info.get("ratingsCount")
+    ratings_count = (
+        int(ratings_count_raw) if isinstance(ratings_count_raw, (int, float)) else None
     )
-    if cover_url and cover_url.startswith("http://"):
-        cover_url = "https://" + cover_url[len("http://") :]
+    print_type = volume_info.get("printType") or None
+    maturity_rating = volume_info.get("maturityRating") or None
 
     identifiers: dict[str, str] = {}
     volume_id = item.get("id")
     if volume_id:
         identifiers["googlebooks_volume"] = volume_id
+    preview_link = volume_info.get("previewLink")
+    if preview_link:
+        identifiers["googlebooks_preview"] = preview_link
+    info_link = volume_info.get("infoLink")
+    if info_link:
+        identifiers["googlebooks_info"] = info_link
 
     return BookMetadata(
         title=title,
+        subtitle=subtitle,
         authors=authors,
         publisher=publisher,
         isbn=isbn,
@@ -90,7 +119,19 @@ def _parse_volume(item: dict[str, Any]) -> BookMetadata:
         published_date=published_date,
         page_count=page_count,
         cover_url=cover_url,
+        rating=rating,
+        ratings_count=ratings_count,
+        print_type=print_type,
+        maturity_rating=maturity_rating,
     )
+
+
+def _is_book(item: dict[str, Any]) -> bool:
+    """Return True if item is a regular BOOK (not a magazine, etc.)."""
+    volume_info = item.get("volumeInfo", {}) or {}
+    print_type = volume_info.get("printType")
+    # Default to BOOK when printType is missing (older responses omit it).
+    return print_type in (None, "", "BOOK")
 
 
 class GoogleBooksProvider:
@@ -119,7 +160,7 @@ class GoogleBooksProvider:
             logger.warning("ISBN lookup failed for %s: %s", isbn, exc)
             return []
 
-        items = data.get("items", []) or []
+        items = [i for i in (data.get("items", []) or []) if _is_book(i)]
         if not items:
             return []
 
@@ -155,7 +196,7 @@ class GoogleBooksProvider:
             logger.warning("Search failed for title=%s author=%s: %s", title, author, exc)
             return []
 
-        items = data.get("items", []) or []
+        items = [i for i in (data.get("items", []) or []) if _is_book(i)]
         if not items:
             return []
 

--- a/src/bookery/metadata/openlibrary_parser.py
+++ b/src/bookery/metadata/openlibrary_parser.py
@@ -59,6 +59,7 @@ def parse_isbn_response(data: dict[str, Any]) -> BookMetadata:
 
     return BookMetadata(
         title=title,
+        subtitle=data.get("subtitle") or None,
         publisher=publisher,
         isbn=isbn,
         language=language,
@@ -126,6 +127,7 @@ def parse_works_metadata(data: dict[str, Any]) -> BookMetadata:
 
     return BookMetadata(
         title=title,
+        subtitle=data.get("subtitle") or None,
         description=description,
         subjects=subjects,
         identifiers=identifiers,
@@ -189,6 +191,7 @@ def parse_search_results(data: dict[str, Any]) -> list[BookMetadata]:
         results.append(
             BookMetadata(
                 title=title,
+                subtitle=doc.get("subtitle") or None,
                 authors=authors,
                 isbn=isbn,
                 language=language,

--- a/src/bookery/metadata/types.py
+++ b/src/bookery/metadata/types.py
@@ -15,6 +15,7 @@ class BookMetadata:
     """
 
     title: str
+    subtitle: str | None = None
     authors: list[str] = field(default_factory=list)
     author_sort: str | None = None
     language: str | None = None
@@ -30,6 +31,10 @@ class BookMetadata:
     published_date: str | None = None
     original_publication_date: str | None = None
     page_count: int | None = None
+    rating: float | None = None
+    ratings_count: int | None = None
+    print_type: str | None = None
+    maturity_rating: str | None = None
     source_path: Path | None = None
 
     @property

--- a/tests/integration/test_migration_lifecycle.py
+++ b/tests/integration/test_migration_lifecycle.py
@@ -30,7 +30,7 @@ class TestMigrationLifecycle:
 
         # Step 2: Open with bookery to trigger migration
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 5
+        assert _get_schema_version(conn) == 6
 
         # Step 3: Verify the book survived and tags work
         catalog = LibraryCatalog(conn)
@@ -51,7 +51,7 @@ class TestMigrationLifecycle:
         # Open 3 times
         for _ in range(3):
             conn = open_library(db_path)
-            assert _get_schema_version(conn) == 5
+            assert _get_schema_version(conn) == 6
             conn.close()
 
         # Final open — add a book and tag it

--- a/tests/unit/test_bookmetadata_new_fields.py
+++ b/tests/unit/test_bookmetadata_new_fields.py
@@ -49,6 +49,41 @@ class TestCatalogRoundTrip:
             conn.close()
 
 
+class TestExpandedBookMetadata:
+    def test_v6_fields_default_to_none(self) -> None:
+        meta = BookMetadata(title="T")
+        assert meta.subtitle is None
+        assert meta.rating is None
+        assert meta.ratings_count is None
+        assert meta.print_type is None
+        assert meta.maturity_rating is None
+
+    def test_v6_fields_round_trip(self, tmp_path: Path) -> None:
+        conn = open_library(tmp_path / "lib.db")
+        try:
+            catalog = LibraryCatalog(conn)
+            meta = BookMetadata(
+                title="T",
+                authors=["A"],
+                source_path=Path("/tmp/x.epub"),
+                subtitle="A Subtitle",
+                rating=4.3,
+                ratings_count=2145,
+                print_type="BOOK",
+                maturity_rating="NOT_MATURE",
+            )
+            book_id = catalog.add_book(meta, file_hash="h" * 64)
+            record = catalog.get_by_id(book_id)
+            assert record is not None
+            assert record.metadata.subtitle == "A Subtitle"
+            assert record.metadata.rating == 4.3
+            assert record.metadata.ratings_count == 2145
+            assert record.metadata.print_type == "BOOK"
+            assert record.metadata.maturity_rating == "NOT_MATURE"
+        finally:
+            conn.close()
+
+
 class TestOpenLibraryParserPopulation:
     def test_isbn_response_populates_published_date_and_pages(self) -> None:
         data = {
@@ -109,3 +144,18 @@ class TestOpenLibraryParserPopulation:
         data = {"title": "T", "covers": [-1, 88]}
         meta = parse_isbn_response(data)
         assert meta.cover_url == "https://covers.openlibrary.org/b/id/88-L.jpg"
+
+    def test_isbn_response_populates_subtitle(self) -> None:
+        data = {"title": "T", "subtitle": "A Novel"}
+        meta = parse_isbn_response(data)
+        assert meta.subtitle == "A Novel"
+
+    def test_works_metadata_populates_subtitle(self) -> None:
+        data = {"key": "/works/OL1W", "title": "T", "subtitle": "A Novel"}
+        meta = parse_works_metadata(data)
+        assert meta.subtitle == "A Novel"
+
+    def test_search_result_populates_subtitle(self) -> None:
+        data = {"docs": [{"title": "T", "subtitle": "A Novel"}]}
+        results = parse_search_results(data)
+        assert results[0].subtitle == "A Novel"

--- a/tests/unit/test_consensus_provider.py
+++ b/tests/unit/test_consensus_provider.py
@@ -227,6 +227,38 @@ def test_authors_list_agreement_prefers_agreed_value() -> None:
     assert result[0].metadata.identifiers["provenance_authors"] == "googlebooks"
 
 
+def test_new_scalar_fields_vote_and_record_provenance() -> None:
+    p1 = FakeProvider(
+        "openlibrary",
+        isbn_results=[
+            _cand("openlibrary", title="Dune", subtitle="A Novel", rating=4.5)
+        ],
+    )
+    p2 = FakeProvider(
+        "googlebooks",
+        isbn_results=[
+            _cand(
+                "googlebooks",
+                title="Dune",
+                subtitle="An Epic",
+                rating=4.3,
+                ratings_count=2145,
+                print_type="BOOK",
+                maturity_rating="NOT_MATURE",
+            )
+        ],
+    )
+    consensus = ConsensusProvider([p1, p2])
+    merged = consensus.search_by_isbn("9780441013593")[0].metadata
+    # Disagreement on subtitle → priority (openlibrary) wins.
+    assert merged.subtitle == "A Novel"
+    # Google-only fields come through.
+    assert merged.ratings_count == 2145
+    assert merged.print_type == "BOOK"
+    assert merged.maturity_rating == "NOT_MATURE"
+    assert merged.identifiers["provenance_ratings_count"] == "googlebooks"
+
+
 def test_lookup_by_url_returns_first_hit_in_priority_order() -> None:
     cand = MetadataCandidate(
         metadata=BookMetadata(title="Dune"),

--- a/tests/unit/test_db_mapping.py
+++ b/tests/unit/test_db_mapping.py
@@ -17,11 +17,12 @@ class TestMetadataToRow:
         row = metadata_to_row(meta, file_hash="abc123")
 
         expected_keys = {
-            "title", "authors", "author_sort", "language", "publisher",
+            "title", "subtitle", "authors", "author_sort", "language", "publisher",
             "isbn", "description", "series", "series_index", "identifiers",
             "subjects", "source_path", "output_path", "file_hash",
             "cover_url", "published_date", "original_publication_date",
-            "page_count",
+            "page_count", "rating", "ratings_count", "print_type",
+            "maturity_rating",
         }
         assert expected_keys == set(row.keys())
 

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -60,6 +60,11 @@ class TestOpenLibrary:
             "published_date",
             "original_publication_date",
             "page_count",
+            "subtitle",
+            "rating",
+            "ratings_count",
+            "print_type",
+            "maturity_rating",
         }
         assert expected == columns
 
@@ -79,7 +84,7 @@ class TestOpenLibrary:
         row = cursor.fetchone()
         conn.close()
         assert row is not None
-        assert row[0] == 5
+        assert row[0] == 6
 
     def test_creates_indexes(self, db_path: Path) -> None:
         """Expected indexes exist on the books table."""

--- a/tests/unit/test_genre_applier.py
+++ b/tests/unit/test_genre_applier.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from bookery.core.genre_applier import ApplyResult, apply_genres
+from bookery.core.genre_applier import (
+    PRIMARY_GENRE_FIELD,
+    ApplyResult,
+    apply_genres,
+    auto_apply_for_book,
+    collect_unmatched_subject_frequencies,
+)
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 from bookery.metadata.types import BookMetadata
@@ -131,6 +137,82 @@ class TestApplyGenresDryRun:
         # Only the original genre should remain
         genres = catalog.get_genres_for_book(book_id)
         assert len(genres) == 1
+
+
+class TestAutoApplyForBook:
+    """Tests for auto_apply_for_book() (single-book genre hook)."""
+
+    def test_assigns_primary_from_subjects(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book_with_subjects(
+            catalog, "Mystery Novel", ["mystery", "thriller"], "h1"
+        )
+        primary = auto_apply_for_book(catalog, book_id, ["mystery", "thriller"])
+        assert primary == "Mystery & Thriller"
+        assert catalog.get_primary_genre(book_id) == "Mystery & Thriller"
+        prov = catalog.get_provenance(book_id)
+        assert PRIMARY_GENRE_FIELD in prov
+        assert prov[PRIMARY_GENRE_FIELD].source == "genres"
+
+    def test_locked_primary_genre_is_preserved(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book_with_subjects(
+            catalog, "Mystery Novel", ["fantasy"], "h2"
+        )
+        catalog.add_genre(book_id, "Fantasy", is_primary=True)
+        catalog.set_field_lock(book_id, PRIMARY_GENRE_FIELD, True)
+        # Try to auto-apply with subjects that would pick a different primary.
+        primary = auto_apply_for_book(catalog, book_id, ["mystery", "thriller"])
+        assert catalog.get_primary_genre(book_id) == "Fantasy"
+        # Returned value reflects preserved state
+        assert primary == "Fantasy"
+
+    def test_unmatched_subjects_leave_book_unmapped(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = _add_book_with_subjects(
+            catalog, "Oddity", ["quantum chromodynamics"], "h3"
+        )
+        primary = auto_apply_for_book(
+            catalog, book_id, ["quantum chromodynamics"]
+        )
+        assert primary is None
+        assert catalog.get_primary_genre(book_id) is None
+
+
+class TestUpdateBookHook:
+    """Confirm catalog.update_book triggers auto_apply_for_book via hook."""
+
+    def test_update_book_with_subjects_triggers_auto_assignment(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = catalog.add_book(
+            BookMetadata(title="T", source_path=Path("/t.epub")),
+            file_hash="h4",
+        )
+        catalog.update_book(
+            book_id,
+            source="openlibrary",
+            subjects=["science fiction", "space opera"],
+        )
+        assert catalog.get_primary_genre(book_id) == "Science Fiction"
+
+    def test_update_book_without_subjects_does_not_touch_genres(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = _add_book_with_subjects(catalog, "T", ["fantasy"], "h5")
+        catalog.add_genre(book_id, "Fantasy", is_primary=True)
+        catalog.update_book(book_id, source="user", publisher="Ace")
+        assert catalog.get_primary_genre(book_id) == "Fantasy"
+
+
+class TestCollectUnmatchedSubjectFrequencies:
+    def test_counts_only_unmapped_subjects(self, catalog: LibraryCatalog) -> None:
+        _add_book_with_subjects(
+            catalog, "A", ["widgetology", "science fiction"], "h6"
+        )
+        _add_book_with_subjects(catalog, "B", ["widgetology"], "h7")
+        freq = collect_unmatched_subject_frequencies(catalog)
+        assert ("widgetology", 2) in freq
+        assert all(sub != "science fiction" for sub, _ in freq)
 
 
 class TestApplyResult:

--- a/tests/unit/test_genre_commands.py
+++ b/tests/unit/test_genre_commands.py
@@ -224,3 +224,63 @@ class TestLsGenreFilter:
         )
         assert result.exit_code == 1
         assert "not a canonical genre" in result.output
+
+
+class TestGenreStats:
+    """Tests for `bookery genre stats`."""
+
+    def test_stats_shows_unmatched_frequencies(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        for i, subs in enumerate([
+            ["widgetology", "science fiction"],
+            ["widgetology"],
+            ["whatsits"],
+        ]):
+            catalog.add_book(
+                BookMetadata(title=f"B{i}", source_path=Path(f"/{i}.epub")),
+                file_hash=f"h{i}",
+            )
+            catalog.store_subjects(i + 1, subs)
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["genre", "stats", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "widgetology" in result.output
+        assert "whatsits" in result.output
+
+    def test_stats_empty_catalog(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.db"
+        open_library(db_path).close()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["genre", "stats", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "No unmatched" in result.output
+
+
+class TestGenreAuto:
+    """Tests for `bookery genre auto`."""
+
+    def test_auto_all_reassigns_like_apply_force(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        book_id = catalog.add_book(
+            BookMetadata(title="B", source_path=Path("/b.epub")),
+            file_hash="h1",
+        )
+        catalog.store_subjects(book_id, ["science fiction"])
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["genre", "auto", "--all", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "1" in result.output
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        assert catalog.get_primary_genre(book_id) == "Science Fiction"
+        conn.close()

--- a/tests/unit/test_googlebooks_provider.py
+++ b/tests/unit/test_googlebooks_provider.py
@@ -124,13 +124,78 @@ def test_search_by_title_author_builds_query_and_sorts() -> None:
     }
 
 
-def test_subtitle_is_joined_into_title() -> None:
+def test_subtitle_is_kept_separate_from_title() -> None:
     http = FakeHttpClient(
         {"volumes": {"items": [_volume(title="Dune", subtitle="A Novel")]}}
     )
     provider = GoogleBooksProvider(http_client=http)
     candidates = provider.search_by_isbn("9780441013593")
-    assert candidates[0].metadata.title == "Dune: A Novel"
+    assert candidates[0].metadata.title == "Dune"
+    assert candidates[0].metadata.subtitle == "A Novel"
+
+
+def test_parses_rating_ratings_count_print_type_and_maturity() -> None:
+    vol = _volume(title="Dune")
+    vol["volumeInfo"]["averageRating"] = 4.3
+    vol["volumeInfo"]["ratingsCount"] = 2145
+    vol["volumeInfo"]["printType"] = "BOOK"
+    vol["volumeInfo"]["maturityRating"] = "NOT_MATURE"
+    http = FakeHttpClient({"volumes": {"items": [vol]}})
+    provider = GoogleBooksProvider(http_client=http)
+    meta = provider.search_by_isbn("9780441013593")[0].metadata
+    assert meta.rating == 4.3
+    assert meta.ratings_count == 2145
+    assert meta.print_type == "BOOK"
+    assert meta.maturity_rating == "NOT_MATURE"
+
+
+def test_largest_cover_variant_is_selected() -> None:
+    vol = _volume(title="Dune")
+    vol["volumeInfo"]["imageLinks"] = {
+        "smallThumbnail": "http://example/st.jpg",
+        "thumbnail": "http://example/t.jpg",
+        "small": "http://example/s.jpg",
+        "medium": "http://example/m.jpg",
+        "large": "http://example/l.jpg",
+        "extraLarge": "http://example/xl.jpg",
+    }
+    http = FakeHttpClient({"volumes": {"items": [vol]}})
+    provider = GoogleBooksProvider(http_client=http)
+    meta = provider.search_by_isbn("9780441013593")[0].metadata
+    assert meta.cover_url == "https://example/xl.jpg"
+
+
+def test_cover_falls_back_to_next_available_variant() -> None:
+    vol = _volume(title="Dune", thumbnail=None)
+    vol["volumeInfo"]["imageLinks"] = {"medium": "http://example/m.jpg"}
+    http = FakeHttpClient({"volumes": {"items": [vol]}})
+    provider = GoogleBooksProvider(http_client=http)
+    meta = provider.search_by_isbn("9780441013593")[0].metadata
+    assert meta.cover_url == "https://example/m.jpg"
+
+
+def test_preview_and_info_links_recorded_in_identifiers() -> None:
+    vol = _volume(title="Dune")
+    vol["volumeInfo"]["previewLink"] = "https://books.google.com/preview"
+    vol["volumeInfo"]["infoLink"] = "https://books.google.com/info"
+    http = FakeHttpClient({"volumes": {"items": [vol]}})
+    provider = GoogleBooksProvider(http_client=http)
+    meta = provider.search_by_isbn("9780441013593")[0].metadata
+    assert meta.identifiers["googlebooks_preview"] == "https://books.google.com/preview"
+    assert meta.identifiers["googlebooks_info"] == "https://books.google.com/info"
+
+
+def test_non_book_print_type_is_skipped() -> None:
+    mag = _volume(vol_id="MAG", title="Magazine")
+    mag["volumeInfo"]["printType"] = "MAGAZINE"
+    book = _volume(vol_id="BOOKVOL", title="Dune")
+    book["volumeInfo"]["printType"] = "BOOK"
+    http = FakeHttpClient({"volumes": {"items": [mag, book]}})
+    provider = GoogleBooksProvider(http_client=http)
+    candidates = provider.search_by_title_author("Dune")
+    titles = [c.metadata.title for c in candidates]
+    assert "Magazine" not in titles
+    assert "Dune" in titles
 
 
 def test_isbn_10_is_used_when_no_isbn_13() -> None:

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 5
+        assert version == 6
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -93,6 +93,15 @@ class TestMigrations:
         assert cursor.fetchone()[0] == 0
         conn.close()
 
+    def test_v6_adds_book_metadata_columns(self, db_path: Path) -> None:
+        """V6 migration adds subtitle, rating, ratings_count, print_type, maturity_rating."""
+        conn = open_library(db_path)
+        cursor = conn.execute("PRAGMA table_info(books)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        for col in ("subtitle", "rating", "ratings_count", "print_type", "maturity_rating"):
+            assert col in columns, f"missing {col}"
+
     def test_apply_migrations_is_idempotent(self, db_path: Path) -> None:
         """Running migrations twice does not raise or change version."""
         conn = open_library(db_path)
@@ -117,7 +126,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 5
+        assert version == 6
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")

--- a/tests/unit/test_query_commands.py
+++ b/tests/unit/test_query_commands.py
@@ -133,6 +133,31 @@ class TestInfoCommand:
         assert "9780156001311" in result.output
         assert "medieval monastery" in result.output
 
+    def test_info_renders_subtitle_and_rating(self, tmp_path: Path) -> None:
+        """info shows subtitle and rating when present."""
+        db_path = tmp_path / "lib.db"
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        catalog.add_book(
+            BookMetadata(
+                title="Dune",
+                subtitle="A Novel",
+                authors=["Frank Herbert"],
+                rating=4.3,
+                ratings_count=2145,
+                source_path=Path("/books/dune.epub"),
+            ),
+            file_hash="hash_dune",
+        )
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["info", "1", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "A Novel" in result.output
+        assert "4.3" in result.output
+        assert "2,145" in result.output
+
     def test_info_nonexistent_shows_error(self, tmp_path: Path) -> None:
         """info for unknown ID shows an error."""
         db_path = tmp_path / "lib.db"


### PR DESCRIPTION
## Summary
- **#95**: Schema V6 adds `subtitle`, `rating`, `ratings_count`, `print_type`, `maturity_rating`. Google Books pulls all of them, keeps subtitle separate from title, picks the largest cover variant (`extraLarge` → `smallThumbnail`), records `previewLink`/`infoLink` in identifiers, and skips `printType != "BOOK"`. Open Library populates `subtitle`. Consensus votes on the new scalar fields.
- **#97**: `catalog.update_book` now fires a genre auto-assignment hook when a provider-sourced write includes `subjects`. A locked `genre_primary` provenance row is preserved. New CLI: `bookery genre stats` (unmatched-subject frequencies) and `bookery genre auto --all`.

## Changes
- `db/schema.py`: SCHEMA_V6 with five new columns.
- `metadata/types.py`, `db/mapping.py`: new fields round-trip cleanly.
- `metadata/googlebooks.py`: `_pick_cover`, rating/print_type/maturity parsing, `_is_book` filter, preview/info links.
- `metadata/openlibrary_parser.py`: subtitle on all three parse paths (ISBN, Works, Search).
- `metadata/consensus.py`: new scalars added to `_SCALAR_FIELDS`.
- `cli/commands/rematch_cmd.py`: `_metadata_to_update_fields` carries the new fields.
- `cli/commands/info_cmd.py`: renders Subtitle + "⭐ 4.3 (2,145 ratings)" line.
- `core/genre_applier.py`: new `auto_apply_for_book` and `collect_unmatched_subject_frequencies`.
- `db/catalog.py`: `update_book` invokes the hook when `source` is attached and `subjects` is written.
- `cli/commands/genre_cmd.py`: `genre stats`, `genre auto`.

## Testing
- [x] 1235 unit + integration tests pass (22 new).
- [x] `uv run ruff check src/ tests/` clean.
- [ ] Manual smoke pending: `bookery rematch <id>` hit Google Books 429s locally; Open Library path verified.

## Notes for Reviewer
- **Private-attribute access (follow-up)**: `auto_apply_for_book` calls `catalog._upsert_provenance(...)` and `catalog._conn.commit()` directly. Deliberate for now to keep this PR tight; the clean fix is a public `catalog.record_provenance(...)` method, easy follow-up.
- The auto-genre hook only triggers when `source` is provided to `update_book`, so internal `store_subjects` calls don't short-circuit the separate `genre apply` workflow.

## Related Issues
Closes #95
Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)