### PR TITLE
feat(cli): add bookery remove command (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ bookery info 42
 | Command | Description |
 |---------|-------------|
 | `import <dir>` | Scan for EPUBs, copy into `library_root`, and catalog them (supports `--match`, `--move`) |
+| `remove <id>...` | Delete one or more books from the catalog and disk (`-y` skips prompt; `--keep-file` keeps the file) |
 | `ls` | List all books in the catalog (filter with `--series` or `--tag`) |
 | `info <id>` | Show detailed metadata for a book by ID |
 | `search <query>` | Search the catalog by title, author, or description |

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -18,6 +18,7 @@ from bookery.cli.commands import (
     ls_cmd,
     match_cmd,
     rematch_cmd,
+    remove_cmd,
     search_cmd,
     serve_cmd,
     sync_cmd,
@@ -66,6 +67,7 @@ cli.add_command(inventory_cmd.inventory)
 cli.add_command(ls_cmd.ls)
 cli.add_command(match_cmd.match)
 cli.add_command(rematch_cmd.rematch)
+cli.add_command(remove_cmd.remove)
 cli.add_command(search_cmd.search)
 cli.add_command(serve_cmd.serve)
 cli.add_command(sync_cmd.sync)

--- a/src/bookery/cli/commands/remove_cmd.py
+++ b/src/bookery/cli/commands/remove_cmd.py
@@ -1,0 +1,175 @@
+# ABOUTME: The `bookery remove` command for deleting books from catalog and disk.
+# ABOUTME: Prompts per ID by default, supports -y/--yes, --keep-file, and multi-ID input.
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+
+from bookery.cli.options import db_option, resolve_db_path
+from bookery.core.remove import RemoveResult, remove_book
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+
+console = Console()
+
+
+def _human_size(num_bytes: int) -> str:
+    """Render a byte count as KB/MB/GB to one decimal place."""
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024.0:
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024.0
+    return f"{size:.1f} PB"
+
+
+def _build_confirmation_panel(
+    catalog: LibraryCatalog,
+    book_id: int,
+    *,
+    keep_file: bool,
+) -> Panel | None:
+    """Build a Rich panel summarizing what removing this book will touch.
+
+    Returns None if the book ID isn't in the catalog — the caller treats
+    that as an error case and reports it separately.
+    """
+    record = catalog.get_by_id(book_id)
+    if record is None:
+        return None
+
+    output_path = record.output_path
+    size_text = "n/a"
+    if output_path is not None:
+        try:
+            size_text = _human_size(output_path.stat().st_size)
+        except OSError:
+            size_text = "missing"
+
+    tag_count = len(catalog.get_tags_for_book(book_id))
+    genre_count = len(catalog.get_genres_for_book(book_id))
+
+    # Duplicate cluster check (same query the core uses, surfaced for UX)
+    dup_count = 0
+    if output_path is not None:
+        cursor = catalog._conn.execute(
+            "SELECT COUNT(*) FROM books WHERE output_path = ? AND id != ?",
+            (str(output_path), book_id),
+        )
+        dup_count = int(cursor.fetchone()[0])
+
+    body = Text()
+    body.append(f"ID:      {book_id}\n", style="bold")
+    body.append(f"Title:   {record.metadata.title}\n")
+    body.append(f"Author:  {record.metadata.author or 'Unknown'}\n")
+    body.append(f"Path:    {output_path if output_path else '(no file)'}\n")
+    body.append(f"Size:    {size_text}\n")
+    body.append(f"Tags:    {tag_count}    Genres: {genre_count}\n")
+    if dup_count > 0:
+        body.append(
+            f"Note: {dup_count} other catalog entries point at this same "
+            "file; the file will be kept on disk.\n",
+            style="yellow",
+        )
+    if keep_file:
+        body.append("Mode: --keep-file (file on disk will be preserved)\n", style="cyan")
+
+    return Panel(body, title="Remove this book?", border_style="red")
+
+
+def _render_result(result: RemoveResult) -> None:
+    """Print the per-book outcome line plus any warnings."""
+    console.print(
+        f'[green]Removed[/green] "{result.title}" by {result.author} (ID {result.book_id})'
+    )
+    if result.file_removed:
+        console.print(f"  [dim]file:[/dim] {result.file_path}")
+    for sibling in result.siblings_removed:
+        console.print(f"  [dim]sibling:[/dim] {sibling}")
+    for warning in result.warnings:
+        console.print(f"  [yellow]warning:[/yellow] {warning}")
+
+
+@click.command("remove")
+@click.argument("book_ids", nargs=-1, type=int, required=True)
+@db_option
+@click.option(
+    "-y",
+    "--yes",
+    "auto_accept",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt (scripting-friendly).",
+)
+@click.option(
+    "--keep-file",
+    "keep_file",
+    is_flag=True,
+    default=False,
+    help="Delete only the catalog row; leave the file on disk untouched.",
+)
+def remove(
+    book_ids: tuple[int, ...],
+    db_path: Path | None,
+    auto_accept: bool,
+    keep_file: bool,
+) -> None:
+    """Remove one or more books from the catalog.
+
+    By default the on-disk file (and any sibling files sharing its stem,
+    e.g. ``.kepub.epub``) is deleted along with the catalog row. Use
+    ``--keep-file`` to leave the file in place — handy when you're about
+    to re-import with corrected metadata.
+
+    Symlinks: if a book's ``output_path`` is a symlink, only the link is
+    removed; the target file is preserved.
+
+    Exit codes:
+      0  All requested IDs handled (removed or declined)
+      1  At least one ID could not be removed
+      2  Usage error (no IDs supplied)
+    """
+    conn = open_library(resolve_db_path(db_path))
+    catalog = LibraryCatalog(conn)
+
+    failures = 0
+    try:
+        for book_id in book_ids:
+            panel = _build_confirmation_panel(catalog, book_id, keep_file=keep_file)
+            if panel is None:
+                console.print(f"[red]error:[/red] book {book_id} not found")
+                failures += 1
+                continue
+
+            console.print(panel)
+
+            if not auto_accept:
+                prompt = (
+                    "Delete catalog entry (keep file on disk)?"
+                    if keep_file
+                    else "Delete this book?"
+                )
+                if not click.confirm(prompt, default=False):
+                    console.print(f"[dim]Skipped {book_id}[/dim]")
+                    continue
+
+            try:
+                result = remove_book(catalog, book_id, keep_file=keep_file)
+            except ValueError as exc:
+                console.print(f"[red]error:[/red] {exc}")
+                failures += 1
+                continue
+            except OSError as exc:
+                console.print(f"[red]error:[/red] {exc}")
+                failures += 1
+                continue
+
+            _render_result(result)
+    finally:
+        conn.close()
+
+    if failures:
+        raise click.exceptions.Exit(1)

--- a/src/bookery/core/remove.py
+++ b/src/bookery/core/remove.py
@@ -1,0 +1,195 @@
+# ABOUTME: Pure removal logic for catalog rows and their on-disk files.
+# ABOUTME: Owns sibling-file discovery, duplicate-cluster detection, and empty-dir cleanup.
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from bookery.db.catalog import LibraryCatalog
+
+
+@dataclass(frozen=True)
+class RemoveResult:
+    """Outcome of a single ``remove_book`` invocation.
+
+    ``file_path`` is the catalog's ``output_path`` (None if the row had no
+    file recorded). ``file_removed`` is True only when we actually unlinked
+    that primary file; missing-on-disk, --keep-file, and duplicate-cluster
+    cases all leave it False and surface a warning instead.
+    """
+
+    book_id: int
+    title: str
+    author: str
+    file_path: Path | None
+    file_removed: bool
+    siblings_removed: tuple[Path, ...]
+    warnings: tuple[str, ...]
+
+
+def _other_rows_pointing_at(catalog: LibraryCatalog, output_path: Path, exclude_id: int) -> int:
+    """Count other catalog rows whose ``output_path`` matches ``output_path``.
+
+    We compare on the stringified path the catalog stored — this is what
+    ``add_book`` writes, so equality here mirrors the duplicate-cluster
+    invariant exactly.
+    """
+    cursor = catalog._conn.execute(
+        "SELECT COUNT(*) FROM books WHERE output_path = ? AND id != ?",
+        (str(output_path), exclude_id),
+    )
+    return int(cursor.fetchone()[0])
+
+
+def _discover_siblings(primary: Path) -> list[Path]:
+    """Find files in the same directory that share the primary's stem.
+
+    Example: for ``book.epub`` this returns ``book.kepub.epub`` (any file
+    whose name starts with ``book.`` other than the primary itself).
+    Symlinks are returned as-is; the caller is responsible for the
+    "unlink only" semantics.
+    """
+    parent = primary.parent
+    if not parent.is_dir():
+        return []
+    # ``Path.stem`` strips the final suffix only — for ``book.epub`` that's
+    # ``book``. Sibling files like ``book.kepub.epub`` start with ``book.``.
+    prefix = primary.stem + "."
+    siblings: list[Path] = []
+    for entry in parent.iterdir():
+        if entry == primary:
+            continue
+        if not entry.is_file() and not entry.is_symlink():
+            continue
+        if entry.name.startswith(prefix):
+            siblings.append(entry)
+    return siblings
+
+
+def _cleanup_empty_parents(library_path: Path, levels: int = 2) -> None:
+    """Remove up to ``levels`` ancestor directories that became empty.
+
+    For ``library_root/Author/Title/book.epub`` this prunes the Title and
+    Author directories when they're empty after deletion. ``library_root``
+    itself is implicitly safe because we stop after ``levels`` jumps.
+    """
+    parent = library_path.parent
+    for _ in range(levels):
+        try:
+            # ``rmdir`` only succeeds on empty dirs — exactly the guard we
+            # want, no need for a manual ``iterdir`` check first.
+            parent.rmdir()
+        except OSError:
+            return
+        parent = parent.parent
+
+
+def remove_book(
+    catalog: LibraryCatalog,
+    book_id: int,
+    *,
+    keep_file: bool,
+) -> RemoveResult:
+    """Delete one cataloged book and (optionally) its file(s) on disk.
+
+    Operation order:
+
+    1. Load the row. Raise ``ValueError`` if the ID is unknown.
+    2. Decide whether the file is safe to delete (skip on --keep-file, on
+       missing output_path, or when it's part of a duplicate cluster).
+    3. Delete the DB row first — FK cascades clean up tags, genres, and
+       provenance. If the SQL fails the file is untouched.
+    4. Unlink the primary file and any siblings sharing its stem; treat
+       already-missing as a soft warning. Prune empty parent directories.
+
+    Symlinks: ``Path.unlink`` deletes the link only, leaving the target
+    intact. The CLI ``--help`` documents this.
+
+    Raises:
+        ValueError: If ``book_id`` is not in the catalog.
+    """
+    record = catalog.get_by_id(book_id)
+    if record is None:
+        raise ValueError(f"Book with id {book_id} not found")
+
+    title = record.metadata.title
+    author = record.metadata.author or "Unknown"
+    file_path = record.output_path
+
+    warnings: list[str] = []
+    skip_disk = keep_file
+
+    # Duplicate-cluster check: if any other row also points at this exact
+    # output_path, we must not unlink the shared file.
+    if not skip_disk and file_path is not None:
+        other_count = _other_rows_pointing_at(catalog, file_path, book_id)
+        if other_count > 0:
+            warnings.append(
+                f"{other_count} other catalog entries point at this file; "
+                f"keeping {file_path} on disk."
+            )
+            skip_disk = True
+
+    # Commit the DB delete before touching the filesystem. If the SQL
+    # raises, the file is still on disk and the user can retry safely.
+    catalog.delete_book(book_id)
+
+    file_removed = False
+    siblings_removed: list[Path] = []
+
+    if file_path is None:
+        return RemoveResult(
+            book_id=book_id,
+            title=title,
+            author=author,
+            file_path=None,
+            file_removed=False,
+            siblings_removed=(),
+            warnings=tuple(warnings),
+        )
+
+    if skip_disk:
+        return RemoveResult(
+            book_id=book_id,
+            title=title,
+            author=author,
+            file_path=file_path,
+            file_removed=False,
+            siblings_removed=(),
+            warnings=tuple(warnings),
+        )
+
+    siblings = _discover_siblings(file_path)
+
+    # Primary file
+    try:
+        file_path.unlink()
+        file_removed = True
+    except FileNotFoundError:
+        warnings.append(f"file already missing: {file_path}")
+    except OSError as exc:
+        warnings.append(f"could not delete {file_path}: {exc}")
+
+    # Siblings
+    for sibling in siblings:
+        try:
+            sibling.unlink()
+            siblings_removed.append(sibling)
+        except FileNotFoundError:
+            warnings.append(f"sibling already missing: {sibling}")
+        except OSError as exc:
+            warnings.append(f"could not delete sibling {sibling}: {exc}")
+
+    # Only attempt parent cleanup if we actually unlinked at least the
+    # primary — otherwise leaving the dir alone is the safer call.
+    if file_removed:
+        _cleanup_empty_parents(file_path, levels=2)
+
+    return RemoveResult(
+        book_id=book_id,
+        title=title,
+        author=author,
+        file_path=file_path,
+        file_removed=file_removed,
+        siblings_removed=tuple(siblings_removed),
+        warnings=tuple(warnings),
+    )

--- a/tests/e2e/test_remove_cli.py
+++ b/tests/e2e/test_remove_cli.py
@@ -1,0 +1,174 @@
+# ABOUTME: End-to-end tests for the `bookery remove` CLI command.
+# ABOUTME: Exercises prompts, -y, --keep-file, missing IDs, and multi-ID through CliRunner.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+def _seed_book(
+    db_path: Path,
+    library_root: Path,
+    *,
+    title: str = "The Name of the Rose",
+    file_hash: str = "h1",
+    relative: str = "Umberto Eco/Rose/book.epub",
+    output_path: Path | None = None,
+) -> tuple[int, Path]:
+    """Insert a book row pointing at a real file under ``library_root``.
+
+    Returns the new book ID and the on-disk path that was created.
+    """
+    if output_path is None:
+        output_path = library_root / relative
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(b"fake epub bytes")
+
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    book_id = catalog.add_book(
+        BookMetadata(
+            title=title,
+            authors=["Umberto Eco"],
+            source_path=Path("/books/source.epub"),
+        ),
+        file_hash=file_hash,
+        output_path=output_path,
+    )
+    conn.close()
+    return book_id, output_path
+
+
+class TestRemoveCliPrompt:
+    def test_prompt_accept_removes_book(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        book_id, output = _seed_book(db_path, library_root)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["remove", str(book_id), "--db", str(db_path)], input="y\n")
+
+        assert result.exit_code == 0, result.output
+        assert "Removed" in result.output
+        assert not output.exists()
+
+    def test_prompt_decline_keeps_book(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        book_id, output = _seed_book(db_path, library_root)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["remove", str(book_id), "--db", str(db_path)], input="n\n")
+
+        assert result.exit_code == 0
+        assert output.exists()
+        conn = open_library(db_path)
+        assert LibraryCatalog(conn).get_by_id(book_id) is not None
+        conn.close()
+
+
+class TestRemoveCliYesFlag:
+    def test_yes_skips_prompt(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        book_id, output = _seed_book(db_path, library_root)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["remove", str(book_id), "-y", "--db", str(db_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "Removed" in result.output
+        assert not output.exists()
+
+    def test_multi_id_with_missing(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        book_a, path_a = _seed_book(
+            db_path,
+            library_root,
+            title="A",
+            file_hash="ha",
+            relative="A/Book/a.epub",
+        )
+        book_b, path_b = _seed_book(
+            db_path,
+            library_root,
+            title="B",
+            file_hash="hb",
+            relative="B/Book/b.epub",
+        )
+
+        missing_id = 9999
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["remove", str(book_a), str(missing_id), str(book_b), "-y", "--db", str(db_path)],
+        )
+
+        # Partial failure → exit code 1, but real books are still removed.
+        assert result.exit_code == 1, result.output
+        assert not path_a.exists()
+        assert not path_b.exists()
+        assert "not found" in result.output
+
+
+class TestRemoveCliKeepFile:
+    def test_keep_file_preserves_disk(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        book_id, output = _seed_book(db_path, library_root)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["remove", str(book_id), "--keep-file", "-y", "--db", str(db_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert output.exists()
+        conn = open_library(db_path)
+        assert LibraryCatalog(conn).get_by_id(book_id) is None
+        conn.close()
+
+
+class TestRemoveCliMissingFile:
+    def test_missing_file_warns_but_succeeds(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        book_id, output = _seed_book(db_path, library_root)
+        output.unlink()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["remove", str(book_id), "-y", "--db", str(db_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "already missing" in result.output
+
+
+class TestRemoveCliUsageErrors:
+    def test_no_ids_is_usage_error(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        # Touch the DB so we don't blow up on connection.
+        open_library(db_path).close()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["remove", "--db", str(db_path)])
+
+        assert result.exit_code == 2
+
+    def test_help_lists_remove(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "remove" in result.output

--- a/tests/unit/test_core_remove.py
+++ b/tests/unit/test_core_remove.py
@@ -1,0 +1,181 @@
+# ABOUTME: Unit tests for the pure remove_book core logic.
+# ABOUTME: Covers cascade, missing file, --keep-file, duplicate clusters, and empty-dir cleanup.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.core.remove import RemoveResult, remove_book
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> LibraryCatalog:
+    """LibraryCatalog backed by a temporary SQLite database."""
+    conn = open_library(tmp_path / "test.db")
+    return LibraryCatalog(conn)
+
+
+def _make_metadata(title: str = "The Name of the Rose") -> BookMetadata:
+    return BookMetadata(
+        title=title,
+        authors=["Umberto Eco"],
+        author_sort="Eco, Umberto",
+        language="eng",
+        publisher="Harcourt",
+        isbn="9780156001311",
+        source_path=Path("/books/source.epub"),
+    )
+
+
+def _write_epub(library_root: Path, relative: str = "Umberto Eco/Rose/book.epub") -> Path:
+    path = library_root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"fake epub bytes")
+    return path
+
+
+class TestRemoveBookHappyPath:
+    def test_removes_db_row_and_file(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path)
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+
+        result = remove_book(catalog, book_id, keep_file=False)
+
+        assert isinstance(result, RemoveResult)
+        assert result.book_id == book_id
+        assert result.title == "The Name of the Rose"
+        assert result.author == "Umberto Eco"
+        assert result.file_path == output
+        assert result.file_removed is True
+        assert result.siblings_removed == ()
+        assert result.warnings == ()
+        assert catalog.get_by_id(book_id) is None
+        assert not output.exists()
+
+    def test_removes_sibling_kepub(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path)
+        sibling = output.with_name("book.kepub.epub")
+        sibling.write_bytes(b"fake kepub")
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+
+        result = remove_book(catalog, book_id, keep_file=False)
+
+        assert result.file_removed is True
+        assert sibling in result.siblings_removed
+        assert not sibling.exists()
+        assert not output.exists()
+
+    def test_empty_parent_dirs_cleaned_up(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path, "Umberto Eco/Rose/book.epub")
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+
+        remove_book(catalog, book_id, keep_file=False)
+
+        # Title directory and author directory should both be gone.
+        assert not output.parent.exists()
+        assert not output.parent.parent.exists()
+        # library_root itself stays.
+        assert tmp_path.exists()
+
+    def test_parent_with_other_files_preserved(
+        self, catalog: LibraryCatalog, tmp_path: Path
+    ) -> None:
+        output = _write_epub(tmp_path, "Umberto Eco/Rose/book.epub")
+        # Drop a stranger file into the title directory.
+        stranger = output.parent / "other.txt"
+        stranger.write_text("keep me")
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+
+        remove_book(catalog, book_id, keep_file=False)
+
+        assert output.parent.exists()
+        assert stranger.exists()
+
+
+class TestRemoveBookCascade:
+    def test_cascade_removes_tags(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path)
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+        catalog.add_tag(book_id, "favorite")
+
+        remove_book(catalog, book_id, keep_file=False)
+
+        # Tag itself stays in the tags table (orphan tags allowed), but the
+        # link row must be gone. Easiest cross-check: re-query for tags on a
+        # ghost book yields an empty list.
+        assert catalog.get_tags_for_book(book_id) == []
+
+    def test_cascade_removes_genres(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path)
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+        catalog.add_genre(book_id, "Mystery & Thriller", is_primary=True)
+
+        remove_book(catalog, book_id, keep_file=False)
+
+        assert catalog.get_genres_for_book(book_id) == []
+
+
+class TestRemoveBookMissingFile:
+    def test_missing_file_emits_warning(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path)
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+        output.unlink()
+
+        result = remove_book(catalog, book_id, keep_file=False)
+
+        assert result.file_removed is False
+        assert any("already missing" in w for w in result.warnings)
+        assert catalog.get_by_id(book_id) is None
+
+    def test_no_output_path_still_removes_db_row(
+        self, catalog: LibraryCatalog, tmp_path: Path
+    ) -> None:
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=None)
+
+        result = remove_book(catalog, book_id, keep_file=False)
+
+        assert result.file_path is None
+        assert result.file_removed is False
+        assert catalog.get_by_id(book_id) is None
+
+
+class TestKeepFile:
+    def test_keep_file_preserves_file(self, catalog: LibraryCatalog, tmp_path: Path) -> None:
+        output = _write_epub(tmp_path)
+        sibling = output.with_name("book.kepub.epub")
+        sibling.write_bytes(b"fake kepub")
+        book_id = catalog.add_book(_make_metadata(), file_hash="h1", output_path=output)
+
+        result = remove_book(catalog, book_id, keep_file=True)
+
+        assert result.file_removed is False
+        assert result.siblings_removed == ()
+        assert output.exists()
+        assert sibling.exists()
+        assert catalog.get_by_id(book_id) is None
+
+
+class TestDuplicateCluster:
+    def test_duplicate_cluster_preserves_file(
+        self, catalog: LibraryCatalog, tmp_path: Path
+    ) -> None:
+        output = _write_epub(tmp_path)
+        first_id = catalog.add_book(_make_metadata("Rose A"), file_hash="h1", output_path=output)
+        second_id = catalog.add_book(_make_metadata("Rose B"), file_hash="h2", output_path=output)
+
+        result = remove_book(catalog, first_id, keep_file=False)
+
+        assert result.file_removed is False
+        assert any("other catalog entries" in w for w in result.warnings)
+        assert output.exists()
+        # The other row is still pointing at it.
+        assert catalog.get_by_id(second_id) is not None
+
+
+class TestUnknownId:
+    def test_unknown_id_raises(self, catalog: LibraryCatalog) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            remove_book(catalog, 9999, keep_file=False)


### PR DESCRIPTION
## Summary
- New `bookery remove <id>...` command that deletes the catalog row and on-disk file together (with `-y` to skip the prompt and `--keep-file` to keep the file).
- Sibling-file discovery for `.kepub.epub` and friends, empty `Author/Title/` directory cleanup, and a duplicate-cluster guard that keeps a file when multiple rows point at it.
- Missing-on-disk downgraded to a soft warning so users can recover from half-broken state; FK cascades on the existing schema handle tag/genre/provenance cleanup.
- Pure `core/remove.py:remove_book(...) -> RemoveResult` keeps the CLI layer thin and the logic unit-testable.

Closes #70

## Test plan
- [x] `uv run pytest tests/unit/test_core_remove.py tests/e2e/test_remove_cli.py` (19 new tests, all pass)
- [x] `uv run pytest` (1296 passed, no regressions)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check` on touched files
- [x] `uv run pyright` on touched files
- [x] `bookery remove --help` smoke test (help text renders, exit codes documented)