### PR TITLE
Add #102: hierarchical folder/note TOC for vault-export

### DIFF
--- a/src/bookery/core/vault/assemble.py
+++ b/src/bookery/core/vault/assemble.py
@@ -47,19 +47,39 @@ def _disambiguate(notes: list[Note]) -> dict[int, tuple[str, str]]:
 
 
 _H1_LINE_RE = re.compile(r"^# (.+)$", re.MULTILINE)
+_H2_LINE_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+_FOLDER_SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 
-def _demote_body_h1s(body: str) -> str:
-    """Demote every H1 in a note body to H2.
+def _folder_slug(folder: str) -> str:
+    """Stable slug for a folder anchor: lowercased, non-alphanum collapsed to '-'.
 
-    The assembler emits its own H1 per note as the chapter heading. If the
-    body contains any H1 — whether it duplicates the title or not, and
-    regardless of where it appears — pandoc with ``--toc-depth=1`` would pick
-    it up as a sibling chapter and pollute the TOC with ghost entries. Pushing
-    every body H1 down one level keeps all in-note headings as subsections of
-    the chapter while preserving their text.
+    Empty (root) folder maps to "root" so its anchor is deterministic.
     """
-    return _H1_LINE_RE.sub(r"## \1", body)
+    if not folder:
+        return "root"
+    slug = _FOLDER_SLUG_RE.sub("-", folder.lower()).strip("-")
+    return slug or "root"
+
+
+def _folder_label(folder: str) -> str:
+    """Display label for a folder chapter heading. Root folder gets 'Notes'."""
+    return folder if folder else "Notes"
+
+
+def _demote_body_headings(body: str) -> str:
+    """Demote body H1/H2 down two levels so they sit beneath the note's H2.
+
+    Folders are H1 chapters and notes are H2 sections, so any in-body H1 or H2
+    would compete with chapter/section headings in the TOC. Pushing body H1→H3
+    and body H2→H4 keeps the TOC clean (pandoc ``--toc-depth=2`` only walks
+    folder→note) while preserving the body's heading text and relative
+    hierarchy. The H2 substitution runs first so demoted H1s (now starting
+    with ``## ``) are not re-matched as H2s.
+    """
+    body = _H2_LINE_RE.sub(r"#### \1", body)
+    body = _H1_LINE_RE.sub(r"### \1", body)
+    return body
 
 
 @dataclass(slots=True)
@@ -90,6 +110,10 @@ def assemble_vault(
     folder_to_notes: dict[str, list[Note]] = {}
     for n in notes:
         folder_to_notes.setdefault(n.relative_folder, []).append(n)
+    # Sort notes within each folder alphabetically (case-insensitive) so the
+    # Kobo TOC reads predictably A→Z under each folder chapter.
+    for folder_notes in folder_to_notes.values():
+        folder_notes.sort(key=lambda n: n.title.casefold())
 
     broken_total = 0
     all_assets: list[Path] = []
@@ -99,14 +123,14 @@ def assemble_vault(
     total = len(notes)
     processed = 0
     for folder in sorted(folder_to_notes):
-        label = folder if folder else "(root)"
-        chunks.append(f"<!-- folder: {label} -->")
+        chunks.append(f"# {_folder_label(folder)} {{#folder-{_folder_slug(folder)}}}")
+        chunks.append("")
         for note in folder_to_notes[folder]:
             processed += 1
             if on_progress is not None:
                 on_progress(processed, total, note.title)
             display_title, unique_slug = disambiguated[id(note)]
-            body = _demote_body_h1s(note.body)
+            body = _demote_body_headings(note.body)
             body, broken = resolve_wikilinks(body, title_to_slug)
             body, assets = resolve_images(body, note_path=note.path, asset_index=asset_index)
             broken_total += broken
@@ -115,7 +139,7 @@ def assemble_vault(
                 if resolved not in seen_assets:
                     seen_assets.add(resolved)
                     all_assets.append(resolved)
-            chunks.append(f"# {display_title} {{#{unique_slug}}}")
+            chunks.append(f"## {display_title} {{#{unique_slug}}}")
             chunks.append("")
             chunks.append(body.rstrip())
             chunks.append("")

--- a/src/bookery/core/vault/epub.py
+++ b/src/bookery/core/vault/epub.py
@@ -86,9 +86,10 @@ def render_epub(
             "-t",
             "epub",
             "--toc",
-            # One TOC entry per note; in-body H2/H3 subheadings stay in the
-            # note text but do not clutter the top-level table of contents.
-            "--toc-depth=1",
+            # Folders are H1 chapters and notes are H2 sections. Depth 2 lets
+            # the Kobo TOC render an expandable folder→note tree while body
+            # H3/H4 subheadings stay in the note text without polluting it.
+            "--toc-depth=2",
             "--metadata",
             f"title={title}",
             "--metadata",

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -27,18 +27,32 @@ def _run(tmp_path: Path, *extra_args: str):
     ), out
 
 
+def _flatten_toc_titles(toc) -> set[str]:
+    """Walk pandoc's nested TOC (Section + children tuples) and collect titles."""
+    titles: set[str] = set()
+    for entry in toc:
+        if isinstance(entry, tuple):
+            section, children = entry
+            if hasattr(section, "title"):
+                titles.add(section.title)
+            titles |= _flatten_toc_titles(children)
+        elif hasattr(entry, "title"):
+            titles.add(entry.title)
+    return titles
+
+
 def test_vault_export_produces_valid_epub(tmp_path: Path):
     result, out = _run(tmp_path, "--index")
     assert result.exit_code == 0, result.output
     assert out.exists()
 
     book = epub.read_epub(str(out))
-    titles = {item.title for item in book.toc if hasattr(item, "title")}
-    # Pandoc's TOC items include the notes as top-level H1s.
-    # At minimum, the file is readable and contains a dc:identifier.
+    titles = _flatten_toc_titles(book.toc)
+    # Folders surface as nested TOC sections; notes appear underneath them.
     ids = [v for v, _ in book.get_metadata("DC", "identifier")]
     assert any(v.startswith("urn:uuid:") for v in ids)
-    assert "Note A" in result.output or titles  # smoke the summary output
+    assert "Note A" in titles
+    assert "Note B" in titles
 
 
 def test_vault_export_stable_identifier_across_runs(tmp_path: Path):
@@ -257,16 +271,16 @@ def test_vault_export_default_output_lands_in_library_root_with_catalog(
         cli,
         [
             "vault-export", "--vault", str(FIXTURE),
+            "--title", "Test Vault",
             "--catalog", "--db", str(db),
         ],
         catch_exceptions=False,
-        # Click's CliRunner does not chdir; emulate the user's working
-        # directory by passing it via the underlying invocation.
+        # Pinning --title keeps the test deterministic even when the
+        # developer's real ~/.bookery/config.toml sets a vault title.
     )
     assert result.exit_code == 0, result.output
     library_epubs = list(_isolate_library_root.rglob("*.epub"))
     assert len(library_epubs) == 1, library_epubs
-    # Default filename is derived from the title — the fixture vault folder
-    # is "vault" so the default title is "vault Vault" and the file is
-    # written to <library_root>/vault Vault.epub.
-    assert (_isolate_library_root / "vault Vault.epub").exists()
+    # Default filename is derived from --title so the EPUB lands at a
+    # stable, predictable path under the library root.
+    assert (_isolate_library_root / "Test Vault.epub").exists()

--- a/tests/integration/test_vault_export_pipeline.py
+++ b/tests/integration/test_vault_export_pipeline.py
@@ -17,10 +17,10 @@ def test_full_pipeline_produces_expected_markdown():
     result = assemble_vault(notes, vault_path=FIXTURE, include_index=True)
     md = result.markdown
 
-    # Anchors present.
-    assert "# Note A {#note-a}" in md
-    assert "# Note B {#note-b}" in md
-    assert "# Lit One {#lit-one}" in md
+    # Folder chapters (H1) wrap note sections (H2) with anchors.
+    assert "## Note A {#note-a}" in md
+    assert "## Note B {#note-b}" in md
+    assert "## Lit One {#lit-one}" in md
 
     # Resolved wiki-links.
     assert "[Note B](#note-b)" in md

--- a/tests/unit/test_vault_assemble.py
+++ b/tests/unit/test_vault_assemble.py
@@ -27,12 +27,44 @@ def test_assembles_concatenated_markdown_with_anchors(tmp_path: Path):
     result = assemble_vault(notes, vault_path=tmp_path)
 
     assert isinstance(result, AssembledVault)
-    # Each note produces an H1 with an anchor via {#slug}.
-    assert "# Note A {#note-a}" in result.markdown
-    assert "# Note B {#note-b}" in result.markdown
-    # Wiki-link resolved.
+    # The folder is the chapter (H1); each note is a section (H2) under it.
+    assert "# Perm {#folder-perm}" in result.markdown
+    assert "## Note A {#note-a}" in result.markdown
+    assert "## Note B {#note-b}" in result.markdown
+    # Wiki-link resolved to the note slug.
     assert "[Note B](#note-b)" in result.markdown
     assert result.broken_link_count == 0
+
+
+def test_folder_emitted_as_h1_chapter(tmp_path: Path):
+    notes = [_note("Solo", "My Folder", "body")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "# My Folder {#folder-my-folder}" in md
+    assert "## Solo {#solo}" in md
+    # Folder header precedes the note section under it.
+    assert md.index("# My Folder") < md.index("## Solo")
+
+
+def test_root_folder_gets_label(tmp_path: Path):
+    notes = [_note("Loose", "", "body")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    # Notes living at the vault root still need a chapter wrapper; use a
+    # stable "Notes" label with a deterministic anchor.
+    assert "# Notes {#folder-root}" in result.markdown
+    assert "## Loose {#loose}" in result.markdown
+
+
+def test_notes_alphabetized_within_folder(tmp_path: Path):
+    notes = [
+        _note("zeta", "F", "z"),
+        _note("Alpha", "F", "a"),
+        _note("mango", "F", "m"),
+    ]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    # Case-insensitive A→Z within a folder.
+    assert md.index("## Alpha") < md.index("## mango") < md.index("## zeta")
 
 
 def test_broken_link_counted(tmp_path: Path):
@@ -48,9 +80,11 @@ def test_folder_grouping_headers(tmp_path: Path):
         _note("B", "Lit", "b"),
     ]
     result = assemble_vault(notes, vault_path=tmp_path)
-    # Folder names appear as top-level section separators before their notes.
-    assert result.markdown.index("Lit") < result.markdown.index("# B")
-    assert result.markdown.index("Perm") < result.markdown.index("# A")
+    md = result.markdown
+    # Folders are sorted; each folder H1 precedes its notes' H2 sections.
+    assert md.index("# Lit") < md.index("## B")
+    assert md.index("# Perm") < md.index("## A")
+    assert md.index("# Lit") < md.index("# Perm")
 
 
 def test_index_appended_when_enabled(tmp_path: Path):
@@ -73,18 +107,18 @@ def test_on_progress_called_per_note(tmp_path: Path):
     assert sorted(title for _, _, title in seen) == ["A", "B", "C"]
 
 
-def test_body_h1_demoted_to_h2(tmp_path: Path):
-    # Any H1 in the body — matching or not, at the start or buried after
-    # other content — must be demoted so pandoc's --toc-depth=1 never picks
-    # it up as a sibling chapter.
+def test_body_h1_demoted_to_h3(tmp_path: Path):
+    # Folders are H1, notes are H2. A body H1 must drop two levels to H3 so
+    # pandoc's --toc-depth=2 never picks it up as a chapter or section.
     notes = [_note("Same Title", "F", "![cover](x.png)\n\n# Same Title\n\nbody\n")]
     result = assemble_vault(notes, vault_path=tmp_path)
     md = result.markdown
-    # Exactly one top-level heading per note: the assembler's anchor-bearing H1.
+    # Exactly one H1 per folder.
     h1_lines = [ln for ln in md.splitlines() if ln.startswith("# ")]
-    assert h1_lines == ["# Same Title {#same-title}"]
-    h2_lines = [ln for ln in md.splitlines() if ln.startswith("## ")]
-    assert "## Same Title" in h2_lines
+    assert h1_lines == ["# F {#folder-f}"]
+    # Note heading is H2; body H1 demoted to H3.
+    assert "## Same Title {#same-title}" in md
+    assert "### Same Title" in md
 
 
 def test_non_matching_body_h1_also_demoted(tmp_path: Path):
@@ -92,8 +126,20 @@ def test_non_matching_body_h1_also_demoted(tmp_path: Path):
     result = assemble_vault(notes, vault_path=tmp_path)
     md = result.markdown
     h1_lines = [ln for ln in md.splitlines() if ln.startswith("# ")]
-    assert h1_lines == ["# Title {#title}"]
-    assert "## Different Heading" in md
+    assert h1_lines == ["# F {#folder-f}"]
+    assert "### Different Heading" in md
+
+
+def test_body_h2_demoted_to_h4(tmp_path: Path):
+    # The note itself owns H2; any in-body H2 must cascade down to H4 to keep
+    # the TOC clean and the heading hierarchy consistent.
+    notes = [_note("T", "F", "## Subsection\n\nbody\n")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    # Only one H2 per note: the note's own heading.
+    h2_lines = [ln for ln in md.splitlines() if ln.startswith("## ")]
+    assert h2_lines == ["## T {#t}"]
+    assert "#### Subsection" in md
 
 
 def test_duplicate_titles_in_same_folder_use_filename_hint(tmp_path: Path):
@@ -120,8 +166,8 @@ def test_duplicate_titles_in_same_folder_use_filename_hint(tmp_path: Path):
     )
     result = assemble_vault([n1, n2], vault_path=tmp_path)
     md = result.markdown
-    assert "Reference (book-a-references)" in md
-    assert "Reference (book-b-references)" in md
+    assert "## Reference (book-a-references)" in md
+    assert "## Reference (book-b-references)" in md
 
 
 def test_duplicate_titles_get_unique_slugs(tmp_path: Path):


### PR DESCRIPTION
Closes #102

## Summary

- Vault folders become H1 chapters with anchored slugs (\`# Permanent Notes {#folder-permanent-notes}\`); notes become H2 sections (\`## My Note {#my-note}\`) beneath their folder
- Notes within a folder are sorted case-insensitive A→Z so the Kobo TOC reads predictably
- Body headings cascade: H1→H3, H2→H4, keeping in-note structure subordinate to the assembler's chapter/section levels
- pandoc \`--toc-depth=2\` so both folders and their notes show in the navigation; folder entries expand to reveal contained notes
- e2e TOC smoke test flattens the now-nested ebooklib structure when collecting titles

## Test plan

- [x] \`uv run pytest\` (1239 passing)
- [x] \`uv run ruff check src/ tests/\`
- [x] Manual: \`bookery vault-export\` against the real vault produces an EPUB whose Kobo TOC shows expandable folders rather than a flat note list

## Note for reviewer

This branch was opened in parallel with #104 (#103 path/filename fixes). Both touch \`tests/e2e/test_vault_export_cli.py\` and \`src/bookery/core/vault/epub.py\`; expect a small merge between the two. Either order works.