### PR TITLE
feat(web): search active metadata providers (#114)

### DIFF
--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -6,26 +6,26 @@ from pathlib import Path
 from rich.console import Console
 
 from bookery.core.importer import ImportResult, MatchFn, MatchResult, ProgressFn
+from bookery.metadata.provider import MetadataProvider
 from bookery.metadata.types import BookMetadata
 
 
-def build_metadata_provider(*, use_cache: bool = True):
-    """Build the configured metadata provider with optional response caching.
+def build_active_providers(*, use_cache: bool = True) -> dict[str, MetadataProvider]:
+    """Build a mapping of active MetadataProviders from configuration.
 
-    Reads ``[matching].providers`` and composes the listed providers in
-    priority order. A single provider is returned directly; multiple
-    providers are wrapped in a :class:`ConsensusProvider` that merges
-    per-field values and prefers cross-provider agreement.
+    Reads ``[matching].providers`` and instantiates each listed provider in
+    priority order. Unknown names log a warning and are skipped. Falls back
+    to a single Open Library provider when nothing else is configured.
 
-    When ``use_cache`` is true, each provider's HTTP client is wrapped
-    in a :class:`CachingHttpClient` backed by a SQLite cache at
-    ``{data_dir}/metadata_cache.db`` with a TTL from
-    ``[matching].cache_ttl_days``. The provider label on each cache row
-    keeps entries isolated per upstream API.
+    Each provider's HTTP client is wrapped in a :class:`CachingHttpClient`
+    when ``use_cache`` is true so repeated lookups (e.g. the web enrich
+    flow) hit the local cache.
+
+    Returns a dict keyed by provider name so callers can preserve order
+    and look providers up by key.
     """
     from bookery.core.config import get_data_dir, get_matching_config
     from bookery.metadata.cache import MetadataCache
-    from bookery.metadata.consensus import ConsensusProvider
     from bookery.metadata.googlebooks import GoogleBooksProvider
     from bookery.metadata.http import BookeryHttpClient, CachingHttpClient
     from bookery.metadata.openlibrary import OpenLibraryProvider
@@ -50,19 +50,36 @@ def build_metadata_provider(*, use_cache: bool = True):
             )
         return client
 
-    providers: list = []
+    providers: dict[str, MetadataProvider] = {}
     for name in provider_names:
         if name == "openlibrary":
-            providers.append(OpenLibraryProvider(http_client=_http_for("openlibrary")))  # type: ignore[arg-type]
+            providers[name] = OpenLibraryProvider(http_client=_http_for("openlibrary"))  # type: ignore[arg-type]
         elif name == "googlebooks":
-            providers.append(GoogleBooksProvider(http_client=_http_for("googlebooks")))  # type: ignore[arg-type]
+            providers[name] = GoogleBooksProvider(http_client=_http_for("googlebooks"))  # type: ignore[arg-type]
         else:
             import logging
+
             logging.getLogger(__name__).warning("Unknown metadata provider %r; skipping", name)
 
     if not providers:
-        providers.append(OpenLibraryProvider(http_client=_http_for("openlibrary")))  # type: ignore[arg-type]
+        providers["openlibrary"] = OpenLibraryProvider(
+            http_client=_http_for("openlibrary")  # type: ignore[arg-type]
+        )
 
+    return providers
+
+
+def build_metadata_provider(*, use_cache: bool = True) -> MetadataProvider:
+    """Build the configured metadata provider with optional response caching.
+
+    Wraps :func:`build_active_providers` so legacy single-provider/consensus
+    behavior is preserved. A single active provider is returned directly;
+    multiple providers are wrapped in a :class:`ConsensusProvider` that
+    merges per-field values and prefers cross-provider agreement.
+    """
+    from bookery.metadata.consensus import ConsensusProvider
+
+    providers = list(build_active_providers(use_cache=use_cache).values())
     if len(providers) == 1:
         return providers[0]
     return ConsensusProvider(providers)
@@ -93,29 +110,25 @@ def build_match_fn(
     )
 
     def match_fn(
-        _extracted: BookMetadata, epub_path: Path,
+        _extracted: BookMetadata,
+        epub_path: Path,
     ) -> MatchResult | None:
         del _extracted  # signature required by MatchFn protocol
         result = match_one(epub_path, provider, review, output_dir)
 
         if not quiet and result.normalization and result.normalization.was_modified:
-            console.print(
-                f"  [dim]Normalized:[/dim] {result.normalization.normalized.title}"
-            )
+            console.print(f"  [dim]Normalized:[/dim] {result.normalization.normalized.title}")
 
         if result.status == "matched" and result.metadata is not None:
             if not quiet:
-                console.print(
-                    f"  [green]Written:[/green] {result.output_path}"
-                )
+                console.print(f"  [green]Written:[/green] {result.output_path}")
             return MatchResult(
-                metadata=result.metadata, output_path=result.output_path,
+                metadata=result.metadata,
+                output_path=result.output_path,
             )
 
         if result.status == "error" and not quiet:
-            console.print(
-                f"  [red]Write failed:[/red] {result.error}"
-            )
+            console.print(f"  [red]Write failed:[/red] {result.error}")
 
         return None
 

--- a/src/bookery/cli/commands/serve_cmd.py
+++ b/src/bookery/cli/commands/serve_cmd.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from bookery.cli._match_helpers import build_active_providers
 from bookery.cli.options import db_option, resolve_db_path
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
@@ -34,8 +35,9 @@ def serve(db_path: Path | None, host: str, port: int) -> None:
 
     conn = open_library(resolved, check_same_thread=False)
     catalog = LibraryCatalog(conn)
+    providers = build_active_providers()
 
-    app = create_app(catalog)
+    app = create_app(catalog, providers=providers)  # type: ignore[arg-type]
     try:
         app.run(host=host, port=port)
     finally:

--- a/src/bookery/core/enrichment.py
+++ b/src/bookery/core/enrichment.py
@@ -1,0 +1,131 @@
+# ABOUTME: Multi-provider enrichment search helpers used by the web UI.
+# ABOUTME: Dispatches a single query to every active MetadataProvider and groups results.
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.provider import MetadataProvider
+
+
+@dataclass(frozen=True)
+class ProviderResult:
+    """Grouped candidates from a single MetadataProvider.
+
+    ``candidates`` is pre-sorted by confidence descending so templates can
+    render directly without further ordering work.
+    """
+
+    name: str
+    candidates: list[MetadataCandidate]
+
+    @property
+    def count(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.candidates
+
+
+# Matches a 10- or 13-character ISBN-like token (digits, optional final X for ISBN-10).
+_ISBN_RE = re.compile(r"^\d{9}[\dXx]$|^\d{13}$")
+
+# Detect anything that looks like a URL — http(s):// or bare domain prefix.
+_URL_RE = re.compile(r"^(?:https?://|www\.)", re.IGNORECASE)
+
+
+def looks_like_isbn(value: str) -> bool:
+    """Return True if ``value`` looks like a normalized ISBN-10 or ISBN-13.
+
+    Whitespace and hyphens are stripped before testing, so user input such as
+    ``978-0-441-17271-9`` still resolves to the ISBN dispatch path.
+    """
+    stripped = re.sub(r"[\s-]", "", value)
+    return bool(_ISBN_RE.match(stripped))
+
+
+def normalize_isbn(value: str) -> str:
+    """Strip whitespace and hyphens from an ISBN-like string."""
+    return re.sub(r"[\s-]", "", value)
+
+
+def looks_like_url(value: str) -> bool:
+    """Return True if ``value`` looks like a URL (http/https or www-prefixed)."""
+    return bool(_URL_RE.match(value.strip()))
+
+
+@dataclass(frozen=True)
+class QueryDispatch:
+    """The parsed shape of an enrich search request.
+
+    Exactly one of the three slots is populated, mirroring the dispatch
+    branches in :func:`multi_provider_search`.
+    """
+
+    isbn: str | None = None
+    url: str | None = None
+    title_author: str | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.isbn or self.url or self.title_author)
+
+
+def dispatch_from_form(isbn_field: str, query_field: str) -> QueryDispatch:
+    """Parse raw form fields into a :class:`QueryDispatch`.
+
+    A non-empty ``isbn_field`` always wins. Otherwise the free-text
+    ``query_field`` is inspected: ISBN-shaped digits route to the ISBN
+    branch (digits/hyphens stripped), anything starting with ``http(s)://``
+    or ``www.`` routes to the URL branch, and the remainder is treated
+    as a title+author search string.
+    """
+    isbn_input = (isbn_field or "").strip()
+    query = (query_field or "").strip()
+
+    if isbn_input:
+        return QueryDispatch(isbn=normalize_isbn(isbn_input))
+    if not query:
+        return QueryDispatch()
+    if looks_like_isbn(query):
+        return QueryDispatch(isbn=normalize_isbn(query))
+    if looks_like_url(query):
+        return QueryDispatch(url=query)
+    return QueryDispatch(title_author=query)
+
+
+def multi_provider_search(
+    providers: Mapping[str, MetadataProvider],
+    *,
+    isbn: str | None = None,
+    url: str | None = None,
+    title_author: str | None = None,
+) -> list[ProviderResult]:
+    """Fan a single query out across every registered provider.
+
+    Exactly one of ``isbn``, ``url``, or ``title_author`` should be provided.
+    For each provider, the matching method is called and results are wrapped
+    in a :class:`ProviderResult` ordered by confidence descending. URL lookups
+    return at most one candidate per provider.
+
+    Provider iteration order matches ``providers`` insertion order so the UI
+    layout is deterministic.
+    """
+    results: list[ProviderResult] = []
+    for _key, provider in providers.items():
+        candidates: list[MetadataCandidate] = []
+        if isbn:
+            candidates = list(provider.search_by_isbn(isbn))
+        elif url:
+            single = provider.lookup_by_url(url)
+            if single is not None:
+                candidates = [single]
+        elif title_author:
+            candidates = list(provider.search_by_title_author(title_author))
+        candidates.sort(key=lambda c: c.confidence, reverse=True)
+        results.append(ProviderResult(name=provider.name, candidates=candidates))
+    return results

--- a/src/bookery/web/__init__.py
+++ b/src/bookery/web/__init__.py
@@ -1,19 +1,30 @@
 # ABOUTME: Flask app factory for the Bookery web UI.
 # ABOUTME: Creates the Flask application with catalog dependency injection.
 
+from collections.abc import Mapping
+
 from flask import Flask
 
 from bookery.db.catalog import LibraryCatalog
+from bookery.metadata.provider import MetadataProvider
 from bookery.web.routes import bp
 
 
-def create_app(catalog: LibraryCatalog) -> Flask:
+def create_app(
+    catalog: LibraryCatalog,
+    providers: Mapping[str, MetadataProvider] | None = None,
+) -> Flask:
     """Create and configure the Flask application.
 
     Args:
         catalog: LibraryCatalog instance for database access.
+        providers: Mapping of provider key → MetadataProvider used for the
+            enrich search fan-out. Order is preserved when iterating. Defaults
+            to an empty mapping, which renders enrich search with no provider
+            groups (route still functions for tests that don't need providers).
     """
     app = Flask(__name__)
     app.config["CATALOG"] = catalog
+    app.config["PROVIDERS"] = dict(providers) if providers else {}
     app.register_blueprint(bp)
     return app

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from flask import Blueprint, abort, current_app, redirect, render_template, request, url_for
 
+from bookery.core.enrichment import dispatch_from_form, multi_provider_search
+
 
 def _file_context(book) -> dict[str, str]:
     """Best-effort file format + size for a BookRecord.
@@ -155,4 +157,68 @@ def update_book(book_id):
 
     return render_template(
         "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
+    )
+
+
+def _prefill_for_book(book) -> tuple[str | None, str | None]:
+    """Compute the search-form pre-fill values for a BookRecord.
+
+    Returns ``(isbn, free_text_query)``. ISBN is preferred when present;
+    otherwise a ``"title author"`` string is composed for the free-text input.
+    Either tuple slot may be ``None``.
+    """
+    isbn = book.metadata.isbn or None
+    if isbn:
+        return isbn, None
+    parts = [book.metadata.title or ""]
+    if book.metadata.authors:
+        parts.append(book.metadata.authors[0])
+    query = " ".join(p for p in parts if p).strip()
+    return None, query or None
+
+
+@bp.route("/books/<int:book_id>/enrich", methods=["GET"])
+def enrich_form(book_id):
+    """Render the multi-provider search form for a book."""
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    prefill_isbn, prefill_query = _prefill_for_book(book)
+    return render_template(
+        "_enrich_search.html",
+        book=book,
+        prefill_isbn=prefill_isbn,
+        prefill_query=prefill_query,
+    )
+
+
+@bp.route("/books/<int:book_id>/enrich/search", methods=["POST"])
+def enrich_search(book_id):
+    """Run multi-provider candidate search and render grouped results."""
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    providers = current_app.config.get("PROVIDERS", {})
+
+    dispatch = dispatch_from_form(
+        request.form.get("isbn", ""),
+        request.form.get("query", ""),
+    )
+
+    results = multi_provider_search(
+        providers,
+        isbn=dispatch.isbn,
+        url=dispatch.url,
+        title_author=dispatch.title_author,
+    )
+    any_results = any(not r.is_empty for r in results)
+
+    return render_template(
+        "_enrich_candidates.html",
+        results=results,
+        any_results=any_results,
     )

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -409,3 +409,88 @@ header h1 a {
         max-width: 100%;
     }
 }
+
+/* --- Enrich search (issue #114) ------------------------------------------ */
+
+.enrich {
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    background: white;
+}
+
+.enrich-form .form-group {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.enrich-form .form-group label {
+    min-width: 8rem;
+    color: var(--color-muted);
+}
+
+.enrich-form .form-group input {
+    flex: 1;
+}
+
+.enrich-form .form-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.5rem;
+}
+
+.htmx-indicator {
+    opacity: 0;
+    transition: opacity 200ms ease-in;
+    color: var(--color-muted);
+    font-size: 0.9rem;
+}
+
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator {
+    opacity: 1;
+}
+
+.enrich-group {
+    margin-top: 1rem;
+}
+
+.enrich-group h4 {
+    font-size: 0.95rem;
+    margin-bottom: 0.25rem;
+}
+
+.enrich-candidates {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.enrich-candidate {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.enrich-candidate-title {
+    font-weight: 500;
+}
+
+.enrich-candidate-meta {
+    color: var(--color-muted);
+    font-size: 0.9rem;
+}
+
+.enrich-empty,
+.enrich-empty-provider {
+    color: var(--color-muted);
+    font-style: italic;
+    padding: 0.5rem 0;
+}

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -1,5 +1,5 @@
 {# ABOUTME: Detail header partial — title, author(s), enriched badge, toolbar. #}
-{# ABOUTME: Toolbar reserves disabled Enrich + Delete slots for follow-up stories. #}
+{# ABOUTME: Toolbar wires Edit + Enrich; Delete is reserved for a follow-up story. #}
 <section class="section section-header" aria-labelledby="detail-header">
     <div class="header-titles">
         <h2 id="detail-header">{{ book.metadata.title }}</h2>
@@ -16,9 +16,9 @@
                 hx-swap="innerHTML">Edit</button>
         <button type="button"
                 class="btn btn-secondary"
-                disabled
-                aria-disabled="true"
-                title="Coming soon">Enrich</button>
+                hx-get="{{ url_for('web.enrich_form', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Enrich</button>
         <button type="button"
                 class="btn btn-destructive"
                 disabled

--- a/src/bookery/web/templates/_enrich_candidate_row.html
+++ b/src/bookery/web/templates/_enrich_candidate_row.html
@@ -1,0 +1,28 @@
+{# ABOUTME: Single candidate row for the enrich search results. #}
+{# ABOUTME: Renders title, authors, ISBN, year, publisher, provider, confidence, inert View button. #}
+<li class="enrich-candidate">
+    <div class="enrich-candidate-body">
+        <p class="enrich-candidate-title">{{ candidate.metadata.title }}</p>
+        <p class="enrich-candidate-meta">
+            {% if candidate.metadata.author %}
+                <span class="enrich-author">{{ candidate.metadata.author }}</span>
+            {% endif %}
+            {% if candidate.metadata.isbn %}
+                · <span class="enrich-isbn">{{ candidate.metadata.isbn }}</span>
+            {% endif %}
+            {% if candidate.metadata.published_date %}
+                · <span class="enrich-year">{{ candidate.metadata.published_date }}</span>
+            {% endif %}
+            {% if candidate.metadata.publisher %}
+                · <span class="enrich-publisher">{{ candidate.metadata.publisher }}</span>
+            {% endif %}
+            · <span class="enrich-provider">{{ candidate.source }}</span>
+            · <span class="enrich-confidence">{{ "%.2f"|format(candidate.confidence) }}</span>
+        </p>
+    </div>
+    <button type="button"
+            class="btn btn-secondary"
+            disabled
+            aria-disabled="true"
+            title="Coming soon">View</button>
+</li>

--- a/src/bookery/web/templates/_enrich_candidates.html
+++ b/src/bookery/web/templates/_enrich_candidates.html
@@ -1,0 +1,20 @@
+{# ABOUTME: Grouped multi-provider candidate results for the enrich search flow. #}
+{# ABOUTME: Renders one group per provider with confidence-ordered rows or empty-state copy. #}
+{% if not any_results %}
+    <p class="enrich-empty">No candidates found. Try a different query.</p>
+{% else %}
+    {% for result in results %}
+    <section class="enrich-group" aria-labelledby="enrich-group-{{ loop.index }}">
+        <h4 id="enrich-group-{{ loop.index }}">{{ result.name }} {% if result.is_empty %}(—){% else %}({{ result.count }}){% endif %}</h4>
+        {% if result.is_empty %}
+            <p class="enrich-empty-provider">No candidates from {{ result.name }}</p>
+        {% else %}
+            <ul class="enrich-candidates">
+                {% for candidate in result.candidates %}
+                    {% include "_enrich_candidate_row.html" %}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </section>
+    {% endfor %}
+{% endif %}

--- a/src/bookery/web/templates/_enrich_search.html
+++ b/src/bookery/web/templates/_enrich_search.html
@@ -1,0 +1,43 @@
+{# ABOUTME: Search form partial for the multi-provider enrich flow. #}
+{# ABOUTME: Pre-fills ISBN when present; otherwise pre-fills "title author" free-text. #}
+<section class="enrich" aria-labelledby="enrich-heading">
+    <h3 id="enrich-heading">Search providers</h3>
+
+    <form class="enrich-form"
+          hx-post="{{ url_for('web.enrich_search', book_id=book.id) }}"
+          hx-target="#enrich-results"
+          hx-swap="innerHTML"
+          hx-indicator="#enrich-indicator">
+        <div class="form-group">
+            <label for="enrich-isbn">ISBN</label>
+            <input type="text"
+                   id="enrich-isbn"
+                   name="isbn"
+                   value="{{ prefill_isbn or '' }}"
+                   placeholder="9780441172719"
+                   autocomplete="off">
+        </div>
+
+        <div class="form-group">
+            <label for="enrich-query">or free text / URL</label>
+            <input type="text"
+                   id="enrich-query"
+                   name="query"
+                   value="{{ prefill_query or '' }}"
+                   placeholder="title author or https://openlibrary.org/..."
+                   autocomplete="off">
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">Go</button>
+            <button type="button"
+                    class="btn btn-secondary"
+                    hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
+                    hx-target="#book-content"
+                    hx-swap="innerHTML">Cancel</button>
+            <span id="enrich-indicator" class="htmx-indicator" aria-live="polite">Searching…</span>
+        </div>
+    </form>
+
+    <div id="enrich-results" aria-live="polite"></div>
+</section>

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,0 +1,188 @@
+# ABOUTME: Unit tests for the multi-provider enrichment helper used by the web UI.
+# ABOUTME: Covers ISBN/URL/title-author dispatch, ordering, empty groups, and detect helpers.
+
+from bookery.core.enrichment import (
+    ProviderResult,
+    dispatch_from_form,
+    looks_like_isbn,
+    looks_like_url,
+    multi_provider_search,
+    normalize_isbn,
+)
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+
+
+class _Provider:
+    """Minimal MetadataProvider double for helper-level tests."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        by_isbn: list[MetadataCandidate] | None = None,
+        by_title_author: list[MetadataCandidate] | None = None,
+        by_url: MetadataCandidate | None = None,
+    ) -> None:
+        self.name = name
+        self._by_isbn = by_isbn or []
+        self._by_title_author = by_title_author or []
+        self._by_url = by_url
+        self.isbn_calls: list[str] = []
+        self.title_author_calls: list[tuple[str, str | None]] = []
+        self.url_calls: list[str] = []
+
+    def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
+        self.isbn_calls.append(isbn)
+        return list(self._by_isbn)
+
+    def search_by_title_author(
+        self, title: str, author: str | None = None
+    ) -> list[MetadataCandidate]:
+        self.title_author_calls.append((title, author))
+        return list(self._by_title_author)
+
+    def lookup_by_url(self, url: str) -> MetadataCandidate | None:
+        self.url_calls.append(url)
+        return self._by_url
+
+
+def _cand(title: str, confidence: float) -> MetadataCandidate:
+    return MetadataCandidate(
+        metadata=BookMetadata(title=title),
+        confidence=confidence,
+        source="fake",
+        source_id="fake:1",
+    )
+
+
+class TestLooksLikeIsbn:
+    def test_isbn13_digits(self):
+        assert looks_like_isbn("9780441172719")
+
+    def test_isbn10_digits(self):
+        assert looks_like_isbn("0441172717")
+
+    def test_isbn10_with_x_checksum(self):
+        assert looks_like_isbn("044117271X")
+
+    def test_isbn_with_hyphens(self):
+        assert looks_like_isbn("978-0-441-17271-9")
+
+    def test_too_short(self):
+        assert not looks_like_isbn("123")
+
+    def test_free_text(self):
+        assert not looks_like_isbn("Dune Frank Herbert")
+
+
+class TestLooksLikeUrl:
+    def test_https(self):
+        assert looks_like_url("https://openlibrary.org/works/OL1234W")
+
+    def test_http(self):
+        assert looks_like_url("http://example.com/path")
+
+    def test_www_prefix(self):
+        assert looks_like_url("www.example.com")
+
+    def test_free_text_is_not_url(self):
+        assert not looks_like_url("Dune Frank Herbert")
+
+
+class TestNormalizeIsbn:
+    def test_strips_hyphens_and_whitespace(self):
+        assert normalize_isbn("978-0-441-17271-9") == "9780441172719"
+        assert normalize_isbn(" 044117271X ") == "044117271X"
+
+
+class TestMultiProviderSearch:
+    def test_isbn_dispatch_hits_every_provider(self):
+        a = _Provider("A", by_isbn=[_cand("a", 0.5)])
+        b = _Provider("B", by_isbn=[_cand("b", 0.7)])
+
+        results = multi_provider_search({"a": a, "b": b}, isbn="9780441172719")
+
+        assert [r.name for r in results] == ["A", "B"]
+        assert a.isbn_calls == ["9780441172719"]
+        assert b.isbn_calls == ["9780441172719"]
+        assert a.title_author_calls == []
+        assert b.title_author_calls == []
+        assert a.url_calls == []
+
+    def test_title_author_dispatch(self):
+        p = _Provider("A")
+        multi_provider_search({"a": p}, title_author="Dune Herbert")
+        assert p.title_author_calls == [("Dune Herbert", None)]
+        assert p.isbn_calls == []
+
+    def test_url_dispatch_returns_single_candidate(self):
+        cand = _cand("via url", 0.8)
+        p = _Provider("A", by_url=cand)
+        results = multi_provider_search({"a": p}, url="https://example.com")
+        assert p.url_calls == ["https://example.com"]
+        assert results[0].candidates == [cand]
+
+    def test_url_dispatch_with_no_match_yields_empty_group(self):
+        p = _Provider("A", by_url=None)
+        results = multi_provider_search({"a": p}, url="https://example.com")
+        assert results[0].is_empty
+        assert results[0].count == 0
+
+    def test_candidates_sorted_by_confidence_desc(self):
+        p = _Provider(
+            "A",
+            by_title_author=[_cand("low", 0.1), _cand("high", 0.9), _cand("mid", 0.5)],
+        )
+        results = multi_provider_search({"a": p}, title_author="x")
+        assert [c.metadata.title for c in results[0].candidates] == ["high", "mid", "low"]
+
+    def test_preserves_provider_order(self):
+        a = _Provider("Alpha")
+        b = _Provider("Beta")
+        c = _Provider("Gamma")
+        results = multi_provider_search({"a": a, "b": b, "c": c}, title_author="x")
+        assert [r.name for r in results] == ["Alpha", "Beta", "Gamma"]
+
+
+class TestDispatchFromForm:
+    def test_isbn_field_wins_over_query(self):
+        d = dispatch_from_form("9780441172719", "ignored free text")
+        assert d.isbn == "9780441172719"
+        assert d.url is None
+        assert d.title_author is None
+
+    def test_isbn_field_normalizes_hyphens(self):
+        d = dispatch_from_form("978-0-441-17271-9", "")
+        assert d.isbn == "9780441172719"
+
+    def test_isbn_like_query_routes_to_isbn(self):
+        d = dispatch_from_form("", "9780441172719")
+        assert d.isbn == "9780441172719"
+
+    def test_url_query_routes_to_url(self):
+        d = dispatch_from_form("", "https://openlibrary.org/works/OL1")
+        assert d.url == "https://openlibrary.org/works/OL1"
+        assert d.isbn is None
+
+    def test_free_text_routes_to_title_author(self):
+        d = dispatch_from_form("", "Dune Frank Herbert")
+        assert d.title_author == "Dune Frank Herbert"
+
+    def test_empty_inputs_produce_empty_dispatch(self):
+        d = dispatch_from_form("", "")
+        assert d.is_empty
+        assert d.isbn is None
+        assert d.url is None
+        assert d.title_author is None
+
+
+class TestProviderResult:
+    def test_count_and_empty_flag(self):
+        empty = ProviderResult(name="X", candidates=[])
+        assert empty.is_empty
+        assert empty.count == 0
+
+        full = ProviderResult(name="X", candidates=[_cand("a", 0.5)])
+        assert not full.is_empty
+        assert full.count == 1

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,14 +1,72 @@
 # ABOUTME: Shared fixtures for tests/web — Flask test client + BookRecord builders.
 # ABOUTME: Mirrors tests/unit/test_web_app.py helpers without coupling to that file.
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 from bookery.db.mapping import BookRecord
+from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.types import BookMetadata
 from bookery.web import create_app
+
+
+@dataclass
+class FakeProvider:
+    """Test double matching the MetadataProvider protocol.
+
+    Each method records the call args and returns the queued list/value so
+    tests can assert which dispatch path the route used.
+    """
+
+    name: str
+    by_isbn: list[MetadataCandidate] = field(default_factory=list)
+    by_title_author: list[MetadataCandidate] = field(default_factory=list)
+    by_url: MetadataCandidate | None = None
+    isbn_calls: list[str] = field(default_factory=list)
+    title_author_calls: list[tuple[str, str | None]] = field(default_factory=list)
+    url_calls: list[str] = field(default_factory=list)
+
+    def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
+        self.isbn_calls.append(isbn)
+        return list(self.by_isbn)
+
+    def search_by_title_author(
+        self, title: str, author: str | None = None
+    ) -> list[MetadataCandidate]:
+        self.title_author_calls.append((title, author))
+        return list(self.by_title_author)
+
+    def lookup_by_url(self, url: str) -> MetadataCandidate | None:
+        self.url_calls.append(url)
+        return self.by_url
+
+
+def make_candidate(
+    title: str = "Sample",
+    authors: list[str] | None = None,
+    isbn: str | None = None,
+    publisher: str | None = None,
+    published_date: str | None = None,
+    confidence: float = 0.5,
+    source: str = "fake",
+    source_id: str = "fake:1",
+) -> MetadataCandidate:
+    """Build a MetadataCandidate for web tests."""
+    return MetadataCandidate(
+        metadata=BookMetadata(
+            title=title,
+            authors=authors or ["Author"],
+            isbn=isbn,
+            publisher=publisher,
+            published_date=published_date,
+        ),
+        confidence=confidence,
+        source=source,
+        source_id=source_id,
+    )
 
 
 def make_book(
@@ -63,9 +121,15 @@ def mock_catalog():
 
 
 @pytest.fixture
-def app(mock_catalog):
-    """Flask app wired to the mock catalog."""
-    app = create_app(mock_catalog)
+def providers():
+    """Default providers fixture: empty dict (tests override as needed)."""
+    return {}
+
+
+@pytest.fixture
+def app(mock_catalog, providers):
+    """Flask app wired to the mock catalog and provider registry."""
+    app = create_app(mock_catalog, providers=providers)
     app.config["TESTING"] = True
     return app
 

--- a/tests/web/test_detail.py
+++ b/tests/web/test_detail.py
@@ -119,13 +119,15 @@ class TestToolbar:
         assert "/books/1/edit" in html
         assert "Edit" in html
 
-    def test_toolbar_has_disabled_enrich_and_delete(self, mock_catalog, client):
+    def test_toolbar_has_enrich_active_and_delete_disabled(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = make_book(1)
         html = client.get("/books/1").data.decode()
         assert "Enrich" in html
         assert "Delete" in html
-        # Both placeholders carry a "Coming soon" affordance.
-        assert html.count('title="Coming soon"') >= 2
+        # Enrich is wired to the search route (#114).
+        assert "/books/1/enrich" in html
+        # Delete remains a "Coming soon" placeholder until the delete story ships.
+        assert 'title="Coming soon"' in html
         # Delete uses destructive styling.
         assert "btn-destructive" in html
 

--- a/tests/web/test_enrich_search.py
+++ b/tests/web/test_enrich_search.py
@@ -1,0 +1,251 @@
+# ABOUTME: Tests for the enrich search routes — search form, multi-provider fan-out.
+# ABOUTME: Covers ISBN/title-author/URL dispatch, ordering, empty-state copy, htmx wiring.
+
+import pytest
+
+from tests.web.conftest import FakeProvider, make_book, make_candidate
+
+
+@pytest.fixture
+def open_library():
+    return FakeProvider(name="Open Library")
+
+
+@pytest.fixture
+def google_books():
+    return FakeProvider(name="Google Books")
+
+
+@pytest.fixture
+def providers(open_library, google_books):
+    return {"openlibrary": open_library, "googlebooks": google_books}
+
+
+class TestEnrichSearchForm:
+    def test_prefills_isbn_when_present(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", authors=["Herbert, Frank"], isbn="9780441172719"
+        )
+
+        html = client.get("/books/1/enrich").data.decode()
+        assert "9780441172719" in html
+        # ISBN goes in the isbn-specific input, not the free-text query.
+        assert 'name="isbn"' in html
+
+    def test_prefills_title_author_when_no_isbn(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", authors=["Herbert, Frank"], isbn=None
+        )
+
+        html = client.get("/books/1/enrich").data.decode()
+        # Free-text query input pre-fills with "title author".
+        assert 'name="query"' in html
+        assert "Dune" in html
+        assert "Herbert, Frank" in html
+
+    def test_form_posts_to_search_endpoint(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        html = client.get("/books/1/enrich").data.decode()
+        assert "/books/1/enrich/search" in html
+
+    def test_form_targets_enrich_panel(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        html = client.get("/books/1/enrich").data.decode()
+        # Results swap into a dedicated region inside the panel.
+        assert 'hx-target="#enrich-results"' in html
+
+    def test_form_has_hx_indicator(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        html = client.get("/books/1/enrich").data.decode()
+        assert "hx-indicator" in html
+
+    def test_cancel_button_swaps_back_to_detail(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        html = client.get("/books/1/enrich").data.decode()
+        # Cancel hits the detail endpoint and swaps #book-content back.
+        assert "/books/1" in html
+        assert "Cancel" in html
+
+    def test_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        response = client.get("/books/999/enrich")
+        assert response.status_code == 404
+
+
+class TestEnrichSearchPost:
+    def test_isbn_field_dispatches_to_search_by_isbn(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_isbn = [make_candidate(title="A", confidence=0.9)]
+
+        client.post("/books/1/enrich/search", data={"isbn": "9780441172719", "query": ""})
+
+        assert open_library.isbn_calls == ["9780441172719"]
+        assert google_books.isbn_calls == ["9780441172719"]
+        assert open_library.title_author_calls == []
+        assert open_library.url_calls == []
+
+    def test_isbn_like_query_dispatches_to_search_by_isbn(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        client.post("/books/1/enrich/search", data={"query": "9780441172719"})
+
+        assert open_library.isbn_calls == ["9780441172719"]
+        assert open_library.title_author_calls == []
+
+    def test_isbn10_query_dispatches_to_search_by_isbn(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        client.post("/books/1/enrich/search", data={"query": "044117271X"})
+
+        assert open_library.isbn_calls == ["044117271X"]
+
+    def test_url_query_dispatches_to_lookup_by_url(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_url = make_candidate(title="From URL", confidence=0.95)
+
+        client.post(
+            "/books/1/enrich/search",
+            data={"query": "https://openlibrary.org/works/OL1234W"},
+        )
+
+        assert open_library.url_calls == ["https://openlibrary.org/works/OL1234W"]
+        assert open_library.isbn_calls == []
+        assert open_library.title_author_calls == []
+
+    def test_free_text_query_dispatches_to_search_by_title_author(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        client.post("/books/1/enrich/search", data={"query": "Dune Frank Herbert"})
+
+        assert open_library.title_author_calls == [("Dune Frank Herbert", None)]
+        assert open_library.isbn_calls == []
+        assert open_library.url_calls == []
+
+    def test_renders_candidates_for_each_provider(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [
+            make_candidate(title="OL One", confidence=0.9, source="Open Library"),
+            make_candidate(title="OL Two", confidence=0.7, source="Open Library"),
+        ]
+        google_books.by_title_author = [
+            make_candidate(title="GB One", confidence=0.8, source="Google Books"),
+        ]
+
+        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+
+        assert "Open Library" in html
+        assert "Open Library (2)" in html
+        assert "Google Books" in html
+        assert "Google Books (1)" in html
+        assert "OL One" in html
+        assert "OL Two" in html
+        assert "GB One" in html
+
+    def test_orders_candidates_by_confidence_descending(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [
+            make_candidate(title="Low", confidence=0.3),
+            make_candidate(title="High", confidence=0.9),
+            make_candidate(title="Mid", confidence=0.6),
+        ]
+        google_books.by_title_author = []
+
+        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+
+        high_pos = html.find("High")
+        mid_pos = html.find("Mid")
+        low_pos = html.find("Low")
+        assert -1 < high_pos < mid_pos < low_pos
+
+    def test_empty_provider_renders_no_candidates_message(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [make_candidate(title="OL", confidence=0.5)]
+        google_books.by_title_author = []  # empty
+
+        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+
+        assert "No candidates from Google Books" in html
+
+    def test_all_providers_empty_renders_global_empty_state(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = []
+        google_books.by_title_author = []
+
+        html = client.post(
+            "/books/1/enrich/search", data={"query": "Nothing matches"}
+        ).data.decode()
+
+        assert "No candidates found" in html
+        # No per-provider empty state when the whole result set is empty.
+        assert "No candidates from" not in html
+
+    def test_candidate_row_renders_required_fields(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [
+            make_candidate(
+                title="Dune",
+                authors=["Herbert, Frank"],
+                isbn="9780441172719",
+                publisher="Ace Books",
+                published_date="1965",
+                confidence=0.91,
+            )
+        ]
+        google_books.by_title_author = []
+
+        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+
+        assert "Dune" in html
+        assert "Herbert, Frank" in html
+        assert "9780441172719" in html
+        assert "Ace Books" in html
+        assert "1965" in html
+        assert "0.91" in html
+
+    def test_view_button_present_but_inert(self, mock_catalog, client, open_library, google_books):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [make_candidate(title="X", confidence=0.5)]
+        google_books.by_title_author = []
+
+        html = client.post("/books/1/enrich/search", data={"query": "X"}).data.decode()
+
+        assert "View" in html
+        # Inert: no hx-get/hx-post wired to the View button yet (Story 4).
+        # We assert disabled attribute is present on the View button.
+        assert "disabled" in html
+
+    def test_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        response = client.post("/books/999/enrich/search", data={"query": "Dune"})
+        assert response.status_code == 404
+
+
+class TestEnrichButtonOnDetail:
+    def test_enrich_button_active_and_targets_enrich_endpoint(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # Enrich button now wired up: hx-get pointing at the enrich endpoint.
+        assert "/books/1/enrich" in html
+        # The toolbar no longer carries Enrich as disabled.
+        # (Delete may still be disabled — narrow the check to Enrich's block.)
+        assert "Enrich" in html


### PR DESCRIPTION
## Summary

- Wires the Enrich button on the book detail page to a real multi-provider candidate search.
- Adds `GET /books/<id>/enrich` (pre-filled search form) and `POST /books/<id>/enrich/search` (provider fan-out, grouped results).
- New `bookery.core.enrichment` helper module: `multi_provider_search`, `dispatch_from_form`, `ProviderResult`, and ISBN/URL detection helpers.
- Active-provider registry consolidated in `cli/_match_helpers.build_active_providers()` and injected into the Flask app from `serve_cmd`, so the web UI uses the same configured providers as `bookery match`.
- Form dispatch: ISBN-shaped query → `search_by_isbn`, URL → `lookup_by_url`, free text → `search_by_title_author`. ISBN field beats free text when both are submitted.
- Per-provider empty state renders `No candidates from <name>`; all-empty renders `No candidates found. Try a different query.` Candidates are sorted by confidence descending. `View` button is rendered but disabled until the apply story (#115).
- htmx wiring: `hx-indicator` on the form, results swap into `#enrich-results`, Cancel swaps `#book-content` back to the detail partial.

## Test plan

- [x] `uv run pytest` — 1321 tests pass (24 new in `tests/unit/test_enrichment.py` + `tests/web/test_enrich_search.py`).
- [x] `uv run ruff check src/ tests/`
- [x] `uv run pyright src/bookery/web/ tests/web/`
- [ ] Manual: `bookery serve`, open a book, click Enrich, exercise ISBN / free-text / URL queries and confirm grouped results.

Closes #114