### PR TITLE
fix(web): never overwrite non-empty fields with empty proposed values on apply (#125)

### DIFF
--- a/src/bookery/web/diff.py
+++ b/src/bookery/web/diff.py
@@ -15,13 +15,17 @@ class FieldDiff:
     ``current`` and ``proposed`` are pre-formatted display strings (empty
     string when the underlying value is None/missing). ``changed`` collapses
     None/empty equivalence and ordered-list comparison so templates can
-    branch on a single boolean.
+    branch on a single boolean. ``skip_clear`` flags rows where the proposed
+    value is empty but the current value is set — the apply handler must
+    not overwrite a curated value with nothing, and the diff UI mutes the
+    row so the user can see why no write will happen.
     """
 
     field: str
     current: str
     proposed: str
     changed: bool
+    skip_clear: bool = False
 
 
 # Field order matches the diff panel UX spec (title, authors, isbn, ...).
@@ -67,31 +71,41 @@ def metadata_diff(current: BookMetadata, proposed: BookMetadata) -> list[FieldDi
     Returns one :class:`FieldDiff` per displayable field in a fixed order so
     the diff panel always renders the same rows regardless of which sides
     are populated. ``None`` and empty string are treated as equivalent for
-    every scalar field; authors are compared as ordered lists.
+    every scalar field; authors are compared as ordered lists. Rows where
+    the proposed value is empty and the current value is non-empty are
+    flagged ``skip_clear`` so the apply pipeline can drop them.
     """
     diffs: list[FieldDiff] = []
     for field in _FIELDS:
         if field == "authors":
             cur_list = current.authors or []
             prop_list = proposed.authors or []
+            changed = _authors_changed(cur_list, prop_list)
+            skip_clear = changed and not prop_list and bool(cur_list)
             diffs.append(
                 FieldDiff(
                     field=field,
                     current=_format_authors(cur_list),
                     proposed=_format_authors(prop_list),
-                    changed=_authors_changed(cur_list, prop_list),
+                    changed=changed,
+                    skip_clear=skip_clear,
                 )
             )
             continue
 
         cur_val = getattr(current, field)
         prop_val = getattr(proposed, field)
+        changed = _scalar_changed(cur_val, prop_val)
+        cur_display = _format_scalar(cur_val)
+        prop_display = _format_scalar(prop_val)
+        skip_clear = changed and not prop_display and bool(cur_display)
         diffs.append(
             FieldDiff(
                 field=field,
-                current=_format_scalar(cur_val),
-                proposed=_format_scalar(prop_val),
-                changed=_scalar_changed(cur_val, prop_val),
+                current=cur_display,
+                proposed=prop_display,
+                changed=changed,
+                skip_clear=skip_clear,
             )
         )
     return diffs

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -306,6 +306,36 @@ def _find_candidate(
     return None
 
 
+def _is_empty_scalar(value: object) -> bool:
+    """True when a scalar metadata value is None or an empty/whitespace string."""
+    if value is None:
+        return True
+    return isinstance(value, str) and value.strip() == ""
+
+
+def _should_write_scalar(current: object, proposed: object) -> bool:
+    """Decide whether to mirror ``proposed`` into the catalog row.
+
+    Skip when the values are equivalent (no-op) or when proposed is empty
+    while current is not — the apply pipeline must never silently wipe a
+    curated value because the provider happened to lack one (issue #125).
+    """
+    if _is_empty_scalar(proposed) and not _is_empty_scalar(current):
+        return False
+    cur = "" if current is None else str(current)
+    prop = "" if proposed is None else str(proposed)
+    return cur != prop
+
+
+def _should_write_authors(current: list[str], proposed: list[str]) -> bool:
+    """Authors variant of :func:`_should_write_scalar` for the list field."""
+    cur = current or []
+    prop = proposed or []
+    if not prop and cur:
+        return False
+    return list(cur) != list(prop)
+
+
 @bp.route("/books/<int:book_id>/delete", methods=["GET"])
 def delete_confirm(book_id):
     """Render the delete confirmation panel (htmx swap into #book-content)."""
@@ -462,21 +492,26 @@ def enrich_apply(book_id):
     # Mirror the candidate's fields into the catalog with provenance credited
     # to the provider. We intentionally only write fields that the provider
     # supplied so untouched values (e.g. an unset ISBN) don't clobber what
-    # the user already curated.
-    update_fields: dict[str, object] = {"title": proposed.title}
-    if proposed.authors:
+    # the user already curated. Defense in depth for issue #125: never
+    # overwrite a non-empty current value with an empty proposed value —
+    # even if a form post somehow forces the clearing value through.
+    current = book.metadata
+    update_fields: dict[str, object] = {}
+    if _should_write_scalar(current.title, proposed.title):
+        update_fields["title"] = proposed.title
+    if _should_write_authors(current.authors, proposed.authors):
         update_fields["authors"] = list(proposed.authors)
-    if proposed.isbn is not None:
+    if _should_write_scalar(current.isbn, proposed.isbn):
         update_fields["isbn"] = proposed.isbn
-    if proposed.language is not None:
+    if _should_write_scalar(current.language, proposed.language):
         update_fields["language"] = proposed.language
-    if proposed.publisher is not None:
+    if _should_write_scalar(current.publisher, proposed.publisher):
         update_fields["publisher"] = proposed.publisher
-    if proposed.description is not None:
+    if _should_write_scalar(current.description, proposed.description):
         update_fields["description"] = proposed.description
-    if proposed.series is not None:
+    if _should_write_scalar(current.series, proposed.series):
         update_fields["series"] = proposed.series
-    if proposed.series_index is not None:
+    if _should_write_scalar(current.series_index, proposed.series_index):
         update_fields["series_index"] = proposed.series_index
 
     # Always credit provenance to the matched provider's canonical name

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -547,3 +547,23 @@ header h1 a {
     flex-wrap: wrap;
     margin-top: 1rem;
 }
+
+/* --- Apply-candidate diff: skip-clear rows (issue #125) ----------------- */
+
+.diff-row.diff-clear {
+    color: var(--color-muted);
+    background: #fafafa;
+    font-style: italic;
+}
+
+.diff-row.diff-clear .diff-skip-note {
+    color: var(--color-muted);
+    font-size: 0.85rem;
+}
+
+.enrich-diff-skip-summary {
+    margin-left: 0.5rem;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    font-style: italic;
+}

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -24,6 +24,10 @@
         </tbody>
     </table>
 
+    {# Apply only writes fields that actually change AND aren't a skipped clear. #}
+    {% set write_count = diffs|selectattr('changed')|rejectattr('skip_clear')|list|length %}
+    {% set skip_clear_count = diffs|selectattr('skip_clear')|list|length %}
+
     <div class="enrich-diff-actions" role="group" aria-label="Diff actions">
         <form class="enrich-diff-apply"
               method="post"
@@ -33,7 +37,14 @@
             <input type="hidden" name="provider" value="{{ provider_name }}">
             <input type="hidden" name="query" value="{{ query }}">
             <input type="hidden" name="candidate_id" value="{{ candidate_id }}">
-            <button type="submit" class="btn btn-primary">Apply</button>
+            <button type="submit" class="btn btn-primary">
+                Apply{% if write_count %} ({{ write_count }} change{{ '' if write_count == 1 else 's' }}){% endif %}
+            </button>
+            {% if skip_clear_count %}
+                <span class="enrich-diff-skip-summary">
+                    {{ skip_clear_count }} field{{ '' if skip_clear_count == 1 else 's' }} kept — provider had no value
+                </span>
+            {% endif %}
         </form>
 
         <button type="button"

--- a/src/bookery/web/templates/_field_diff_row.html
+++ b/src/bookery/web/templates/_field_diff_row.html
@@ -1,8 +1,24 @@
 {# ABOUTME: Single field row inside the apply-candidate diff table. #}
 {# ABOUTME: Highlights changed cells, collapses long values into <details>. #}
-<tr class="diff-row diff-{{ 'changed' if diff.changed else 'unchanged' }}">
+{% set row_class = 'diff-clear' if diff.skip_clear else ('diff-changed' if diff.changed else 'diff-unchanged') %}
+<tr class="diff-row {{ row_class }}">
     <th scope="row" class="diff-field">{{ diff.field|replace('_', ' ')|title }}</th>
-    {% if diff.changed %}
+    {% if diff.skip_clear %}
+        {# Proposed is empty while current is set — skipped to protect curated data (issue #125). #}
+        <td class="diff-current">
+            {% if diff.current and diff.current|length > 200 %}
+                <details>
+                    <summary>{{ diff.current[:200] }}…</summary>
+                    {{ diff.current }}
+                </details>
+            {% else %}
+                {{ diff.current or "—" }}
+            {% endif %}
+        </td>
+        <td class="diff-proposed muted">
+            <span class="diff-skip-note">— · current kept — provider had no value</span>
+        </td>
+    {% elif diff.changed %}
         <td class="diff-current changed">
             {% if diff.current and diff.current|length > 200 %}
                 <details>

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from bookery.core.pipeline import WriteResult
+from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.types import BookMetadata
 from bookery.web.diff import FieldDiff, metadata_diff
 from tests.web.conftest import FakeProvider, make_book, make_candidate
@@ -545,3 +546,267 @@ class TestCandidateRowViewWiring:
         assert "provider=Open+Library" in html or "provider=Open%20Library" in html
         assert "candidate_id=OL" in html
         assert "disabled" not in html.lower() or "View" in html
+
+
+# --- Skip-clear guard (issue #125) ------------------------------------------
+
+
+class TestMetadataDiffSkipClear:
+    """Diff helper flags rows where proposed is empty but current is set.
+
+    These rows must surface as ``skip_clear`` so the apply handler can drop
+    them and the diff UI can render the muted "current kept" treatment.
+    """
+
+    def test_empty_proposed_with_current_marked_skip_clear(self):
+        current = BookMetadata(title="Dune", authors=["Stephen King"])
+        proposed = BookMetadata(title="Dune", authors=[])
+
+        diffs = metadata_diff(current, proposed)
+        authors_diff = next(d for d in diffs if d.field == "authors")
+        assert authors_diff.skip_clear is True
+        assert authors_diff.changed is True
+
+    def test_empty_scalar_proposed_with_current_marked_skip_clear(self):
+        current = BookMetadata(title="Dune", publisher="Ace Books")
+        proposed = BookMetadata(title="Dune", publisher="")
+
+        diffs = metadata_diff(current, proposed)
+        publisher_diff = next(d for d in diffs if d.field == "publisher")
+        assert publisher_diff.skip_clear is True
+
+    def test_none_scalar_proposed_with_current_marked_skip_clear(self):
+        current = BookMetadata(title="Dune", isbn="9780441172719")
+        proposed = BookMetadata(title="Dune", isbn=None)
+
+        diffs = metadata_diff(current, proposed)
+        isbn_diff = next(d for d in diffs if d.field == "isbn")
+        assert isbn_diff.skip_clear is True
+
+    def test_both_empty_not_skip_clear(self):
+        current = BookMetadata(title="Dune", publisher=None)
+        proposed = BookMetadata(title="Dune", publisher="")
+
+        diffs = metadata_diff(current, proposed)
+        publisher_diff = next(d for d in diffs if d.field == "publisher")
+        # Both effectively empty → no change, not a skipped clear either.
+        assert publisher_diff.skip_clear is False
+        assert publisher_diff.changed is False
+
+    def test_non_empty_proposed_not_skip_clear(self):
+        current = BookMetadata(title="Dune", publisher="Ace Books")
+        proposed = BookMetadata(title="Dune", publisher="Penguin")
+
+        diffs = metadata_diff(current, proposed)
+        publisher_diff = next(d for d in diffs if d.field == "publisher")
+        assert publisher_diff.skip_clear is False
+        assert publisher_diff.changed is True
+
+
+class TestEnrichApplySkipClear:
+    """Server-side guard: never overwrite a non-empty field with an empty one."""
+
+    def test_empty_authors_does_not_overwrite_existing_authors(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="It", authors=["Stephen King"], source_path=source
+        )
+
+        # Candidate has empty authors — must NOT clobber existing "Stephen King".
+        # Build the candidate directly so we can pin authors to an empty list
+        # (make_candidate substitutes a default when given a falsy authors list).
+        candidate = MetadataCandidate(
+            metadata=BookMetadata(title="It", authors=[]),
+            confidence=0.5,
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        _, kwargs = mock_catalog.update_book.call_args
+        # authors should NOT be passed (or, if passed, must equal current).
+        assert "authors" not in kwargs or kwargs["authors"] == ["Stephen King"]
+
+    def test_empty_scalar_does_not_overwrite_existing_scalar(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", publisher="Ace Books", source_path=source
+        )
+
+        candidate = make_candidate(
+            title="Dune",
+            authors=["Frank Herbert"],
+            publisher="",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        _, kwargs = mock_catalog.update_book.call_args
+        # publisher should not be sent through as an empty clearing value.
+        assert "publisher" not in kwargs or kwargs["publisher"] == "Ace Books"
+
+    def test_non_empty_proposed_still_overwrites(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Old", authors=["Old Author"], source_path=source
+        )
+
+        candidate = make_candidate(
+            title="New",
+            authors=["New Author"],
+            publisher="Acme",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        _, kwargs = mock_catalog.update_book.call_args
+        assert kwargs["title"] == "New"
+        assert kwargs["authors"] == ["New Author"]
+        assert kwargs["publisher"] == "Acme"
+
+    def test_empty_proposed_when_current_also_empty_is_noop(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        # Current publisher is None; proposed publisher is "" — should be safe no-op.
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", publisher=None, source_path=source
+        )
+
+        candidate = make_candidate(
+            title="Dune",
+            authors=["Frank Herbert"],
+            publisher="",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # Apply still succeeds; publisher simply not written.
+        assert response.headers.get("HX-Redirect") == "/books/1"
+        _, kwargs = mock_catalog.update_book.call_args
+        assert "publisher" not in kwargs
+
+    def test_empty_title_does_not_overwrite_existing_title(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="It", authors=["Stephen King"], source_path=source
+        )
+
+        # Even though title is "required" elsewhere, defend against a
+        # candidate that somehow surfaces an empty title.
+        candidate = make_candidate(
+            title="",
+            authors=["Stephen King"],
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        _, kwargs = mock_catalog.update_book.call_args
+        assert "title" not in kwargs or kwargs["title"] == "It"
+
+
+class TestEnrichDiffSkipClearRendering:
+    """The diff panel surfaces skip-clear rows with a muted indicator."""
+
+    def test_skip_clear_row_has_diff_clear_class(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1, title="It", authors=["Stephen King"])
+        # Empty authors on the candidate → skip_clear row in the diff table.
+        # Construct directly so the empty author list isn't replaced by a default.
+        candidate = MetadataCandidate(
+            metadata=BookMetadata(title="It", authors=[]),
+            confidence=0.5,
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "query": "9780441172719",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        assert "diff-clear" in html
+        # User-visible note explaining the skipped clear.
+        assert "current kept" in html.lower()


### PR DESCRIPTION
## Summary

Fixes #125. The web "Apply candidate metadata" flow silently wiped curated
fields whenever a provider returned an empty value for them (book 524's
`authors = "Stephen King"` getting clobbered by an OpenLibrary candidate
with `authors = ""`).

- Adds a server-side guard in `enrich_apply` so a proposed empty/None
  value can never overwrite a non-empty current value. Defense in depth:
  even if the form somehow posts a clearing value, the handler drops it
  before calling `catalog.update_book`.
- Extends `FieldDiff` with a `skip_clear` flag so the diff helper marks
  these rows once and both the apply pipeline and the template can read
  the same signal.
- Updates `_field_diff_row.html` to render skip-clear rows with a muted
  `.diff-clear` row plus a "current kept — provider had no value" note.
- Apply button now shows the effective write count and a short summary
  of how many fields were preserved.

Out of scope (tracked separately): per-field accept/reject toggles
(#121) and the broader diff color/strikethrough refactor (#133).

Refs #115, #121.

## Acceptance criteria

- [x] Apply never overwrites a non-empty current field with an empty proposed value
- [x] Diff UI shows clearing rows differently (muted `.diff-clear` row + skip note)
- [x] Test: candidate with empty authors does not overwrite existing authors on apply
- [x] Test: candidate with non-empty value still overwrites as before
- [x] Test: candidate with empty value where current is also empty is a no-op

## Test plan

- [x] `uv run pytest` — full suite green (1394 passed)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright src/bookery/web/diff.py src/bookery/web/routes.py` — 0 errors
- [ ] Manual: open a real book in the web UI, search OpenLibrary for a
      candidate with empty authors, View → confirm the authors row is
      muted with a "current kept" note and the Apply button count is
      reduced; click Apply and confirm the book's authors are unchanged.