### PR TITLE
feat(web): restructure book detail and edit pages (#112)

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1,7 +1,45 @@
 # ABOUTME: Flask blueprint with route handlers for the Bookery web UI.
 # ABOUTME: Handles book listing, detail view, search, and inline editing with htmx support.
 
+import os
+from pathlib import Path
+
 from flask import Blueprint, abort, current_app, redirect, render_template, request, url_for
+
+
+def _file_context(book) -> dict[str, str]:
+    """Best-effort file format + size for a BookRecord.
+
+    Stat the output_path when present, otherwise the source_path. On any
+    failure (missing file, permission error) the size renders as an em-dash.
+    The format is derived from the path extension and uppercased.
+    """
+    path: Path | None = book.output_path or book.source_path
+    fmt = ""
+    size_display = "—"
+    if path is not None:
+        suffix = path.suffix.lstrip(".").upper()
+        if suffix:
+            fmt = suffix
+        try:
+            size_bytes = os.stat(path).st_size
+            size_display = _format_size(size_bytes)
+        except OSError:
+            size_display = "—"
+    return {"format": fmt, "size": size_display}
+
+
+def _format_size(num_bytes: int) -> str:
+    """Render a byte count as a short human-friendly string (e.g. '1.2 MB')."""
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
+
 
 bp = Blueprint(
     "web",
@@ -41,11 +79,14 @@ def book_detail(book_id):
 
     tags = catalog.get_tags_for_book(book_id)
     genres = catalog.get_genres_for_book(book_id)
+    file_info = _file_context(book)
 
     if request.headers.get("HX-Request"):
-        return render_template("_detail.html", book=book, tags=tags, genres=genres)
+        return render_template(
+            "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
+        )
 
-    return render_template("detail.html", book=book, tags=tags, genres=genres)
+    return render_template("detail.html", book=book, tags=tags, genres=genres, file_info=file_info)
 
 
 @bp.route("/books/<int:book_id>/edit", methods=["GET"])
@@ -56,7 +97,8 @@ def edit_form(book_id):
     if book is None:
         abort(404)
 
-    return render_template("_edit_form.html", book=book)
+    file_info = _file_context(book)
+    return render_template("_edit_form.html", book=book, file_info=file_info)
 
 
 @bp.route("/books/<int:book_id>/edit", methods=["POST"])
@@ -69,7 +111,15 @@ def update_book(book_id):
 
     title = request.form.get("title", "").strip()
     if not title:
-        return render_template("_edit_form.html", book=book, error="Title is required"), 400
+        return (
+            render_template(
+                "_edit_form.html",
+                book=book,
+                file_info=_file_context(book),
+                error="Title is required",
+            ),
+            400,
+        )
 
     # Parse semicolon-separated authors
     authors_raw = request.form.get("authors", "").strip()
@@ -101,5 +151,8 @@ def update_book(book_id):
     book = catalog.get_by_id(book_id)
     tags = catalog.get_tags_for_book(book_id)
     genres = catalog.get_genres_for_book(book_id)
+    file_info = _file_context(book)
 
-    return render_template("_detail.html", book=book, tags=tags, genres=genres)
+    return render_template(
+        "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
+    )

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -9,6 +9,40 @@
     --color-hover: #f5f5f0;
     --color-badge: #16a34a;
     --color-muted: #666;
+    --color-destructive: #dc2626;
+}
+
+/* Skip link — visually hidden until focused. */
+.skip-link {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    background: var(--color-link);
+    color: white;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    outline: 2px solid var(--color-link);
+    outline-offset: 2px;
+}
+
+/* Visible focus outline for keyboard users across all interactive elements. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+    outline: 2px solid var(--color-link);
+    outline-offset: 2px;
 }
 
 * {
@@ -242,4 +276,136 @@ header h1 a {
 
 .btn-secondary:hover {
     background: var(--color-hover);
+}
+
+.btn-destructive {
+    background: white;
+    color: var(--color-destructive);
+    border-color: var(--color-destructive);
+}
+
+.btn-destructive:hover:not(:disabled) {
+    background: var(--color-destructive);
+    color: white;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Sections (issue #112) */
+
+.section {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.section:last-child {
+    border-bottom: none;
+}
+
+.section h3 {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    margin-bottom: 0.5rem;
+}
+
+.section h4 {
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    margin: 0.5rem 0 0.25rem;
+}
+
+/* Header section layout — title block, badge, toolbar. */
+
+.section-header .header-titles h2 {
+    font-size: 1.75rem;
+    margin-bottom: 0.25rem;
+}
+
+.section-header .byline {
+    color: var(--color-muted);
+    margin-bottom: 0.75rem;
+}
+
+.enriched-badge {
+    display: inline-block;
+    background: var(--color-badge);
+    color: white;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+}
+
+.toolbar {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+/* Metadata grid — two-column dl. */
+
+.metadata-grid {
+    display: grid;
+    grid-template-columns: 8rem 1fr;
+    gap: 0.25rem 1rem;
+}
+
+.metadata-grid dt {
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.metadata-grid code {
+    font-size: 0.85rem;
+    word-break: break-all;
+}
+
+/* Edit layout — two columns >=720px, stacked below. */
+
+.edit-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+}
+
+@media (min-width: 720px) {
+    .edit-layout {
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    }
+}
+
+.provenance {
+    background: var(--color-hover);
+    padding: 1rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.provenance h3 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    margin-bottom: 0.5rem;
+}
+
+/* Mobile: collapse detail metadata-grid to single column. */
+
+@media (max-width: 600px) {
+    .metadata-grid {
+        grid-template-columns: 1fr;
+    }
+    .metadata-grid dt {
+        margin-top: 0.5rem;
+    }
+    .book-detail {
+        max-width: 100%;
+    }
 }

--- a/src/bookery/web/templates/_detail.html
+++ b/src/bookery/web/templates/_detail.html
@@ -1,60 +1,9 @@
-<h2>{{ book.metadata.title }}</h2>
-
-<button class="btn btn-secondary"
-        hx-get="{{ url_for('web.edit_form', book_id=book.id) }}"
-        hx-target="#book-content"
-        hx-swap="innerHTML">Edit</button>
-
-<dl class="metadata">
-    <dt>Author</dt>
-    <dd>{{ book.metadata.author }}</dd>
-
-    {% if book.metadata.isbn %}
-    <dt>ISBN</dt>
-    <dd>{{ book.metadata.isbn }}</dd>
-    {% endif %}
-
-    {% if book.metadata.language %}
-    <dt>Language</dt>
-    <dd>{{ book.metadata.language }}</dd>
-    {% endif %}
-
-    {% if book.metadata.publisher %}
-    <dt>Publisher</dt>
-    <dd>{{ book.metadata.publisher }}</dd>
-    {% endif %}
-
-    {% if book.metadata.series %}
-    <dt>Series</dt>
-    <dd>{{ book.metadata.series }}{% if book.metadata.series_index %} #{{ book.metadata.series_index }}{% endif %}</dd>
-    {% endif %}
-</dl>
-
-{% if book.metadata.description %}
-<div class="description">
-    <h3>Description</h3>
-    <p>{{ book.metadata.description }}</p>
-</div>
-{% endif %}
-
-{% if tags %}
-<div class="tags">
-    <h3>Tags</h3>
-    <ul>
-        {% for tag in tags %}
-        <li>{{ tag }}</li>
-        {% endfor %}
-    </ul>
-</div>
-{% endif %}
-
-{% if genres %}
-<div class="genres">
-    <h3>Genres</h3>
-    <ul>
-        {% for name, is_primary in genres %}
-        <li>{{ name }}{% if is_primary %} <span class="primary-badge">(primary)</span>{% endif %}</li>
-        {% endfor %}
-    </ul>
-</div>
-{% endif %}
+{# ABOUTME: Top-level book detail partial — composes per-section partials. #}
+{# ABOUTME: Reserves #enrich-panel for future enrichment-diff swaps. #}
+{% include "_detail_header.html" %}
+<div id="enrich-panel"></div>
+{% include "_detail_identity.html" %}
+{% include "_detail_publication.html" %}
+{% include "_detail_classification.html" %}
+{% include "_detail_file.html" %}
+{% include "_detail_description.html" %}

--- a/src/bookery/web/templates/_detail_classification.html
+++ b/src/bookery/web/templates/_detail_classification.html
@@ -1,0 +1,27 @@
+{# ABOUTME: Detail classification partial — tags and genres. #}
+{# ABOUTME: Primary genres render first, marked with a primary badge. #}
+{% if tags or genres %}
+<section class="section" aria-labelledby="detail-classification">
+    <h3 id="detail-classification">Classification</h3>
+    {% if tags %}
+    <div class="tags">
+        <h4>Tags</h4>
+        <ul>
+            {% for tag in tags %}
+            <li>{{ tag }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+    {% if genres %}
+    <div class="genres">
+        <h4>Genres</h4>
+        <ul>
+            {% for name, is_primary in genres|sort(attribute=1, reverse=true) %}
+            <li>{{ name }}{% if is_primary %} <span class="primary-badge">(primary)</span>{% endif %}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+</section>
+{% endif %}

--- a/src/bookery/web/templates/_detail_description.html
+++ b/src/bookery/web/templates/_detail_description.html
@@ -1,0 +1,8 @@
+{# ABOUTME: Detail description partial — long-form blurb. #}
+{# ABOUTME: Section is omitted entirely when no description is available. #}
+{% if book.metadata.description %}
+<section class="section" aria-labelledby="detail-description">
+    <h3 id="detail-description">Description</h3>
+    <p>{{ book.metadata.description }}</p>
+</section>
+{% endif %}

--- a/src/bookery/web/templates/_detail_file.html
+++ b/src/bookery/web/templates/_detail_file.html
@@ -1,0 +1,21 @@
+{# ABOUTME: Detail file partial — format, size, paths, hash, dates. #}
+{# ABOUTME: Pure provenance — never mutated through the edit form. #}
+<section class="section" aria-labelledby="detail-file">
+    <h3 id="detail-file">File</h3>
+    <dl class="metadata-grid">
+        <dt>Format</dt>
+        <dd>{{ file_info.format or "—" }}</dd>
+        <dt>Size</dt>
+        <dd>{{ file_info.size }}</dd>
+        <dt>Source path</dt>
+        <dd><code>{{ book.source_path }}</code></dd>
+        <dt>Output path</dt>
+        <dd>{% if book.output_path %}<code>{{ book.output_path }}</code>{% else %}—{% endif %}</dd>
+        <dt>File hash</dt>
+        <dd><code>{{ book.file_hash }}</code></dd>
+        <dt>Added</dt>
+        <dd>{{ book.date_added }}</dd>
+        <dt>Modified</dt>
+        <dd>{{ book.date_modified }}</dd>
+    </dl>
+</section>

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -1,0 +1,28 @@
+{# ABOUTME: Detail header partial — title, author(s), enriched badge, toolbar. #}
+{# ABOUTME: Toolbar reserves disabled Enrich + Delete slots for follow-up stories. #}
+<section class="section section-header" aria-labelledby="detail-header">
+    <div class="header-titles">
+        <h2 id="detail-header">{{ book.metadata.title }}</h2>
+        <p class="byline">by {{ book.metadata.author }}</p>
+    </div>
+    {% if book.output_path %}
+    <p class="enriched-badge" aria-label="Enriched">&#10003; Enriched</p>
+    {% endif %}
+    <div class="toolbar" role="toolbar" aria-label="Book actions">
+        <button type="button"
+                class="btn btn-secondary"
+                hx-get="{{ url_for('web.edit_form', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Edit</button>
+        <button type="button"
+                class="btn btn-secondary"
+                disabled
+                aria-disabled="true"
+                title="Coming soon">Enrich</button>
+        <button type="button"
+                class="btn btn-destructive"
+                disabled
+                aria-disabled="true"
+                title="Coming soon">Delete</button>
+    </div>
+</section>

--- a/src/bookery/web/templates/_detail_identity.html
+++ b/src/bookery/web/templates/_detail_identity.html
@@ -1,0 +1,21 @@
+{# ABOUTME: Detail identity partial — ISBN, language, and series fields. #}
+{# ABOUTME: Renders only when at least one identity field is set. #}
+{% if book.metadata.isbn or book.metadata.language or book.metadata.series %}
+<section class="section" aria-labelledby="detail-identity">
+    <h3 id="detail-identity">Identity</h3>
+    <dl class="metadata-grid">
+        {% if book.metadata.isbn %}
+        <dt>ISBN</dt>
+        <dd>{{ book.metadata.isbn }}</dd>
+        {% endif %}
+        {% if book.metadata.language %}
+        <dt>Language</dt>
+        <dd>{{ book.metadata.language }}</dd>
+        {% endif %}
+        {% if book.metadata.series %}
+        <dt>Series</dt>
+        <dd>{{ book.metadata.series }}{% if book.metadata.series_index %} #{{ book.metadata.series_index }}{% endif %}</dd>
+        {% endif %}
+    </dl>
+</section>
+{% endif %}

--- a/src/bookery/web/templates/_detail_publication.html
+++ b/src/bookery/web/templates/_detail_publication.html
@@ -1,0 +1,11 @@
+{# ABOUTME: Detail publication partial — publisher info. #}
+{# ABOUTME: Hidden when no publication metadata is set. #}
+{% if book.metadata.publisher %}
+<section class="section" aria-labelledby="detail-publication">
+    <h3 id="detail-publication">Publication</h3>
+    <dl class="metadata-grid">
+        <dt>Publisher</dt>
+        <dd>{{ book.metadata.publisher }}</dd>
+    </dl>
+</section>
+{% endif %}

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -1,51 +1,78 @@
-<form class="edit-form" hx-post="{{ url_for('web.update_book', book_id=book.id) }}" hx-target="#book-content" hx-swap="innerHTML">
-    {% if error %}
-    <div class="form-error">{{ error }}</div>
-    {% endif %}
+{# ABOUTME: Inline edit form with read-only provenance panel and Esc-to-cancel. #}
+{# ABOUTME: Two-column on >=720px viewports, stacked on mobile (handled by CSS). #}
+<div class="edit-layout">
+    <form class="edit-form"
+          hx-post="{{ url_for('web.update_book', book_id=book.id) }}"
+          hx-target="#book-content"
+          hx-swap="innerHTML">
+        {% if error %}
+        <div class="form-error" role="alert">{{ error }}</div>
+        {% endif %}
 
-    <div class="form-group">
-        <label for="title">Title <span class="required">*</span></label>
-        <input type="text" id="title" name="title" value="{{ book.metadata.title }}" required>
-    </div>
-
-    <div class="form-group">
-        <label for="authors">Authors <span class="hint">(semicolon-separated)</span></label>
-        <input type="text" id="authors" name="authors" value="{{ book.metadata.authors | join('; ') }}">
-    </div>
-
-    <div class="form-group">
-        <label for="isbn">ISBN</label>
-        <input type="text" id="isbn" name="isbn" value="{{ book.metadata.isbn or '' }}">
-    </div>
-
-    <div class="form-group">
-        <label for="language">Language</label>
-        <input type="text" id="language" name="language" value="{{ book.metadata.language or '' }}">
-    </div>
-
-    <div class="form-group">
-        <label for="publisher">Publisher</label>
-        <input type="text" id="publisher" name="publisher" value="{{ book.metadata.publisher or '' }}">
-    </div>
-
-    <div class="form-group">
-        <label for="description">Description</label>
-        <textarea id="description" name="description" rows="4">{{ book.metadata.description or '' }}</textarea>
-    </div>
-
-    <div class="form-group form-row">
-        <div>
-            <label for="series">Series</label>
-            <input type="text" id="series" name="series" value="{{ book.metadata.series or '' }}">
+        <div class="form-group">
+            <label for="title">Title <span class="required">*</span></label>
+            <input type="text" id="title" name="title" value="{{ book.metadata.title }}" required>
         </div>
-        <div>
-            <label for="series_index">Series #</label>
-            <input type="number" id="series_index" name="series_index" step="any" value="{{ book.metadata.series_index if book.metadata.series_index is not none else '' }}">
-        </div>
-    </div>
 
-    <div class="form-actions">
-        <button type="submit" class="btn btn-primary">Save</button>
-        <button type="button" class="btn btn-secondary" hx-get="{{ url_for('web.book_detail', book_id=book.id) }}" hx-target="#book-content" hx-swap="innerHTML">Cancel</button>
-    </div>
-</form>
+        <div class="form-group">
+            <label for="authors">Authors <span class="hint">(semicolon-separated)</span></label>
+            <input type="text" id="authors" name="authors" value="{{ book.metadata.authors | join('; ') }}">
+        </div>
+
+        <div class="form-group">
+            <label for="isbn">ISBN</label>
+            <input type="text" id="isbn" name="isbn" value="{{ book.metadata.isbn or '' }}">
+        </div>
+
+        <div class="form-group">
+            <label for="language">Language</label>
+            <input type="text" id="language" name="language" value="{{ book.metadata.language or '' }}">
+        </div>
+
+        <div class="form-group">
+            <label for="publisher">Publisher</label>
+            <input type="text" id="publisher" name="publisher" value="{{ book.metadata.publisher or '' }}">
+        </div>
+
+        <div class="form-group">
+            <label for="description">Description</label>
+            <textarea id="description" name="description" rows="4">{{ book.metadata.description or '' }}</textarea>
+        </div>
+
+        <div class="form-group form-row">
+            <div>
+                <label for="series">Series</label>
+                <input type="text" id="series" name="series" value="{{ book.metadata.series or '' }}">
+            </div>
+            <div>
+                <label for="series_index">Series #</label>
+                <input type="number" id="series_index" name="series_index" step="any" value="{{ book.metadata.series_index if book.metadata.series_index is not none else '' }}">
+            </div>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="button"
+                    class="btn btn-secondary"
+                    id="edit-cancel"
+                    hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
+                    hx-target="#book-content"
+                    hx-swap="innerHTML">Cancel</button>
+        </div>
+    </form>
+
+    {% include "_provenance.html" %}
+</div>
+
+<script>
+    // Esc cancels the edit and swaps back to the detail view.
+    (function () {
+        function onKey(e) {
+            if (e.key === "Escape") {
+                var btn = document.getElementById("edit-cancel");
+                if (btn) { btn.click(); }
+            }
+        }
+        document.addEventListener("keydown", onKey, { once: true });
+    })();
+</script>

--- a/src/bookery/web/templates/_provenance.html
+++ b/src/bookery/web/templates/_provenance.html
@@ -1,0 +1,21 @@
+{# ABOUTME: Read-only provenance panel for the edit page — paths, hash, dates. #}
+{# ABOUTME: Mirrors _detail_file.html content so editors see file context alongside the form. #}
+<aside class="provenance" aria-labelledby="edit-provenance">
+    <h3 id="edit-provenance">Provenance</h3>
+    <dl class="metadata-grid">
+        <dt>Format</dt>
+        <dd>{{ file_info.format or "—" }}</dd>
+        <dt>Size</dt>
+        <dd>{{ file_info.size }}</dd>
+        <dt>Source path</dt>
+        <dd><code>{{ book.source_path }}</code></dd>
+        <dt>Output path</dt>
+        <dd>{% if book.output_path %}<code>{{ book.output_path }}</code>{% else %}—{% endif %}</dd>
+        <dt>File hash</dt>
+        <dd><code>{{ book.file_hash }}</code></dd>
+        <dt>Added</dt>
+        <dd>{{ book.date_added }}</dd>
+        <dt>Modified</dt>
+        <dd>{{ book.date_modified }}</dd>
+    </dl>
+</aside>

--- a/src/bookery/web/templates/base.html
+++ b/src/bookery/web/templates/base.html
@@ -8,10 +8,11 @@
     <script src="{{ url_for('web.static', filename='htmx.min.js') }}"></script>
 </head>
 <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <header>
         <h1><a href="{{ url_for('web.books') }}">Bookery</a></h1>
     </header>
-    <main>
+    <main id="main">
         {% block content %}{% endblock %}
     </main>
 </body>

--- a/src/bookery/web/templates/detail.html
+++ b/src/bookery/web/templates/detail.html
@@ -4,9 +4,11 @@
 
 {% block content %}
 <div class="book-detail">
-    <p class="back-link"><a href="{{ url_for('web.books') }}">&larr; Back to library</a></p>
+    <nav aria-label="Breadcrumb" class="back-link">
+        <a href="{{ url_for('web.books') }}" aria-current="page">&larr; Back to library</a>
+    </nav>
 
-    <div id="book-content">
+    <div id="book-content" aria-live="polite">
         {% include "_detail.html" %}
     </div>
 </div>

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,76 @@
+# ABOUTME: Shared fixtures for tests/web — Flask test client + BookRecord builders.
+# ABOUTME: Mirrors tests/unit/test_web_app.py helpers without coupling to that file.
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from bookery.db.mapping import BookRecord
+from bookery.metadata.types import BookMetadata
+from bookery.web import create_app
+
+
+def make_book(
+    book_id: int = 1,
+    title: str = "Test Book",
+    authors: list[str] | None = None,
+    author_sort: str | None = None,
+    isbn: str | None = None,
+    language: str | None = None,
+    publisher: str | None = None,
+    source_path: Path = Path("/books/test.epub"),
+    output_path: Path | None = None,
+    description: str | None = None,
+    series: str | None = None,
+    series_index: float | None = None,
+    file_hash: str = "abc123",
+    date_added: str = "2026-01-01",
+    date_modified: str = "2026-01-02",
+) -> BookRecord:
+    """Build a BookRecord for web template tests."""
+    return BookRecord(
+        id=book_id,
+        metadata=BookMetadata(
+            title=title,
+            authors=authors or ["Unknown"],
+            author_sort=author_sort or (authors[0] if authors else "Unknown"),
+            isbn=isbn,
+            language=language,
+            publisher=publisher,
+            description=description,
+            series=series,
+            series_index=series_index,
+        ),
+        file_hash=file_hash,
+        source_path=source_path,
+        output_path=output_path,
+        date_added=date_added,
+        date_modified=date_modified,
+    )
+
+
+@pytest.fixture
+def mock_catalog():
+    """Mock LibraryCatalog with sensible defaults."""
+    catalog = Mock()
+    catalog.list_all_by_author.return_value = []
+    catalog.search.return_value = []
+    catalog.get_by_id.return_value = None
+    catalog.get_tags_for_book.return_value = []
+    catalog.get_genres_for_book.return_value = []
+    return catalog
+
+
+@pytest.fixture
+def app(mock_catalog):
+    """Flask app wired to the mock catalog."""
+    app = create_app(mock_catalog)
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """Flask test client."""
+    return app.test_client()

--- a/tests/web/test_accessibility.py
+++ b/tests/web/test_accessibility.py
@@ -1,0 +1,48 @@
+# ABOUTME: Accessibility tests for the web UI per issue #112 acceptance criteria.
+# ABOUTME: Validates skip-link, aria-live region, labels, and Back link semantics.
+
+import re
+
+from tests.web.conftest import make_book
+
+
+class TestSkipLink:
+    def test_skip_link_is_first_focusable(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # Skip-link must appear before <main> in the document.
+        assert "skip-link" in html
+        body_idx = html.index("<body")
+        skip_idx = html.index('href="#main"')
+        main_idx = html.index("<main")
+        assert body_idx < skip_idx < main_idx
+
+
+class TestAriaLive:
+    def test_book_content_has_aria_live(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # The #book-content target announces htmx swaps politely.
+        assert re.search(
+            r'id="book-content"[^>]*aria-live="polite"|aria-live="polite"[^>]*id="book-content"',
+            html,
+        )
+
+
+class TestEditFormLabels:
+    def test_every_input_has_matching_label(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1/edit").data.decode()
+
+        ids = set(re.findall(r'<(?:input|textarea)[^>]*id="([^"]+)"', html))
+        label_fors = set(re.findall(r'<label[^>]*for="([^"]+)"', html))
+
+        assert ids, "Edit form must have inputs with id attrs"
+        assert ids <= label_fors, f"Inputs missing labels: {ids - label_fors}"
+
+
+class TestBackLink:
+    def test_back_link_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        assert "Back to library" in html

--- a/tests/web/test_detail.py
+++ b/tests/web/test_detail.py
@@ -1,0 +1,137 @@
+# ABOUTME: Tests for the restructured book detail page (issue #112).
+# ABOUTME: Verifies section partials, file context, toolbar placeholders, and enriched badge.
+
+from pathlib import Path
+
+from tests.web.conftest import make_book
+
+
+class TestDetailSections:
+    def test_header_section_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", authors=["Herbert, Frank"]
+        )
+
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-header"' in html
+        assert "Dune" in html
+        assert "Herbert, Frank" in html
+
+    def test_identity_section_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, isbn="9780441172719", language="en", series="Dune Chronicles", series_index=1.0
+        )
+
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-identity"' in html
+        assert "<h3" in html and "Identity" in html
+        assert "9780441172719" in html
+        assert "en" in html
+        assert "Dune Chronicles" in html
+
+    def test_publication_section_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, publisher="Ace Books")
+
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-publication"' in html
+        assert "Publication" in html
+        assert "Ace Books" in html
+
+    def test_classification_section_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_tags_for_book.return_value = ["sci-fi"]
+        mock_catalog.get_genres_for_book.return_value = [("Science Fiction", True)]
+
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-classification"' in html
+        assert "Classification" in html
+        assert "sci-fi" in html
+        assert "Science Fiction" in html
+
+    def test_file_section_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            source_path=Path("/books/test.epub"),
+            file_hash="deadbeef",
+            date_added="2026-01-01",
+            date_modified="2026-01-02",
+        )
+
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-file"' in html
+        assert "File" in html
+        assert "deadbeef" in html
+        assert "2026-01-01" in html
+        assert "2026-01-02" in html
+
+    def test_file_section_renders_dash_when_stat_fails(self, mock_catalog, client):
+        # /nonexistent path → stat() raises, size renders as em-dash.
+        mock_catalog.get_by_id.return_value = make_book(
+            1, source_path=Path("/nonexistent/missing.epub")
+        )
+
+        html = client.get("/books/1").data.decode()
+        assert "—" in html  # em-dash fallback for size
+        # Format from extension still works
+        assert "EPUB" in html
+
+    def test_file_section_shows_format_from_extension(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=Path("/books/foo.epub"))
+
+        html = client.get("/books/1").data.decode()
+        assert "EPUB" in html
+
+    def test_description_section_only_when_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, description="A great story.")
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-description"' in html
+        assert "A great story." in html
+
+    def test_description_section_omitted_when_empty(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, description=None)
+        html = client.get("/books/1").data.decode()
+        assert 'aria-labelledby="detail-description"' not in html
+
+
+class TestEnrichedBadge:
+    def test_badge_shown_when_output_path_set(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, output_path=Path("/library/test.epub"))
+
+        html = client.get("/books/1").data.decode()
+        assert "Enriched" in html
+
+    def test_badge_absent_when_output_path_missing(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, output_path=None)
+        html = client.get("/books/1").data.decode()
+        assert "Enriched" not in html
+
+
+class TestToolbar:
+    def test_toolbar_has_role(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        assert 'role="toolbar"' in html
+
+    def test_toolbar_has_edit_active(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # Edit button must include hx-get to edit endpoint
+        assert "/books/1/edit" in html
+        assert "Edit" in html
+
+    def test_toolbar_has_disabled_enrich_and_delete(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        assert "Enrich" in html
+        assert "Delete" in html
+        # Both placeholders carry a "Coming soon" affordance.
+        assert html.count('title="Coming soon"') >= 2
+        # Delete uses destructive styling.
+        assert "btn-destructive" in html
+
+
+class TestEnrichPanelSlot:
+    def test_enrich_panel_div_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        assert 'id="enrich-panel"' in html

--- a/tests/web/test_edit.py
+++ b/tests/web/test_edit.py
@@ -1,0 +1,68 @@
+# ABOUTME: Tests for the restructured edit form + provenance panel (issue #112).
+# ABOUTME: Verifies provenance content, Esc keybind hook, and POST behavior preserved.
+
+from pathlib import Path
+
+from tests.web.conftest import make_book
+
+
+class TestProvenancePanel:
+    def test_provenance_panel_renders(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            source_path=Path("/books/test.epub"),
+            output_path=Path("/library/test.epub"),
+            file_hash="deadbeef",
+            date_added="2026-01-01",
+            date_modified="2026-01-02",
+        )
+        html = client.get("/books/1/edit").data.decode()
+        assert "provenance" in html  # CSS class
+        assert "/books/test.epub" in html
+        assert "/library/test.epub" in html
+        assert "deadbeef" in html
+        assert "2026-01-01" in html
+        assert "2026-01-02" in html
+
+    def test_provenance_panel_dash_for_missing_output(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, output_path=None)
+        html = client.get("/books/1/edit").data.decode()
+        # Provenance shows an em-dash for the missing output path.
+        assert "—" in html
+
+
+class TestEditFormKeybind:
+    def test_edit_form_has_esc_keybind_handler(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1/edit").data.decode()
+        # Inline JS that listens for Escape key to cancel the edit.
+        assert "Escape" in html
+
+
+class TestEditFormStructure:
+    def test_required_marker_only_on_title(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1/edit").data.decode()
+        assert html.count('class="required"') == 1
+
+
+class TestUpdateStillRendersDetail:
+    def test_post_returns_detail_partial_with_sections(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Updated")
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Updated",
+                "authors": "Author, Test",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+        )
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "Updated" in html
+        assert 'aria-labelledby="detail-header"' in html


### PR DESCRIPTION
Closes #112

## Summary

- Split `_detail.html` into per-section partials (header, identity, publication, classification, file, description) and reserved a `#enrich-panel` div for the future enrichment-diff swap.
- New header partial: title + author byline + Enriched badge + `role="toolbar"` action group with disabled Enrich + destructive Delete placeholders (`title="Coming soon"`).
- Added a read-only Provenance panel alongside the edit form (two-column ≥720px, stacked ≤600px) covering format, size, source/output paths, hash, and dates. Vanilla inline JS lets Esc trigger Cancel.
- Routes now compute `file_info` (format from extension, human-friendly size with em-dash fallback on `OSError`) for the detail and edit views.
- CSS adds `--color-destructive`, `.section`, `.metadata-grid`, `.toolbar`, `.btn-destructive`, `.provenance`, plus a focusable skip-link and visible focus outline; `#book-content` now carries `aria-live="polite"` for htmx swap announcements.

## Test plan

New `tests/web/` package:

- `test_detail.py` — section partials present with expected `aria-labelledby`/`<h3>`; em-dash fallback when stat fails; format derived from extension; Enriched badge present only when `output_path` is set; toolbar role + disabled placeholders; `#enrich-panel` slot.
- `test_edit.py` — provenance panel renders alongside the form; em-dash for missing output path; Esc keybind hook present; single required marker; POST still returns the rebuilt detail partial.
- `test_accessibility.py` — skip-link is first focusable inside `<body>`; `aria-live="polite"` on `#book-content`; every edit-form input has a matching `<label for>`; Back link present.

Manual verification:

- [ ] `uv run bookery serve` and visit `/books/<id>` — confirm the new sections, toolbar, and enriched badge.
- [ ] Click Edit, confirm two-column layout ≥720px and provenance panel content.
- [ ] Press Esc while editing — should swap back to the detail view.
- [ ] Resize to ≤600px and confirm the metadata grid + edit layout stack to a single column.
- [ ] Tab from the page top — first focus should land on the Skip to main content link.

Gates:

- [x] `uv run pytest` — 1277 passed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/bookery/web/ tests/web/` — clean