### PR TITLE
feat(web): delete book from detail page (#113)

### DIFF
--- a/src/bookery/web/__init__.py
+++ b/src/bookery/web/__init__.py
@@ -1,6 +1,7 @@
 # ABOUTME: Flask app factory for the Bookery web UI.
 # ABOUTME: Creates the Flask application with catalog dependency injection.
 
+import os
 from collections.abc import Mapping
 
 from flask import Flask
@@ -24,6 +25,11 @@ def create_app(
             groups (route still functions for tests that don't need providers).
     """
     app = Flask(__name__)
+    # SECRET_KEY is required for Flask sessions (and therefore flashed
+    # messages). We ship a dev default so the local CLI/test workflows
+    # work out of the box, but operators should override via the
+    # BOOKERY_SECRET_KEY environment variable in any shared deployment.
+    app.config["SECRET_KEY"] = os.environ.get("BOOKERY_SECRET_KEY", "bookery-dev-secret")
     app.config["CATALOG"] = catalog
     app.config["PROVIDERS"] = dict(providers) if providers else {}
     app.register_blueprint(bp)

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -4,9 +4,20 @@
 import os
 from pathlib import Path
 
-from flask import Blueprint, abort, current_app, redirect, render_template, request, url_for
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 
 from bookery.core.enrichment import dispatch_from_form, multi_provider_search
+from bookery.core.remove import remove_book
 
 
 def _file_context(book) -> dict[str, str]:
@@ -222,3 +233,73 @@ def enrich_search(book_id):
         results=results,
         any_results=any_results,
     )
+
+
+def _duplicate_cluster_count(catalog, output_path: Path | None, book_id: int) -> int:
+    """Return the number of OTHER catalog rows sharing this output_path.
+
+    Mirrors the duplicate-cluster query in ``core/remove.py`` so the
+    confirm panel can surface the same warning the destructive action
+    will eventually print.
+    """
+    if output_path is None:
+        return 0
+    cursor = catalog._conn.execute(
+        "SELECT COUNT(*) FROM books WHERE output_path = ? AND id != ?",
+        (str(output_path), book_id),
+    )
+    return int(cursor.fetchone()[0])
+
+
+@bp.route("/books/<int:book_id>/delete", methods=["GET"])
+def delete_confirm(book_id):
+    """Render the delete confirmation panel (htmx swap into #book-content)."""
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    tags = catalog.get_tags_for_book(book_id)
+    genres = catalog.get_genres_for_book(book_id)
+    file_info = _file_context(book)
+    duplicate_count = _duplicate_cluster_count(catalog, book.output_path, book_id)
+
+    return render_template(
+        "_delete_confirm.html",
+        book=book,
+        file_info=file_info,
+        tag_count=len(tags),
+        genre_count=len(genres),
+        duplicate_count=duplicate_count,
+    )
+
+
+@bp.route("/books/<int:book_id>/delete", methods=["POST"])
+def delete_book(book_id):
+    """Execute the remove and redirect (via HX-Redirect) to /books."""
+    catalog = current_app.config["CATALOG"]
+    if catalog.get_by_id(book_id) is None:
+        abort(404)
+
+    # Form field "keep_file" carries "1" or "0". Only the explicit "0"
+    # opts in to deleting the file from disk; anything else (missing,
+    # unexpected value, "1") preserves the file. We'd rather leak a file
+    # than destroy one on a malformed request.
+    keep_file = request.form.get("keep_file", "1") != "0"
+
+    try:
+        result = remove_book(catalog, book_id, keep_file=keep_file)
+    except ValueError:
+        # remove_book raises ValueError for unknown IDs; we already
+        # checked above, so this is a race — surface as 404.
+        abort(404)
+
+    flash(f'Removed "{result.title}" by {result.author}', "success")
+    for warning in result.warnings:
+        flash(warning, "warning")
+
+    # htmx clients honor HX-Redirect by navigating the browser; non-htmx
+    # callers get a normal 303 redirect back to the list.
+    response = make_response("", 200)
+    response.headers["HX-Redirect"] = url_for("web.books")
+    return response

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -494,3 +494,56 @@ header h1 a {
     font-style: italic;
     padding: 0.5rem 0;
 }
+
+/* --- Flash messages (issue #113) ----------------------------------------- */
+
+.flashes {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+}
+
+.flash {
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    border: 1px solid transparent;
+}
+
+.flash-success {
+    background: #ecfdf5;
+    color: #065f46;
+    border-color: #a7f3d0;
+}
+
+.flash-warning {
+    background: #fffbeb;
+    color: #92400e;
+    border-color: #fde68a;
+}
+
+/* --- Delete confirm panel (issue #113) ----------------------------------- */
+
+.delete-confirm h2 {
+    color: var(--color-destructive);
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.delete-warning {
+    background: #fffbeb;
+    color: #92400e;
+    border: 1px solid #fde68a;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    margin: 0.75rem 0;
+    font-size: 0.9rem;
+}
+
+.delete-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+}

--- a/src/bookery/web/templates/_delete_confirm.html
+++ b/src/bookery/web/templates/_delete_confirm.html
@@ -1,0 +1,52 @@
+{# ABOUTME: Delete confirmation panel — swapped into #book-content via htmx. #}
+{# ABOUTME: Two destructive actions (keep_file=0/1) plus Cancel back to detail. #}
+<section class="section delete-confirm" aria-labelledby="delete-confirm-heading">
+    <h2 id="delete-confirm-heading">Delete this book?</h2>
+
+    <dl class="metadata-grid">
+        <dt>Title</dt>
+        <dd>{{ book.metadata.title }}</dd>
+        <dt>Author</dt>
+        <dd>{{ book.metadata.author or "Unknown" }}</dd>
+        <dt>Path</dt>
+        <dd>
+            {% if book.output_path %}
+                <code>{{ book.output_path }}</code>
+            {% else %}
+                <em>(no file)</em>
+            {% endif %}
+        </dd>
+        <dt>Size</dt>
+        <dd>{{ file_info.size }}</dd>
+        <dt>Tags / Genres</dt>
+        <dd>{{ tag_count }} tags &middot; {{ genre_count }} genres</dd>
+    </dl>
+
+    {% if duplicate_count > 0 %}
+    <p class="delete-warning" role="status">
+        &#9888; {{ duplicate_count }} other catalog
+        {{ "entry" if duplicate_count == 1 else "entries" }} point at this file;
+        the file will be kept on disk regardless of mode.
+    </p>
+    {% endif %}
+
+    <form action="{{ url_for('web.delete_book', book_id=book.id) }}"
+          method="post"
+          hx-post="{{ url_for('web.delete_book', book_id=book.id) }}"
+          hx-swap="none"
+          class="delete-actions">
+        <button type="submit"
+                class="btn btn-destructive"
+                name="keep_file"
+                value="0">Delete book + file</button>
+        <button type="submit"
+                class="btn btn-destructive"
+                name="keep_file"
+                value="1">Delete row only</button>
+        <button type="button"
+                class="btn btn-secondary"
+                hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Cancel</button>
+    </form>
+</section>

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -1,5 +1,5 @@
 {# ABOUTME: Detail header partial — title, author(s), enriched badge, toolbar. #}
-{# ABOUTME: Toolbar wires Edit + Enrich; Delete is reserved for a follow-up story. #}
+{# ABOUTME: Toolbar wires Edit, Enrich, and Delete (confirm panel via htmx). #}
 <section class="section section-header" aria-labelledby="detail-header">
     <div class="header-titles">
         <h2 id="detail-header">{{ book.metadata.title }}</h2>
@@ -21,8 +21,8 @@
                 hx-swap="innerHTML">Enrich</button>
         <button type="button"
                 class="btn btn-destructive"
-                disabled
-                aria-disabled="true"
-                title="Coming soon">Delete</button>
+                hx-get="{{ url_for('web.delete_confirm', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Delete</button>
     </div>
 </section>

--- a/src/bookery/web/templates/base.html
+++ b/src/bookery/web/templates/base.html
@@ -13,6 +13,15 @@
         <h1><a href="{{ url_for('web.books') }}">Bookery</a></h1>
     </header>
     <main id="main">
+        {% with messages = get_flashed_messages(with_categories=True) %}
+            {% if messages %}
+            <ul class="flashes" role="status" aria-live="polite">
+                {% for category, message in messages %}
+                <li class="flash flash-{{ category }}">{{ message }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        {% endwith %}
         {% block content %}{% endblock %}
     </main>
 </body>

--- a/tests/web/test_delete.py
+++ b/tests/web/test_delete.py
@@ -1,0 +1,233 @@
+# ABOUTME: Tests for the web delete flow (issue #113) — confirm panel + POST handler.
+# ABOUTME: Exercises GET confirm rendering, POST remove modes, flashes, and HX-Redirect.
+
+from pathlib import Path
+from unittest.mock import patch
+
+from bookery.core.remove import RemoveResult
+from tests.web.conftest import make_book
+
+
+def _build_result(
+    *,
+    book_id: int = 1,
+    title: str = "Dune",
+    author: str = "Herbert, Frank",
+    file_path: Path | None = Path("/library/Herbert/Dune/dune.epub"),
+    file_removed: bool = True,
+    siblings_removed: tuple[Path, ...] = (),
+    warnings: tuple[str, ...] = (),
+) -> RemoveResult:
+    return RemoveResult(
+        book_id=book_id,
+        title=title,
+        author=author,
+        file_path=file_path,
+        file_removed=file_removed,
+        siblings_removed=siblings_removed,
+        warnings=warnings,
+    )
+
+
+class TestDeleteConfirmGet:
+    def test_renders_title_author_path(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            title="Dune",
+            authors=["Herbert, Frank"],
+            output_path=Path("/library/Herbert/Dune/dune.epub"),
+        )
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        assert "Delete this book?" in html
+        assert "Dune" in html
+        assert "Herbert, Frank" in html
+        assert "/library/Herbert/Dune/dune.epub" in html
+
+    def test_renders_tag_and_genre_counts(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_tags_for_book.return_value = ["sci-fi", "classic", "novel"]
+        mock_catalog.get_genres_for_book.return_value = [
+            ("Science Fiction", True),
+            ("Adventure", False),
+        ]
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        assert "3 tags" in html
+        assert "2 genres" in html
+
+    def test_renders_size_when_file_present(self, mock_catalog, client, tmp_path):
+        epub = tmp_path / "book.epub"
+        epub.write_bytes(b"x" * 2048)
+        mock_catalog.get_by_id.return_value = make_book(1, output_path=epub)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        # 2048 bytes formats as 2.0 KB.
+        assert "2.0 KB" in html
+
+    def test_renders_duplicate_cluster_notice(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, output_path=Path("/library/shared/dune.epub")
+        )
+        # One other row also points at the same output_path.
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (1,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        assert "1 other catalog" in html or "1 duplicate" in html
+        assert "point" in html.lower()
+
+    def test_no_duplicate_notice_when_zero(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+        assert "duplicate" not in html.lower()
+
+    def test_panel_has_destructive_actions(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        assert "btn-destructive" in html
+        assert "Delete book + file" in html
+        assert "Delete row only" in html
+        assert "Cancel" in html
+
+    def test_cancel_swaps_back_to_detail(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        # Cancel does an hx-get back to the detail view.
+        assert "hx-get" in html
+        assert "/books/1" in html
+
+    def test_post_form_targets_delete_route(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+
+        # Form posts to /books/1/delete with keep_file selector.
+        assert 'action="/books/1/delete"' in html or "hx-post" in html
+        assert 'name="keep_file"' in html
+
+    def test_404_when_book_missing(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        response = client.get("/books/999/delete")
+        assert response.status_code == 404
+
+
+class TestDeleteConfirmFilePathNone:
+    def test_renders_when_no_output_path(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, output_path=None)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete").data.decode()
+        # No crash; renders with (no file) marker or similar.
+        assert "Delete this book?" in html
+
+
+class TestDeletePost:
+    def test_keep_file_removes_row_flashes_success(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Herbert"])
+        with patch("bookery.web.routes.remove_book") as mock_remove:
+            mock_remove.return_value = _build_result(
+                title="Dune",
+                author="Herbert",
+                file_path=Path("/library/dune.epub"),
+                file_removed=False,
+            )
+            response = client.post("/books/1/delete", data={"keep_file": "1"})
+
+        # remove_book invoked with keep_file=True
+        mock_remove.assert_called_once()
+        _, kwargs = mock_remove.call_args
+        assert kwargs["keep_file"] is True
+
+        assert response.headers.get("HX-Redirect") == "/books"
+
+        # Flash carried into session, visible on /books.
+        landing = client.get("/books").data.decode()
+        assert "Removed" in landing
+        assert "Dune" in landing
+
+    def test_delete_book_and_file_removes_everything(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Herbert"])
+        with patch("bookery.web.routes.remove_book") as mock_remove:
+            mock_remove.return_value = _build_result(
+                title="Dune",
+                author="Herbert",
+                file_path=Path("/library/dune.epub"),
+                file_removed=True,
+                siblings_removed=(Path("/library/dune.kepub.epub"),),
+            )
+            response = client.post("/books/1/delete", data={"keep_file": "0"})
+
+        _, kwargs = mock_remove.call_args
+        assert kwargs["keep_file"] is False
+
+        assert response.headers.get("HX-Redirect") == "/books"
+        landing = client.get("/books").data.decode()
+        assert "Removed" in landing
+
+    def test_missing_file_surfaces_warning_flash(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Herbert"])
+        with patch("bookery.web.routes.remove_book") as mock_remove:
+            mock_remove.return_value = _build_result(
+                title="Dune",
+                author="Herbert",
+                file_path=Path("/library/dune.epub"),
+                file_removed=False,
+                warnings=("file already missing: /library/dune.epub",),
+            )
+            response = client.post("/books/1/delete", data={"keep_file": "0"})
+
+        assert response.headers.get("HX-Redirect") == "/books"
+        landing = client.get("/books").data.decode()
+        # Warning category renders with a recognizable class/marker.
+        assert "warning" in landing.lower()
+        assert "already missing" in landing
+
+    def test_duplicate_cluster_keeps_file_with_warning(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Herbert"])
+        warning = "1 other catalog entries point at this file; keeping /library/dune.epub on disk."
+        with patch("bookery.web.routes.remove_book") as mock_remove:
+            mock_remove.return_value = _build_result(
+                title="Dune",
+                author="Herbert",
+                file_path=Path("/library/dune.epub"),
+                file_removed=False,
+                warnings=(warning,),
+            )
+            response = client.post("/books/1/delete", data={"keep_file": "0"})
+
+        assert response.headers.get("HX-Redirect") == "/books"
+        landing = client.get("/books").data.decode()
+        assert "warning" in landing.lower()
+        assert "other catalog entries point at this file" in landing
+
+    def test_post_404_when_book_missing(self, mock_catalog, client):
+        # remove_book raises ValueError when ID is unknown; mock get_by_id None
+        # so the route can short-circuit with 404.
+        mock_catalog.get_by_id.return_value = None
+        response = client.post("/books/999/delete", data={"keep_file": "0"})
+        assert response.status_code == 404
+
+
+class TestDetailToolbarDeleteButtonActive:
+    def test_delete_button_wires_to_confirm_route(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # The Delete button is no longer disabled — it hx-gets the confirm route.
+        assert "/books/1/delete" in html
+        assert 'title="Coming soon"' not in html

--- a/tests/web/test_detail.py
+++ b/tests/web/test_detail.py
@@ -119,15 +119,16 @@ class TestToolbar:
         assert "/books/1/edit" in html
         assert "Edit" in html
 
-    def test_toolbar_has_enrich_active_and_delete_disabled(self, mock_catalog, client):
+    def test_toolbar_has_enrich_and_delete_active(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = make_book(1)
         html = client.get("/books/1").data.decode()
         assert "Enrich" in html
         assert "Delete" in html
         # Enrich is wired to the search route (#114).
         assert "/books/1/enrich" in html
-        # Delete remains a "Coming soon" placeholder until the delete story ships.
-        assert 'title="Coming soon"' in html
+        # Delete is wired to the confirm route (#113).
+        assert "/books/1/delete" in html
+        assert 'title="Coming soon"' not in html
         # Delete uses destructive styling.
         assert "btn-destructive" in html
 


### PR DESCRIPTION
## Summary

- Activates the Delete button on the book detail page with a confirmation panel (htmx swap into `#book-content`) reusing the `core.remove.remove_book()` helper from #70.
- Two destructive actions — **Delete book + file** and **Delete row only** — plus a Cancel that swaps back to the detail view. POST returns `HX-Redirect: /books` with `success`/`warning` flashes rendered by `base.html`.
- Wires `SECRET_KEY` into `create_app()` (env override via `BOOKERY_SECRET_KEY`) so Flask sessions/flashes work, and surfaces the duplicate-cluster notice in the confirm panel so users know when the file will be kept regardless of mode.

## Test plan

- [x] `uv run pytest` — full suite (1356 passed)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/bookery/web/ tests/web/` — clean
- [x] `uv run pyright src/bookery/web/ tests/web/` — clean
- [x] New `tests/web/test_delete.py` covers: GET confirm (title/author/path, size, tag/genre counts, duplicate-cluster notice, destructive buttons, Cancel hx-get); POST `keep_file=1` (row only, success flash); POST `keep_file=0` (row + file, success flash); missing file (warning flash); duplicate cluster (warning explains file kept); `HX-Redirect: /books`; 404 on missing book.
- [x] Updated `tests/web/test_detail.py::TestToolbar` to reflect Delete is now active.

Closes #113