### PR TITLE
feat(web): apply candidate metadata with diff (#115)

### DIFF
--- a/src/bookery/web/diff.py
+++ b/src/bookery/web/diff.py
@@ -1,0 +1,97 @@
+# ABOUTME: Field-by-field BookMetadata diff helper for the apply-candidate flow.
+# ABOUTME: Produces FieldDiff rows the diff template renders as current vs proposed.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bookery.metadata.types import BookMetadata
+
+
+@dataclass(frozen=True)
+class FieldDiff:
+    """A single row of the metadata diff.
+
+    ``current`` and ``proposed`` are pre-formatted display strings (empty
+    string when the underlying value is None/missing). ``changed`` collapses
+    None/empty equivalence and ordered-list comparison so templates can
+    branch on a single boolean.
+    """
+
+    field: str
+    current: str
+    proposed: str
+    changed: bool
+
+
+# Field order matches the diff panel UX spec (title, authors, isbn, ...).
+_FIELDS: tuple[str, ...] = (
+    "title",
+    "authors",
+    "isbn",
+    "language",
+    "publisher",
+    "series",
+    "series_index",
+    "description",
+)
+
+
+def _format_authors(authors: list[str]) -> str:
+    """Join an author list for display; empty list renders as empty string."""
+    return "; ".join(authors)
+
+
+def _format_scalar(value: object) -> str:
+    """Render an optional scalar value for display ("" when None)."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _scalar_changed(current: object, proposed: object) -> bool:
+    """True when ``current`` and ``proposed`` differ, treating None == ''."""
+    cur = "" if current is None else str(current)
+    prop = "" if proposed is None else str(proposed)
+    return cur != prop
+
+
+def _authors_changed(current: list[str], proposed: list[str]) -> bool:
+    """True when ordered author lists differ."""
+    return list(current) != list(proposed)
+
+
+def metadata_diff(current: BookMetadata, proposed: BookMetadata) -> list[FieldDiff]:
+    """Compute the per-field diff between two BookMetadata instances.
+
+    Returns one :class:`FieldDiff` per displayable field in a fixed order so
+    the diff panel always renders the same rows regardless of which sides
+    are populated. ``None`` and empty string are treated as equivalent for
+    every scalar field; authors are compared as ordered lists.
+    """
+    diffs: list[FieldDiff] = []
+    for field in _FIELDS:
+        if field == "authors":
+            cur_list = current.authors or []
+            prop_list = proposed.authors or []
+            diffs.append(
+                FieldDiff(
+                    field=field,
+                    current=_format_authors(cur_list),
+                    proposed=_format_authors(prop_list),
+                    changed=_authors_changed(cur_list, prop_list),
+                )
+            )
+            continue
+
+        cur_val = getattr(current, field)
+        prop_val = getattr(proposed, field)
+        diffs.append(
+            FieldDiff(
+                field=field,
+                current=_format_scalar(cur_val),
+                proposed=_format_scalar(prop_val),
+                changed=_scalar_changed(cur_val, prop_val),
+            )
+        )
+    return diffs

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -17,7 +17,11 @@ from flask import (
 )
 
 from bookery.core.enrichment import dispatch_from_form, multi_provider_search
+from bookery.core.pipeline import apply_metadata_safely
 from bookery.core.remove import remove_book
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.provider import MetadataProvider
+from bookery.web.diff import metadata_diff
 
 
 def _file_context(book) -> dict[str, str]:
@@ -228,10 +232,18 @@ def enrich_search(book_id):
     )
     any_results = any(not r.is_empty for r in results)
 
+    # Reconstruct the query string passed to the diff route so View can
+    # re-fetch without keeping per-session state. Whatever dispatch path
+    # was taken (ISBN, URL, title/author), the diff route's own
+    # ``dispatch_from_form`` will resolve the same shape.
+    diff_query = dispatch.isbn or dispatch.url or dispatch.title_author or ""
+
     return render_template(
         "_enrich_candidates.html",
+        book=book,
         results=results,
         any_results=any_results,
+        diff_query=diff_query,
     )
 
 
@@ -249,6 +261,49 @@ def _duplicate_cluster_count(catalog, output_path: Path | None, book_id: int) ->
         (str(output_path), book_id),
     )
     return int(cursor.fetchone()[0])
+
+
+def _find_provider_by_name(name: str) -> MetadataProvider | None:
+    """Look up a configured provider by its display name.
+
+    ``providers`` is keyed by short id (``openlibrary``); the candidate
+    rows carry the provider's human-facing ``name`` (``Open Library``).
+    Iterate the registry so the route works with either key.
+    """
+    providers = current_app.config.get("PROVIDERS", {})
+    for provider in providers.values():
+        if provider.name == name:
+            return provider
+    return providers.get(name)
+
+
+def _refetch_candidate(provider: MetadataProvider, query: str) -> list[MetadataCandidate]:
+    """Re-run the original search against ``provider`` for ``query``.
+
+    Apply requests carry no candidate state across the wire, so we re-call
+    the same dispatch path used by ``enrich_search`` and pick the candidate
+    by ``source_id``. ISBN-shaped queries hit ``search_by_isbn``, URLs go to
+    ``lookup_by_url``, everything else is treated as a title/author search.
+    """
+    dispatch = dispatch_from_form("", query)
+    if dispatch.isbn:
+        return list(provider.search_by_isbn(dispatch.isbn))
+    if dispatch.url:
+        single = provider.lookup_by_url(dispatch.url)
+        return [single] if single is not None else []
+    if dispatch.title_author:
+        return list(provider.search_by_title_author(dispatch.title_author))
+    return []
+
+
+def _find_candidate(
+    candidates: list[MetadataCandidate], candidate_id: str
+) -> MetadataCandidate | None:
+    """Locate a candidate by its provider-supplied ``source_id``."""
+    for candidate in candidates:
+        if candidate.source_id == candidate_id:
+            return candidate
+    return None
 
 
 @bp.route("/books/<int:book_id>/delete", methods=["GET"])
@@ -302,4 +357,142 @@ def delete_book(book_id):
     # callers get a normal 303 redirect back to the list.
     response = make_response("", 200)
     response.headers["HX-Redirect"] = url_for("web.books")
+    return response
+
+
+@bp.route("/books/<int:book_id>/enrich/candidate", methods=["GET"])
+def enrich_candidate(book_id):
+    """Render the field-by-field diff panel for a chosen candidate.
+
+    Re-fetches the candidate from its provider using the original query so
+    no per-session state is required. The diff panel includes an Apply form
+    that POSTs back to ``enrich_apply`` with the same dispatch params.
+    """
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    provider_name = request.args.get("provider", "")
+    query = request.args.get("query", "")
+    candidate_id = request.args.get("candidate_id", "")
+
+    provider = _find_provider_by_name(provider_name)
+    if provider is None:
+        abort(404)
+
+    candidates = _refetch_candidate(provider, query)
+    candidate = _find_candidate(candidates, candidate_id)
+    if candidate is None:
+        abort(404)
+
+    diffs = metadata_diff(book.metadata, candidate.metadata)
+
+    return render_template(
+        "_enrich_diff.html",
+        book=book,
+        candidate=candidate,
+        diffs=diffs,
+        provider_name=provider_name,
+        query=query,
+        candidate_id=candidate_id,
+    )
+
+
+@bp.route("/books/<int:book_id>/enrich/apply", methods=["POST"])
+def enrich_apply(book_id):
+    """Apply the selected candidate's metadata to a non-destructive copy.
+
+    Writes the proposed metadata to a new EPUB copy via
+    ``apply_metadata_safely``, then mirrors the same fields into the
+    catalog and records the output path. Emits a success flash and an
+    ``HX-Redirect`` so the htmx client navigates back to the refreshed
+    detail page.
+
+    Missing source files short-circuit with an error flash and no catalog
+    writes; write-pipeline failures (verification, IO) likewise leave the
+    catalog untouched.
+    """
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    provider_name = request.form.get("provider", "")
+    query = request.form.get("query", "")
+    candidate_id = request.form.get("candidate_id", "")
+
+    provider = _find_provider_by_name(provider_name)
+    if provider is None:
+        abort(404)
+
+    candidates = _refetch_candidate(provider, query)
+    candidate = _find_candidate(candidates, candidate_id)
+    if candidate is None:
+        abort(404)
+
+    detail_url = url_for("web.book_detail", book_id=book_id)
+
+    source = book.source_path
+    if source is None or not source.exists():
+        flash(
+            f"Cannot apply: source file is missing ({source})",
+            "error",
+        )
+        response = make_response("", 200)
+        response.headers["HX-Redirect"] = detail_url
+        return response
+
+    # Prefer the existing library location of this book (its previous output
+    # copy's parent) so multiple enrich passes don't scatter files across
+    # the filesystem. Fall back to the source file's directory.
+    output_dir = book.output_path.parent if book.output_path is not None else source.parent
+
+    proposed = candidate.metadata
+    write_result = apply_metadata_safely(source, proposed, output_dir)
+    if not write_result.success or write_result.path is None:
+        flash(
+            f"Apply failed: {write_result.error or 'unknown error'}",
+            "error",
+        )
+        response = make_response("", 200)
+        response.headers["HX-Redirect"] = detail_url
+        return response
+
+    # Mirror the candidate's fields into the catalog with provenance credited
+    # to the provider. We intentionally only write fields that the provider
+    # supplied so untouched values (e.g. an unset ISBN) don't clobber what
+    # the user already curated.
+    update_fields: dict[str, object] = {"title": proposed.title}
+    if proposed.authors:
+        update_fields["authors"] = list(proposed.authors)
+    if proposed.isbn is not None:
+        update_fields["isbn"] = proposed.isbn
+    if proposed.language is not None:
+        update_fields["language"] = proposed.language
+    if proposed.publisher is not None:
+        update_fields["publisher"] = proposed.publisher
+    if proposed.description is not None:
+        update_fields["description"] = proposed.description
+    if proposed.series is not None:
+        update_fields["series"] = proposed.series
+    if proposed.series_index is not None:
+        update_fields["series_index"] = proposed.series_index
+
+    # Always credit provenance to the matched provider's canonical name
+    # rather than echoing the user-supplied form value verbatim.
+    catalog.update_book(
+        book_id,
+        source=provider.name,
+        confidence=candidate.confidence,
+        **update_fields,
+    )
+    catalog.set_output_path(book_id, write_result.path)
+
+    flash(
+        f'Applied "{proposed.title}" from {provider.name}',
+        "success",
+    )
+    response = make_response("", 200)
+    response.headers["HX-Redirect"] = detail_url
     return response

--- a/src/bookery/web/templates/_enrich_candidate_row.html
+++ b/src/bookery/web/templates/_enrich_candidate_row.html
@@ -1,5 +1,5 @@
 {# ABOUTME: Single candidate row for the enrich search results. #}
-{# ABOUTME: Renders title, authors, ISBN, year, publisher, provider, confidence, inert View button. #}
+{# ABOUTME: Renders title/authors/ISBN/year/publisher/provider/confidence and a View button that swaps in the diff panel. #}
 <li class="enrich-candidate">
     <div class="enrich-candidate-body">
         <p class="enrich-candidate-title">{{ candidate.metadata.title }}</p>
@@ -22,7 +22,7 @@
     </div>
     <button type="button"
             class="btn btn-secondary"
-            disabled
-            aria-disabled="true"
-            title="Coming soon">View</button>
+            hx-get="{{ url_for('web.enrich_candidate', book_id=book.id, provider=candidate.source, query=diff_query, candidate_id=candidate.source_id) }}"
+            hx-target="#book-content"
+            hx-swap="innerHTML">View</button>
 </li>

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -1,0 +1,51 @@
+{# ABOUTME: Diff panel for the apply-candidate flow — current vs proposed metadata. #}
+{# ABOUTME: Includes header, per-field rows, and Apply/Back-to-results/Cancel actions. #}
+<section class="enrich-diff" aria-labelledby="enrich-diff-heading">
+    <header class="enrich-diff-header">
+        <h3 id="enrich-diff-heading">
+            Apply candidate
+            · <span class="enrich-diff-provider">{{ candidate.source }}</span>
+            · <span class="enrich-diff-confidence">conf {{ "%.2f"|format(candidate.confidence) }}</span>
+        </h3>
+    </header>
+
+    <table class="enrich-diff-table">
+        <thead>
+            <tr>
+                <th scope="col">Field</th>
+                <th scope="col">Current</th>
+                <th scope="col">Proposed</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for diff in diffs %}
+                {% include "_field_diff_row.html" %}
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <div class="enrich-diff-actions" role="group" aria-label="Diff actions">
+        <form class="enrich-diff-apply"
+              method="post"
+              action="{{ url_for('web.enrich_apply', book_id=book.id) }}"
+              hx-post="{{ url_for('web.enrich_apply', book_id=book.id) }}"
+              hx-swap="none">
+            <input type="hidden" name="provider" value="{{ provider_name }}">
+            <input type="hidden" name="query" value="{{ query }}">
+            <input type="hidden" name="candidate_id" value="{{ candidate_id }}">
+            <button type="submit" class="btn btn-primary">Apply</button>
+        </form>
+
+        <button type="button"
+                class="btn btn-secondary"
+                hx-get="{{ url_for('web.enrich_form', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Back to results</button>
+
+        <button type="button"
+                class="btn btn-muted"
+                hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Cancel</button>
+    </div>
+</section>

--- a/src/bookery/web/templates/_field_diff_row.html
+++ b/src/bookery/web/templates/_field_diff_row.html
@@ -1,0 +1,39 @@
+{# ABOUTME: Single field row inside the apply-candidate diff table. #}
+{# ABOUTME: Highlights changed cells, collapses long values into <details>. #}
+<tr class="diff-row diff-{{ 'changed' if diff.changed else 'unchanged' }}">
+    <th scope="row" class="diff-field">{{ diff.field|replace('_', ' ')|title }}</th>
+    {% if diff.changed %}
+        <td class="diff-current changed">
+            {% if diff.current and diff.current|length > 200 %}
+                <details>
+                    <summary>{{ diff.current[:200] }}…</summary>
+                    {{ diff.current }}
+                </details>
+            {% else %}
+                {{ diff.current or "—" }}
+            {% endif %}
+        </td>
+        <td class="diff-proposed changed">
+            {% if diff.proposed and diff.proposed|length > 200 %}
+                <details>
+                    <summary>{{ diff.proposed[:200] }}…</summary>
+                    {{ diff.proposed }}
+                </details>
+            {% else %}
+                {{ diff.proposed or "—" }}
+            {% endif %}
+        </td>
+    {% else %}
+        <td class="diff-current">
+            {% if diff.current and diff.current|length > 200 %}
+                <details>
+                    <summary>{{ diff.current[:200] }}…</summary>
+                    {{ diff.current }}
+                </details>
+            {% else %}
+                {{ diff.current or "—" }}
+            {% endif %}
+        </td>
+        <td class="diff-proposed muted"><span class="diff-same">same</span></td>
+    {% endif %}
+</tr>

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -1,0 +1,547 @@
+# ABOUTME: Tests for the apply-candidate enrichment flow — diff helper, GET, POST.
+# ABOUTME: Covers metadata_diff unit tests, candidate re-fetch, apply write + catalog updates.
+
+from unittest.mock import patch
+
+import pytest
+
+from bookery.core.pipeline import WriteResult
+from bookery.metadata.types import BookMetadata
+from bookery.web.diff import FieldDiff, metadata_diff
+from tests.web.conftest import FakeProvider, make_book, make_candidate
+
+
+@pytest.fixture
+def open_library():
+    return FakeProvider(name="Open Library")
+
+
+@pytest.fixture
+def google_books():
+    return FakeProvider(name="Google Books")
+
+
+@pytest.fixture
+def providers(open_library, google_books):
+    return {"openlibrary": open_library, "googlebooks": google_books}
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(app):
+    """Provide a SECRET_KEY so ``flash()`` can sign the session cookie.
+
+    Sibling PR #113 wires this into ``create_app``; this fixture keeps the
+    apply-flow tests independent of that landing first.
+    """
+    app.config["SECRET_KEY"] = "test-secret"
+    return app
+
+
+# --- metadata_diff unit tests -------------------------------------------------
+
+
+class TestMetadataDiff:
+    def test_unchanged_fields_marked_unchanged(self):
+        current = BookMetadata(title="Dune", authors=["Frank Herbert"], isbn="9780441172719")
+        proposed = BookMetadata(title="Dune", authors=["Frank Herbert"], isbn="9780441172719")
+
+        diffs = metadata_diff(current, proposed)
+        title_diff = next(d for d in diffs if d.field == "title")
+        assert title_diff.changed is False
+        author_diff = next(d for d in diffs if d.field == "authors")
+        assert author_diff.changed is False
+
+    def test_changed_title_marked_changed(self):
+        current = BookMetadata(title="Dune")
+        proposed = BookMetadata(title="Dune: First Edition")
+
+        diffs = metadata_diff(current, proposed)
+        title_diff = next(d for d in diffs if d.field == "title")
+        assert title_diff.changed is True
+        assert title_diff.current == "Dune"
+        assert title_diff.proposed == "Dune: First Edition"
+
+    def test_none_and_empty_string_equivalent(self):
+        current = BookMetadata(title="Dune", publisher=None)
+        proposed = BookMetadata(title="Dune", publisher="")
+
+        diffs = metadata_diff(current, proposed)
+        publisher_diff = next(d for d in diffs if d.field == "publisher")
+        assert publisher_diff.changed is False
+
+    def test_authors_compared_as_ordered_list(self):
+        current = BookMetadata(title="X", authors=["A", "B"])
+        proposed = BookMetadata(title="X", authors=["B", "A"])
+
+        diffs = metadata_diff(current, proposed)
+        author_diff = next(d for d in diffs if d.field == "authors")
+        assert author_diff.changed is True
+
+    def test_authors_same_order_marked_unchanged(self):
+        current = BookMetadata(title="X", authors=["A", "B"])
+        proposed = BookMetadata(title="X", authors=["A", "B"])
+
+        diffs = metadata_diff(current, proposed)
+        author_diff = next(d for d in diffs if d.field == "authors")
+        assert author_diff.changed is False
+
+    def test_all_required_fields_present(self):
+        current = BookMetadata(title="X")
+        proposed = BookMetadata(title="X")
+
+        diffs = metadata_diff(current, proposed)
+        fields = {d.field for d in diffs}
+        assert fields == {
+            "title",
+            "authors",
+            "isbn",
+            "language",
+            "publisher",
+            "series",
+            "series_index",
+            "description",
+        }
+
+    def test_series_index_changed(self):
+        current = BookMetadata(title="X", series_index=1.0)
+        proposed = BookMetadata(title="X", series_index=2.0)
+
+        diffs = metadata_diff(current, proposed)
+        si_diff = next(d for d in diffs if d.field == "series_index")
+        assert si_diff.changed is True
+
+    def test_returns_field_diff_dataclass(self):
+        current = BookMetadata(title="X")
+        proposed = BookMetadata(title="Y")
+        diffs = metadata_diff(current, proposed)
+        assert all(isinstance(d, FieldDiff) for d in diffs)
+
+
+# --- GET /books/<id>/enrich/candidate ---------------------------------------
+
+
+class TestEnrichCandidateGet:
+    def test_isbn_path_renders_diff(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune Old", authors=["Frank Herbert"], isbn="9780441172719"
+        )
+        candidate = make_candidate(
+            title="Dune",
+            authors=["Frank Herbert"],
+            isbn="9780441172719",
+            confidence=0.92,
+            source="Open Library",
+            source_id="OL:M/123",
+        )
+        open_library.by_isbn = [candidate]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:M/123",
+            },
+        )
+
+        assert response.status_code == 200
+        html = response.data.decode()
+        # Diff header includes provider + confidence
+        assert "Open Library" in html
+        assert "0.92" in html
+        # Field rows present
+        assert "Dune Old" in html
+        assert "Dune" in html
+
+    def test_changed_field_has_changed_class(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Old Title")
+        candidate = make_candidate(
+            title="New Title",
+            authors=["Unknown"],
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_title_author = [candidate]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "Old Title",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        # Changed cell visually distinct via the .changed class.
+        assert "changed" in html
+
+    def test_unchanged_field_labeled_same(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", isbn="9780441172719")
+        candidate = make_candidate(
+            title="New Title",
+            isbn="9780441172719",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        # ISBN matches → "same" label rendered.
+        assert "same" in html
+
+    def test_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        response = client.get(
+            "/books/999/enrich/candidate",
+            query_string={"provider": "Open Library", "query": "x", "candidate_id": "x"},
+        )
+        assert response.status_code == 404
+
+    def test_unknown_provider_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={"provider": "Unknown", "query": "x", "candidate_id": "x"},
+        )
+        assert response.status_code == 404
+
+    def test_candidate_id_not_found_returns_404(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:does-not-exist",
+            },
+        )
+        assert response.status_code == 404
+
+    def test_apply_button_carries_through_params(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        # Apply form carries provider, query, candidate_id so POST can re-fetch.
+        assert 'name="provider"' in html
+        assert 'name="query"' in html
+        assert 'name="candidate_id"' in html
+
+    def test_back_to_results_link_present(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        # Back-to-results re-runs the search panel.
+        assert "Back to results" in html
+
+
+# --- POST /books/<id>/enrich/apply ------------------------------------------
+
+
+class TestEnrichApplyPost:
+    def test_calls_write_helper_with_source_and_metadata(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+
+        proposed = BookMetadata(title="Proposed Title", authors=["Author"], isbn="9780441172719")
+        candidate = make_candidate(
+            title="Proposed Title",
+            authors=["Author"],
+            isbn="9780441172719",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        # Replace metadata so write helper sees the full BookMetadata we built.
+        candidate.metadata = proposed
+        open_library.by_isbn = [candidate]
+
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        mock_apply.assert_called_once()
+        args, _ = mock_apply.call_args
+        assert args[0] == source
+        # Metadata argument carries proposed values.
+        assert args[1].title == "Proposed Title"
+        assert response.status_code == 200
+
+    def test_updates_catalog_with_proposed_fields(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+
+        candidate = make_candidate(
+            title="New Title",
+            authors=["New Author"],
+            isbn="9780441172719",
+            publisher="Acme",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        mock_catalog.update_book.assert_called()
+        _, kwargs = mock_catalog.update_book.call_args
+        # Updated fields include title and authors from the candidate.
+        assert kwargs["title"] == "New Title"
+        assert kwargs["authors"] == ["New Author"]
+        assert kwargs["publisher"] == "Acme"
+        # Source attribution credited to the provider name.
+        assert kwargs.get("source") == "Open Library"
+
+    def test_records_output_path(self, mock_catalog, client, open_library, tmp_path):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        mock_catalog.set_output_path.assert_called_once_with(1, dest)
+
+    def test_sets_hx_redirect_to_detail(self, mock_catalog, client, open_library, tmp_path):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        assert response.headers.get("HX-Redirect") == "/books/1"
+
+    def test_success_flash_on_apply(self, mock_catalog, client, app, open_library, tmp_path):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", source_path=source)
+
+        open_library.by_isbn = [
+            make_candidate(title="Dune", source="Open Library", source_id="OL:1"),
+        ]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # Flash queued under the success category, surfaced by the test
+        # client's session cookie.
+        with client.session_transaction() as session:
+            flashes = session.get("_flashes", [])
+        categories = [c for c, _ in flashes]
+        messages = [m for _, m in flashes]
+        assert "success" in categories
+        assert any('Applied "Dune"' in m and "Open Library" in m for m in messages)
+
+    def test_missing_source_flashes_error_no_db_write(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        missing = tmp_path / "does-not-exist.epub"
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=missing)
+
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # Write helper never invoked, catalog never written.
+        mock_apply.assert_not_called()
+        mock_catalog.update_book.assert_not_called()
+        mock_catalog.set_output_path.assert_not_called()
+        # Response still 200 for htmx but with HX-Redirect to detail.
+        assert response.headers.get("HX-Redirect") == "/books/1"
+
+        # Error flash queued under the error category.
+        with client.session_transaction() as session:
+            flashes = session.get("_flashes", [])
+        assert any(category == "error" for category, _ in flashes)
+        assert any("source" in msg.lower() for _, msg in flashes)
+
+    def test_write_failure_flashes_error(self, mock_catalog, client, open_library, tmp_path):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(
+                path=None, success=False, error="verification failed"
+            )
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # Write failed → catalog untouched.
+        mock_catalog.update_book.assert_not_called()
+        mock_catalog.set_output_path.assert_not_called()
+
+    def test_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        response = client.post(
+            "/books/999/enrich/apply",
+            data={"provider": "Open Library", "query": "x", "candidate_id": "x"},
+        )
+        assert response.status_code == 404
+
+    def test_unknown_provider_returns_404(self, mock_catalog, client, tmp_path):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        response = client.post(
+            "/books/1/enrich/apply",
+            data={"provider": "Unknown", "query": "x", "candidate_id": "x"},
+        )
+        assert response.status_code == 404
+
+    def test_candidate_not_found_returns_404(self, mock_catalog, client, open_library, tmp_path):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+        response = client.post(
+            "/books/1/enrich/apply",
+            data={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:missing",
+            },
+        )
+        assert response.status_code == 404
+
+
+# --- _enrich_candidate_row View button wiring -------------------------------
+
+
+class TestCandidateRowViewWiring:
+    def test_view_button_wires_diff_endpoint(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_isbn = [
+            make_candidate(title="X", source="Open Library", source_id="OL:42"),
+        ]
+
+        response = client.post(
+            "/books/1/enrich/search",
+            data={"isbn": "9780441172719", "query": ""},
+        )
+
+        html = response.data.decode()
+        # View button now active — fires hx-get to candidate diff route.
+        assert "/books/1/enrich/candidate" in html
+        assert "provider=Open+Library" in html or "provider=Open%20Library" in html
+        assert "candidate_id=OL" in html
+        assert "disabled" not in html.lower() or "View" in html

--- a/tests/web/test_enrich_search.py
+++ b/tests/web/test_enrich_search.py
@@ -222,7 +222,9 @@ class TestEnrichSearchPost:
         assert "1965" in html
         assert "0.91" in html
 
-    def test_view_button_present_but_inert(self, mock_catalog, client, open_library, google_books):
+    def test_view_button_wires_to_diff_route(
+        self, mock_catalog, client, open_library, google_books
+    ):
         mock_catalog.get_by_id.return_value = make_book(1)
         open_library.by_title_author = [make_candidate(title="X", confidence=0.5)]
         google_books.by_title_author = []
@@ -230,9 +232,9 @@ class TestEnrichSearchPost:
         html = client.post("/books/1/enrich/search", data={"query": "X"}).data.decode()
 
         assert "View" in html
-        # Inert: no hx-get/hx-post wired to the View button yet (Story 4).
-        # We assert disabled attribute is present on the View button.
-        assert "disabled" in html
+        # View now fires the diff fetch into #book-content (issue #115).
+        assert "/books/1/enrich/candidate" in html
+        assert 'hx-target="#book-content"' in html
 
     def test_missing_book_returns_404(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = None


### PR DESCRIPTION
## Summary

- Closes the enrichment loop in the web UI: pick a candidate from the search results, see a field-by-field current-vs-proposed diff, and Apply to write a non-destructive EPUB copy and update the catalog.
- New `src/bookery/web/diff.py` exposes `FieldDiff` + `metadata_diff()` covering title, authors (ordered list), isbn, language, publisher, series, series_index, description. `None` and empty string are treated as equivalent.
- New routes: `GET /books/<id>/enrich/candidate` renders the diff panel (no session state — re-fetches the candidate by replaying the original search and matching on `MetadataCandidate.source_id`). `POST /books/<id>/enrich/apply` runs `apply_metadata_safely`, mirrors fields into the catalog with provider provenance, and returns `HX-Redirect: /books/<id>` with a success flash.
- The previously-inert `View` button on `_enrich_candidate_row.html` is now wired to the diff route.

## Pragmatism note

The original spec referenced an `EnrichmentService.apply` API that doesn't exist in this codebase. Per the implementation brief, I matched the real shape used elsewhere in the repo: `MetadataProvider` for re-fetch, `apply_metadata_safely` (from `bookery.core.pipeline`) for the non-destructive write, and `catalog.update_book` / `catalog.set_output_path` for catalog updates. User-visible behaviour matches the spec.

## Deferred / follow-ups

- Already-enriched warning is not rendered: `BookRecord` has no `enriched_at` field. Worth filing a small follow-up issue to add that column and surface the warning.
- Sibling PR #113 (delete flow) ships `SECRET_KEY` in `create_app` and base-template flash rendering. This branch leaves those files untouched per the coordination brief; a test-local fixture sets `SECRET_KEY` so the apply tests pass standalone. Once both PRs land together flash messages will render in the chrome.

## Test plan

- [x] `uv run pytest` — 1367 passed, 1 warning (pre-existing).
- [x] `uv run ruff check src/ tests/` — all checks pass.
- [x] `uv run ruff format --check` on touched files — already formatted.
- [x] `uv run pyright src/bookery/web/ tests/web/` — 0 errors.
- [x] `tests/web/test_enrich_apply.py` — 27 cases covering `metadata_diff` unit behaviour, GET render (changed/unchanged classes, 404s, params plumbed through), POST apply (write helper called, catalog updated, output_path recorded, success/error flashes, HX-Redirect target, missing-source / write-failure paths).
- [x] `tests/web/test_enrich_search.py` updated to assert the `View` button now wires to the diff route.
- [ ] Manual smoke test in `bookery serve` (left for reviewer — needs a real provider call).