### PR TITLE
Fix #1: resolve pyright type errors across src and tests

### DIFF
--- a/src/bookery/core/converter.py
+++ b/src/bookery/core/converter.py
@@ -99,22 +99,25 @@ def convert_one(
 
     try:
         if extract_result.format == "epub":
+            assert extract_result.epub_path is not None
             shutil.copy2(extract_result.epub_path, output_path)
         else:
+            assert extract_result.html_path is not None
+            html_path = extract_result.html_path
             opf_metadata = parse_opf_metadata(extract_result.opf_path)
 
             # Parse NCX TOC and split HTML into chapters if available
             chapters = None
             nav_points = parse_ncx_toc(extract_result.ncx_path)
             if nav_points:
-                html_content = extract_result.html_path.read_text(
+                html_content = html_path.read_text(
                     encoding="utf-8", errors="replace",
                 )
                 chapters = split_html_by_anchors(html_content, nav_points)
                 if chapters:
                     logger.info(
                         "Split %s into %d chapters from NCX",
-                        extract_result.html_path.name,
+                        html_path.name,
                         len(chapters),
                     )
                 else:
@@ -124,7 +127,7 @@ def convert_one(
                     )
 
             assemble_epub_from_html(
-                extract_result.html_path,
+                html_path,
                 output_path,
                 metadata=opf_metadata,
                 images_dir=extract_result.images_dir,

--- a/tests/e2e/test_rematch_cli.py
+++ b/tests/e2e/test_rematch_cli.py
@@ -127,6 +127,7 @@ class TestRematchQuietMode:
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
         record = catalog.get_by_id(book_id)
+        assert record is not None
         assert record.metadata.title == "Il Nome della Rosa"
         assert record.output_path is not None
         conn.close()
@@ -276,6 +277,7 @@ class TestRematchInteractive:
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
         record = catalog.get_by_id(book_id)
+        assert record is not None
         assert record.output_path is None
         conn.close()
 

--- a/tests/integration/test_convert_pipeline.py
+++ b/tests/integration/test_convert_pipeline.py
@@ -316,6 +316,7 @@ class TestNcxSplitRoundTrip:
         root = ET.fromstring(opf)
         ns = {"opf": "http://www.idpf.org/2007/opf"}
         spine = root.find("opf:spine", ns)
+        assert spine is not None
         itemrefs = spine.findall("opf:itemref", ns)
         assert itemrefs[0].get("idref") == "cover", (
             "Expected cover as first spine item for Kobo rendering"
@@ -410,6 +411,7 @@ class TestConvertThenMatchPipeline:
             convert_result = convert_one(mobi_file, output_dir)
 
         assert convert_result.success
+        assert convert_result.epub_path is not None
         assert convert_result.epub_path.exists()
 
         # Now feed the converted EPUB into match_one with a mock provider
@@ -434,4 +436,5 @@ class TestConvertThenMatchPipeline:
         match_result = match_one(convert_result.epub_path, mock_provider, mock_review, output_dir)
 
         assert match_result.status == "matched"
+        assert match_result.metadata is not None
         assert match_result.metadata.title == "The Real Title"

--- a/tests/integration/test_match_pipeline.py
+++ b/tests/integration/test_match_pipeline.py
@@ -140,6 +140,7 @@ class TestFullMatchPipeline:
 
         result = apply_metadata_safely(sample_epub, best.metadata, output_dir)
         assert result.success is True
+        assert result.path is not None
         first_output = result.path
 
         # Second pass with resume: should detect existing file via manifest

--- a/tests/integration/test_rematch_pipeline.py
+++ b/tests/integration/test_rematch_pipeline.py
@@ -123,12 +123,15 @@ class TestRematchPipeline:
         )
         book_id = catalog.add_book(metadata, file_hash="ghost123")
         record = catalog.get_by_id(book_id)
+        assert record is not None
 
         # Source file doesn't exist
+        assert record.source_path is not None
         assert not record.source_path.exists()
 
         # The rematch loop checks source_path.exists() before calling match_one
         unchanged = catalog.get_by_id(book_id)
+        assert unchanged is not None
         assert unchanged.metadata.title == "Ghost Book"
         assert unchanged.output_path is None
 

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -415,6 +415,7 @@ class TestConvertOneErrors:
             result = convert_one(mobi_file, output_dir)
 
         assert result.success is False
+        assert result.error is not None
         assert "DRM protected" in result.error
         assert result.epub_path is None
 

--- a/tests/unit/test_mobi_reader.py
+++ b/tests/unit/test_mobi_reader.py
@@ -795,6 +795,7 @@ class TestAssembleEpubFromHtml:
         root = ET.fromstring(opf)
         ns = {"opf": "http://www.idpf.org/2007/opf"}
         spine = root.find("opf:spine", ns)
+        assert spine is not None
         itemrefs = spine.findall("opf:itemref", ns)
         assert itemrefs[0].get("idref") == "cover", (
             "Expected cover as first spine item"
@@ -868,6 +869,7 @@ class TestAssembleEpubFromHtml:
         root = ET.fromstring(opf)
         ns = {"opf": "http://www.idpf.org/2007/opf"}
         spine = root.find("opf:spine", ns)
+        assert spine is not None
         idrefs = [ref.get("idref") for ref in spine.findall("opf:itemref", ns)]
         assert "cover" not in idrefs, "Cover should not be in spine without cover image"
 

--- a/tests/unit/test_openlibrary_provider.py
+++ b/tests/unit/test_openlibrary_provider.py
@@ -413,6 +413,8 @@ class TestSubtitleRetry:
 
         assert len(results) == 2
         assert len(call_log) == 2
+        assert call_log[0] is not None
+        assert call_log[1] is not None
         assert call_log[0]["title"] == "The King's Deception: A Novel"
         assert call_log[1]["title"] == "The King's Deception"
 

--- a/tests/unit/test_pipeline_match.py
+++ b/tests/unit/test_pipeline_match.py
@@ -192,4 +192,5 @@ class TestMatchOne:
             result = match_one(epub_path, provider, review, output_dir)
 
         assert result.status == "error"
+        assert result.error is not None
         assert "Disk full" in result.error

--- a/tests/unit/test_verify.py
+++ b/tests/unit/test_verify.py
@@ -2,12 +2,14 @@
 # ABOUTME: Validates file existence checks, hash verification, and result aggregation.
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from bookery.core.verifier import VerifyResult, verify_library
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
+from bookery.db.mapping import BookRecord
 from bookery.metadata.types import BookMetadata
 
 
@@ -49,7 +51,11 @@ class TestVerifyResult:
 
     def test_total_issues(self) -> None:
         """total_issues counts all problem categories."""
-        result = VerifyResult(ok=5, missing_source=["a"], missing_output=["b", "c"])
+        result = VerifyResult(
+            ok=5,
+            missing_source=cast(list[BookRecord], ["a"]),
+            missing_output=cast(list[BookRecord], ["b", "c"]),
+        )
         assert result.total_issues == 3
 
 


### PR DESCRIPTION
## Summary
- Pyright was wired in `pyproject.toml` + dev deps but never run clean. 24 errors across 10 files.
- Fixes `src/bookery/core/converter.py` (Optional `MobiExtractResult` field narrowing) + 9 test files (None guards).
- All checks green: pyright 0 errors, pytest 1253 passed, ruff lint clean.

## Changes
- **src/bookery/core/converter.py**: narrow Optional fields on `MobiExtractResult` via assertions per format branch (`epub_path` when `format=="epub"`, `html_path` otherwise). Alias `html_path` once to reduce repeated attribute access.
- **tests/e2e/test_rematch_cli.py**: `assert record is not None` after `catalog.get_by_id()`.
- **tests/integration/test_convert_pipeline.py**: guards for `ET.find()`, `ConvertResult.epub_path`, `MatchResult.metadata`.
- **tests/integration/test_match_pipeline.py**: guard for `WriteResult.path`.
- **tests/integration/test_rematch_pipeline.py**: guards for `catalog.get_by_id()` and `record.source_path`.
- **tests/unit/test_converter.py**: guard for `ConvertResult.error`.
- **tests/unit/test_mobi_reader.py**: guards for `ET.find()` spine lookups.
- **tests/unit/test_openlibrary_provider.py**: assert `call_log` entries non-None before subscript.
- **tests/unit/test_pipeline_match.py**: guard for `MatchResult.error`.
- **tests/unit/test_verify.py**: `cast` str sentinels to `list[BookRecord]` for a counter-only test.

## Testing
- [x] `uv run pyright` — 0 errors (was 24)
- [x] `uv run pytest` — 1253 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Pre-commit hook (pyright + ruff) passes

## Related Issues
Refs #1.

Remaining work on #1 (separate follow-ups):
- ty evaluation vs continuing with pyright
- CI integration (no `.github/workflows/` exists yet)
- CONTRIBUTING.md documentation

## Notes from review
- `assert`-style narrowing in `converter.py` is stripped under `python -O`. Considered raising explicit `MobiReadError` instead; deferred as a separate refactor since CLI tools rarely run with `-O` and the larger fix is a discriminated-union refactor of `MobiExtractResult`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)