### PR TITLE
fix(web): use real anchors for book list rows (#124)

### DIFF
--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -107,12 +107,18 @@ header h1 a {
     color: var(--color-muted);
 }
 
-.book-table tr[onclick] {
-    cursor: pointer;
+.book-table tbody tr.book-row:hover {
+    background: var(--color-hover);
 }
 
-.book-table tr[onclick]:hover {
-    background: var(--color-hover);
+.book-row-title a {
+    color: var(--color-link);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.book-row-title a:hover {
+    text-decoration: underline;
 }
 
 .empty-state {

--- a/src/bookery/web/templates/_table.html
+++ b/src/bookery/web/templates/_table.html
@@ -1,7 +1,9 @@
 {% if books %}
     {% for book in books %}
-    <tr onclick="window.location='{{ url_for('web.book_detail', book_id=book.id) }}'">
-        <td>{{ book.metadata.title }}</td>
+    <tr class="book-row">
+        <td class="book-row-title">
+            <a href="{{ url_for('web.book_detail', book_id=book.id) }}">{{ book.metadata.title }}</a>
+        </td>
         <td>{{ book.metadata.author }}</td>
         <td>{{ book.metadata.isbn or '' }}</td>
         <td>{{ book.metadata.language or '' }}</td>

--- a/tests/web/test_accessibility.py
+++ b/tests/web/test_accessibility.py
@@ -46,3 +46,32 @@ class TestBackLink:
         mock_catalog.get_by_id.return_value = make_book(1)
         html = client.get("/books/1").data.decode()
         assert "Back to library" in html
+
+
+class TestBookListRowAnchors:
+    """Issue #124 — book list rows must use real anchors, not onclick JS."""
+
+    def test_row_has_real_anchor_to_detail(self, mock_catalog, client):
+        mock_catalog.list_all_by_author.return_value = [
+            make_book(book_id=42, title="The Test Book", authors=["Jane Author"])
+        ]
+        html = client.get("/books").data.decode()
+        assert 'href="/books/42"' in html
+
+    def test_row_has_no_onclick_attribute(self, mock_catalog, client):
+        mock_catalog.list_all_by_author.return_value = [
+            make_book(book_id=42, title="The Test Book", authors=["Jane Author"])
+        ]
+        html = client.get("/books").data.decode()
+        assert "onclick" not in html.lower()
+
+    def test_anchor_wraps_title_text(self, mock_catalog, client):
+        mock_catalog.list_all_by_author.return_value = [
+            make_book(book_id=42, title="The Test Book", authors=["Jane Author"])
+        ]
+        html = client.get("/books").data.decode()
+        # Anchor must contain the title text so keyboard users land on a
+        # focusable element whose accessible name is the book title.
+        assert re.search(
+            r'<a[^>]+href="/books/42"[^>]*>\s*The Test Book\s*</a>', html
+        )


### PR DESCRIPTION
## Summary

Fixes #124. The book list (`/books`) previously used `<tr onclick="...">` for row navigation, which broke keyboard access, screen reader semantics, middle-click new-tab, and Cmd/Ctrl-click new-tab.

- Title cell now contains a real `<a href="/books/{id}">` wrapping the book title
- `onclick` attribute removed from rows entirely
- CSS updated: `.book-row:hover` keeps the row hover affordance; title link is styled as a link with underline on hover
- New tests in `tests/web/test_accessibility.py::TestBookListRowAnchors` assert the anchor is present, href is correct, and no `onclick` is emitted

Chose the simplest approach that meets the acceptance bar: anchor lives in the title cell only. Most users click the title anyway, and this avoids brittle CSS pseudo-element tricks while delivering full keyboard, screen reader, middle-click, and modifier-click support.

## Test plan

- [x] `uv run pytest` — 1386 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Failing test written first (TDD)
- [ ] Manual: Tab through `/books`, Enter navigates to detail
- [ ] Manual: Middle-click on a title opens detail in a new tab
- [ ] Manual: Cmd-click on a title opens detail in a new tab
- [ ] Manual: Right-click on title shows link context menu
- [ ] Manual: Screen reader announces each title as a link

Closes #124