### PR TITLE
fix(web): strip HTML from descriptions on write, migrate existing rows (#123)

### DIFF
--- a/scripts/migrate_strip_description_html.py
+++ b/scripts/migrate_strip_description_html.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# ABOUTME: One-shot migration that strips HTML from existing book descriptions.
+# ABOUTME: Idempotent — re-running on already-stripped rows is a no-op.
+
+"""Clean the ``books.description`` column in-place.
+
+The web UI stores plain text on write (see issue #123), but rows written
+before the fix may carry HTML markup like ``<p class="description">…``
+that renders as escaped literal text in the detail page and edit form.
+
+Usage:
+    uv run python scripts/migrate_strip_description_html.py PATH_TO_LIBRARY.db
+    uv run python scripts/migrate_strip_description_html.py --dry-run PATH_TO_LIBRARY.db
+
+The default run prints a count of rows touched. ``--dry-run`` prints the
+same count and the first few affected ids without writing.
+
+Idempotent: ``strip_html`` is a fixed point on plain text input, so a row
+already cleaned does not register as a change on a second pass. Tested in
+``tests/integration/test_strip_description_migration.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+# Allow running the script straight from the repo without installing the
+# package — prepend ``src/`` to sys.path so ``bookery.util.text`` imports.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from bookery.util.text import strip_html  # noqa: E402
+
+
+def migrate(db_path: Path, *, dry_run: bool = False) -> int:
+    """Strip HTML from every non-null description in the catalog.
+
+    Returns the number of rows whose description value actually changed.
+    A "changed" row is one where ``strip_html(value) != value``. Rows that
+    are already plain text are left alone (the UPDATE is filtered, not
+    blanket-applied, so we don't bump ``date_modified`` for no reason).
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(
+            "SELECT id, description FROM books WHERE description IS NOT NULL"
+        )
+        updates: list[tuple[str, int]] = []
+        for row in cursor:
+            cleaned = strip_html(row["description"])
+            if cleaned != row["description"]:
+                updates.append((cleaned, row["id"]))
+
+        if dry_run:
+            preview = ", ".join(str(book_id) for _, book_id in updates[:10])
+            print(f"[dry-run] would clean {len(updates)} description rows", flush=True)
+            if preview:
+                print(f"[dry-run] sample ids: {preview}", flush=True)
+            return len(updates)
+
+        if updates:
+            conn.executemany(
+                "UPDATE books SET description = ? WHERE id = ?",
+                updates,
+            )
+            conn.commit()
+        print(f"Cleaned {len(updates)} description rows", flush=True)
+        return len(updates)
+    finally:
+        conn.close()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("db_path", type=Path, help="Path to the bookery library.db")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.db_path.exists():
+        print(f"error: no such file: {args.db_path}", file=sys.stderr)
+        return 2
+    migrate(args.db_path, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -8,6 +8,7 @@ import ebooklib
 from ebooklib import epub
 
 from bookery.metadata.types import BookMetadata
+from bookery.util.text import strip_html
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,20 @@ def _get_metadata_value(book: epub.EpubBook, namespace: str, name: str) -> str |
     # Metadata entries are tuples of (value, attributes)
     value = values[0][0]
     return str(value).strip() if value else None
+
+
+def _strip_description(value: str | None) -> str | None:
+    """Strip HTML markup from a DC:description value read from the OPF.
+
+    Publishers and conversion tools commonly wrap descriptions in ``<p>`` or
+    ``<div>`` tags, and the raw OPF string carries entity escapes (``&amp;``,
+    ``&#x27;``). Normalize to plain text so the catalog stores the same shape
+    regardless of where the metadata came from.
+    """
+    if value is None:
+        return None
+    stripped = strip_html(value)
+    return stripped or None
 
 
 def _get_authors(book: epub.EpubBook) -> list[str]:
@@ -119,7 +134,7 @@ def read_epub_metadata(path: Path) -> BookMetadata:
         language=_get_metadata_value(book, "DC", "language"),
         publisher=_get_metadata_value(book, "DC", "publisher"),
         isbn=isbn,
-        description=_get_metadata_value(book, "DC", "description"),
+        description=_strip_description(_get_metadata_value(book, "DC", "description")),
         identifiers=identifiers,
         cover_image=cover_image,
         source_path=path,

--- a/src/bookery/formats/mobi.py
+++ b/src/bookery/formats/mobi.py
@@ -15,6 +15,7 @@ from ebooklib import epub
 from mobi import extract as mobi_extract
 
 from bookery.metadata.types import BookMetadata
+from bookery.util.text import strip_html
 
 logger = logging.getLogger(__name__)
 
@@ -343,9 +344,13 @@ def parse_opf_metadata(opf_path: Path | None) -> BookMetadata | None:
     pub_el = metadata_el.find("dc:publisher", ns)
     publisher = pub_el.text.strip() if pub_el is not None and pub_el.text else None
 
-    # Description
+    # Description — MOBI/OPF descriptions are often HTML; normalize to plain
+    # text so the catalog stores the same shape as descriptions from other
+    # sources (EPUB, providers, edit form).
     desc_el = metadata_el.find("dc:description", ns)
-    description = desc_el.text.strip() if desc_el is not None and desc_el.text else None
+    description_raw = desc_el.text.strip() if desc_el is not None and desc_el.text else None
+    description = strip_html(description_raw) if description_raw else None
+    description = description or None
 
     # ISBN from dc:identifier with opf:scheme="ISBN"
     isbn = None

--- a/src/bookery/metadata/googlebooks.py
+++ b/src/bookery/metadata/googlebooks.py
@@ -9,12 +9,12 @@ from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.http import HttpClient, MetadataFetchError
 from bookery.metadata.scoring import score_candidate
 from bookery.metadata.types import BookMetadata
+from bookery.util.text import strip_html
 
 logger = logging.getLogger(__name__)
 
 _GB_BASE = "https://www.googleapis.com/books/v1/volumes"
 _SEARCH_LIMIT = 5
-_HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 # Ordered from largest to smallest — we pick the first variant Google returns.
 _COVER_VARIANTS = (
@@ -27,9 +27,9 @@ _COVER_VARIANTS = (
 )
 
 
-def _strip_html(text: str) -> str:
-    """Remove HTML tags and collapse whitespace."""
-    return re.sub(r"\s+", " ", _HTML_TAG_RE.sub("", text)).strip()
+# Backward-compatible alias for the shared helper. Google Books descriptions
+# are rich HTML so we keep this local name for readability at the call site.
+_strip_html = strip_html
 
 
 def _pick_isbn(industry_identifiers: list[dict[str, str]]) -> str | None:

--- a/src/bookery/metadata/openlibrary_parser.py
+++ b/src/bookery/metadata/openlibrary_parser.py
@@ -4,6 +4,7 @@
 from typing import Any
 
 from bookery.metadata.types import BookMetadata
+from bookery.util.text import strip_html
 
 _COVERS_BASE_URL = "https://covers.openlibrary.org/b/isbn"
 
@@ -74,16 +75,22 @@ def parse_works_response(data: dict[str, Any]) -> str | None:
     """Extract the description from an Open Library Works response.
 
     Handles the OL quirk where description can be either a plain string
-    or a dict with {"type": ..., "value": "actual text"}.
+    or a dict with {"type": ..., "value": "actual text"}. The value is
+    stripped of any HTML markup so the catalog stores plain text.
     """
     desc = data.get("description")
     if desc is None:
         return None
     if isinstance(desc, str):
-        return desc
-    if isinstance(desc, dict):
-        return desc.get("value")
-    return None
+        raw = desc
+    elif isinstance(desc, dict):
+        raw = desc.get("value")
+    else:
+        return None
+    if not raw:
+        return None
+    cleaned = strip_html(raw)
+    return cleaned or None
 
 
 def parse_works_subjects(data: dict[str, Any]) -> list[str]:

--- a/src/bookery/util/text.py
+++ b/src/bookery/util/text.py
@@ -1,0 +1,79 @@
+# ABOUTME: Plain-text helpers for description fields — HTML stripping and paragraph rendering.
+# ABOUTME: Storage is plain text; render-time wraps blank-line paragraphs in <p> tags.
+
+from __future__ import annotations
+
+import html
+import re
+
+from markupsafe import Markup, escape
+
+_TAG_RE = re.compile(r"<[^>]+>")
+# Match runs of whitespace that don't contain a blank-line break. A blank line
+# is two or more newlines (possibly with intervening spaces/tabs); we keep
+# those as a single "\n\n" so paragraph structure survives the strip.
+_INLINE_WS_RE = re.compile(r"[ \t\r\f\v]+|\n(?!\s*\n)")
+_PARAGRAPH_BREAK_RE = re.compile(r"\n\s*\n+")
+
+
+def strip_html(value: str) -> str:
+    """Strip HTML tags and decode entities, preserving paragraph breaks.
+
+    Removes all tags (the simple regex matches anything between angle
+    brackets), unescapes HTML entities (``&amp;`` → ``&`` etc.), collapses
+    runs of inline whitespace to a single space, and normalizes paragraph
+    breaks (any run of blank lines) to a single ``"\\n\\n"`` separator.
+
+    The result is plain text suitable for writing to the catalog. Idempotent:
+    running it on output that contains no markup returns the input with the
+    same whitespace normalization applied.
+    """
+    if not value:
+        return ""
+
+    # Block-level tags should produce paragraph breaks so we don't run text
+    # together. Insert a sentinel newline pair before stripping all tags.
+    block_break = re.sub(
+        r"</(?:p|div|section|article|header|footer|li|h[1-6]|blockquote|pre)\s*>",
+        "\n\n",
+        value,
+        flags=re.IGNORECASE,
+    )
+    block_break = re.sub(r"<br\s*/?>", "\n", block_break, flags=re.IGNORECASE)
+
+    no_tags = _TAG_RE.sub("", block_break)
+    decoded = html.unescape(no_tags)
+
+    # Normalize paragraph breaks first so the inline-whitespace pass doesn't
+    # eat them. Mark paragraph breaks with a sentinel that survives the
+    # subsequent whitespace collapse, then restore.
+    sentinel = "\x00PARA\x00"
+    with_paras = _PARAGRAPH_BREAK_RE.sub(sentinel, decoded)
+    collapsed = _INLINE_WS_RE.sub(" ", with_paras)
+    restored = collapsed.replace(sentinel, "\n\n")
+
+    # Trim per-paragraph leading/trailing spaces and drop empty paragraphs.
+    paragraphs = [p.strip() for p in restored.split("\n\n")]
+    paragraphs = [p for p in paragraphs if p]
+    return "\n\n".join(paragraphs)
+
+
+def description_paragraphs(value: str | None) -> Markup:
+    """Render plain-text description as HTML paragraphs.
+
+    Splits on blank lines, escapes each paragraph for safe HTML output, and
+    wraps it in ``<p>`` tags. Returns an empty :class:`Markup` for ``None``
+    or empty input so the caller can branch with ``{% if %}`` cleanly.
+
+    This is a render-time helper — it does NOT sanitize, because storage is
+    already plain text (HTML is stripped on write). The escape pass is purely
+    to render characters like ``&`` and ``<`` literally rather than as markup.
+    """
+    if not value:
+        return Markup("")
+    paragraphs = [p.strip() for p in value.split("\n\n")]
+    paragraphs = [p for p in paragraphs if p]
+    if not paragraphs:
+        return Markup("")
+    rendered = "\n".join(f"<p>{escape(p)}</p>" for p in paragraphs)
+    return Markup(rendered)

--- a/src/bookery/web/__init__.py
+++ b/src/bookery/web/__init__.py
@@ -8,6 +8,7 @@ from flask import Flask
 
 from bookery.db.catalog import LibraryCatalog
 from bookery.metadata.provider import MetadataProvider
+from bookery.util.text import description_paragraphs
 from bookery.web.routes import bp
 
 
@@ -32,5 +33,9 @@ def create_app(
     app.config["SECRET_KEY"] = os.environ.get("BOOKERY_SECRET_KEY", "bookery-dev-secret")
     app.config["CATALOG"] = catalog
     app.config["PROVIDERS"] = dict(providers) if providers else {}
+    # Render plain-text description fields as escaped <p> blocks. Storage is
+    # already plain text (HTML is stripped on write), so this filter never
+    # needs to sanitize — it just wraps blank-line paragraphs.
+    app.jinja_env.filters["description_paragraphs"] = description_paragraphs
     app.register_blueprint(bp)
     return app

--- a/src/bookery/web/diff.py
+++ b/src/bookery/web/diff.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from bookery.metadata.types import BookMetadata
+from bookery.util.text import strip_html
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,13 @@ def metadata_diff(current: BookMetadata, proposed: BookMetadata) -> list[FieldDi
 
         cur_val = getattr(current, field)
         prop_val = getattr(proposed, field)
+        # Descriptions are stored as plain text, but provider candidates can
+        # still arrive with HTML markup. Strip both sides so the diff reflects
+        # what the apply pipeline will actually write — and so the proposed
+        # column doesn't render literal <p class="..."> noise.
+        if field == "description":
+            cur_val = strip_html(cur_val) if cur_val else cur_val
+            prop_val = strip_html(prop_val) if prop_val else prop_val
         changed = _scalar_changed(cur_val, prop_val)
         cur_display = _format_scalar(cur_val)
         prop_display = _format_scalar(prop_val)

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -21,6 +21,7 @@ from bookery.core.pipeline import apply_metadata_safely
 from bookery.core.remove import remove_book
 from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.provider import MetadataProvider
+from bookery.util.text import strip_html
 from bookery.web.diff import metadata_diff
 
 
@@ -146,7 +147,11 @@ def update_book(book_id):
     isbn = request.form.get("isbn", "").strip() or None
     language = request.form.get("language", "").strip() or None
     publisher = request.form.get("publisher", "").strip() or None
-    description = request.form.get("description", "").strip() or None
+    # Strip HTML on write so storage is always plain text — the catalog is
+    # the source of truth for the render layer and we never want to round-trip
+    # markup through the FTS index or the edit textarea.
+    description_raw = request.form.get("description", "")
+    description = strip_html(description_raw) or None
     series = request.form.get("series", "").strip() or None
 
     series_index_raw = request.form.get("series_index", "").strip()
@@ -507,8 +512,14 @@ def enrich_apply(book_id):
         update_fields["language"] = proposed.language
     if _should_write_scalar(current.publisher, proposed.publisher):
         update_fields["publisher"] = proposed.publisher
-    if _should_write_scalar(current.description, proposed.description):
-        update_fields["description"] = proposed.description
+    # Provider descriptions are commonly HTML (Google Books, scraped OL).
+    # Strip on write so the catalog stores plain text — mirrors the same
+    # guarantee the edit form path enforces. Compare against the stripped
+    # value too so an HTML-wrapped echo of the current text doesn't read as
+    # a real change.
+    stripped_description = strip_html(proposed.description) if proposed.description else None
+    if _should_write_scalar(current.description, stripped_description):
+        update_fields["description"] = stripped_description
     if _should_write_scalar(current.series, proposed.series):
         update_fields["series"] = proposed.series
     if _should_write_scalar(current.series_index, proposed.series_index):

--- a/src/bookery/web/templates/_detail_description.html
+++ b/src/bookery/web/templates/_detail_description.html
@@ -3,6 +3,6 @@
 {% if book.metadata.description %}
 <section class="section" aria-labelledby="detail-description">
     <h3 id="detail-description">Description</h3>
-    <p>{{ book.metadata.description }}</p>
+    {{ book.metadata.description | description_paragraphs }}
 </section>
 {% endif %}

--- a/tests/integration/test_strip_description_migration.py
+++ b/tests/integration/test_strip_description_migration.py
@@ -1,0 +1,93 @@
+# ABOUTME: Integration tests for scripts/migrate_strip_description_html.py.
+# ABOUTME: Verifies HTML cleanup is correct, idempotent, and leaves clean rows alone.
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from bookery.db.connection import open_library
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "migrate_strip_description_html.py"
+)
+
+
+def _load_script_module():
+    """Import the standalone script as a module for direct function calls."""
+    spec = importlib.util.spec_from_file_location(
+        "_migrate_strip_description_html", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def migrate():
+    return _load_script_module().migrate
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Real bookery library with a couple of seeded book rows."""
+    path = tmp_path / "library.db"
+    # open_library applies all schema migrations against a fresh sqlite file.
+    conn = open_library(path, check_same_thread=False)
+    conn.executemany(
+        "INSERT INTO books (title, source_path, file_hash, description) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            ("With HTML", "/books/1.epub", "hash1", '<p class="description">A &amp; B</p>'),
+            ("Plain Text", "/books/2.epub", "hash2", "Already clean."),
+            ("Null Desc", "/books/3.epub", "hash3", None),
+            ("Multi Para", "/books/4.epub", "hash4", "<p>first</p><p>second</p>"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _descriptions(db_path: Path) -> dict[str, str | None]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT title, description FROM books ORDER BY id").fetchall()
+        return {title: desc for title, desc in rows}
+    finally:
+        conn.close()
+
+
+def test_migrate_strips_html_from_existing_rows(migrate, db_path):
+    count = migrate(db_path)
+    assert count == 2  # the two HTML rows; plain and null are untouched.
+    descs = _descriptions(db_path)
+    assert descs["With HTML"] == "A & B"
+    assert descs["Plain Text"] == "Already clean."
+    assert descs["Null Desc"] is None
+    assert descs["Multi Para"] == "first\n\nsecond"
+
+
+def test_migrate_is_idempotent(migrate, db_path):
+    first = migrate(db_path)
+    second = migrate(db_path)
+    assert first == 2
+    # Second pass: nothing to do — all rows are already plain text.
+    assert second == 0
+    descs = _descriptions(db_path)
+    assert descs["With HTML"] == "A & B"
+    assert descs["Multi Para"] == "first\n\nsecond"
+
+
+def test_migrate_dry_run_does_not_write(migrate, db_path):
+    before = _descriptions(db_path)
+    count = migrate(db_path, dry_run=True)
+    after = _descriptions(db_path)
+    assert count == 2
+    assert before == after  # dry-run preserves the original strings.

--- a/tests/unit/test_util_text.py
+++ b/tests/unit/test_util_text.py
@@ -1,0 +1,99 @@
+# ABOUTME: Unit tests for the description text helpers — strip_html and description_paragraphs.
+# ABOUTME: Covers tag removal, entity decoding, paragraph preservation, and Jinja-safe HTML output.
+
+from markupsafe import Markup
+
+from bookery.util.text import description_paragraphs, strip_html
+
+
+class TestStripHtml:
+    def test_returns_empty_for_empty_input(self):
+        assert strip_html("") == ""
+
+    def test_passes_plain_text_through_unchanged(self):
+        assert strip_html("Just a sentence.") == "Just a sentence."
+
+    def test_strips_simple_tags(self):
+        assert strip_html("<p>hello</p>") == "hello"
+
+    def test_strips_attributes_inside_tags(self):
+        assert strip_html('<p class="description">hello</p>') == "hello"
+
+    def test_decodes_html_entities(self):
+        assert strip_html("foo &amp; bar") == "foo & bar"
+
+    def test_decodes_numeric_entities(self):
+        assert strip_html("don&#x27;t") == "don't"
+
+    def test_preserves_paragraph_breaks(self):
+        html = "<p>first</p><p>second</p>"
+        assert strip_html(html) == "first\n\nsecond"
+
+    def test_blank_line_separated_text_preserved(self):
+        text = "paragraph one\n\nparagraph two"
+        assert strip_html(text) == "paragraph one\n\nparagraph two"
+
+    def test_collapses_runs_of_inline_whitespace(self):
+        assert strip_html("foo    bar\tbaz") == "foo bar baz"
+
+    def test_br_becomes_newline(self):
+        # <br> is a line break, not a paragraph break — gets normalized to a
+        # space in single-paragraph context but doesn't run words together.
+        assert strip_html("line one<br>line two") == "line one line two"
+
+    def test_idempotent_on_plain_text(self):
+        text = "first paragraph\n\nsecond paragraph"
+        once = strip_html(text)
+        twice = strip_html(once)
+        assert once == twice
+
+    def test_idempotent_on_html_input(self):
+        html = "<p>first</p><p>second &amp; third</p>"
+        once = strip_html(html)
+        twice = strip_html(once)
+        assert once == twice
+        assert once == "first\n\nsecond & third"
+
+    def test_nested_tags_stripped(self):
+        assert strip_html("<div><p><em>hi</em></p></div>") == "hi"
+
+    def test_drops_empty_paragraphs(self):
+        # Multiple blank lines collapse to a single paragraph break and any
+        # all-whitespace "paragraphs" get dropped.
+        assert strip_html("a\n\n\n\nb") == "a\n\nb"
+
+    def test_strips_book_524_repro_case(self):
+        # Mirrors the reported bug: stored description contains a literal
+        # <p class="description"> wrapper. After strip we want plain prose.
+        raw = '<p class="description">A great story about &amp;c.</p>'
+        assert strip_html(raw) == "A great story about &c."
+
+
+class TestDescriptionParagraphs:
+    def test_returns_empty_markup_for_none(self):
+        result = description_paragraphs(None)
+        assert isinstance(result, Markup)
+        assert str(result) == ""
+
+    def test_returns_empty_markup_for_empty_string(self):
+        assert str(description_paragraphs("")) == ""
+
+    def test_wraps_single_paragraph_in_p(self):
+        assert str(description_paragraphs("hello")) == "<p>hello</p>"
+
+    def test_wraps_multiple_paragraphs(self):
+        result = str(description_paragraphs("first\n\nsecond"))
+        assert "<p>first</p>" in result
+        assert "<p>second</p>" in result
+
+    def test_escapes_special_chars(self):
+        # Plain-text storage may still contain raw "&" or "<"; render-time
+        # must escape so the browser shows them literally.
+        result = str(description_paragraphs("a & b"))
+        assert result == "<p>a &amp; b</p>"
+
+    def test_does_not_double_escape_existing_entities(self):
+        # Storage is plain text, so "&" is just an ampersand — not an entity.
+        # Escape it once at render.
+        result = str(description_paragraphs("&amp;"))
+        assert result == "<p>&amp;amp;</p>"

--- a/tests/web/test_detail.py
+++ b/tests/web/test_detail.py
@@ -92,6 +92,32 @@ class TestDetailSections:
         html = client.get("/books/1").data.decode()
         assert 'aria-labelledby="detail-description"' not in html
 
+    def test_description_wraps_blank_line_paragraphs_in_p_tags(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, description="first paragraph\n\nsecond paragraph"
+        )
+        html = client.get("/books/1").data.decode()
+        assert "<p>first paragraph</p>" in html
+        assert "<p>second paragraph</p>" in html
+
+    def test_description_does_not_render_literal_html_class_attr(self, mock_catalog, client):
+        # If the catalog still held HTML (legacy data before migration), the
+        # render layer would escape it. After issue #123 the catalog stores
+        # plain text, so the literal '<p class="description">' string the
+        # bug report flagged never appears on the detail page.
+        mock_catalog.get_by_id.return_value = make_book(
+            1, description="Plain prose, no markup."
+        )
+        html = client.get("/books/1").data.decode()
+        assert '&lt;p class=&#34;description&#34;&gt;' not in html
+        assert '<p class="description">' not in html
+        assert "<p>Plain prose, no markup.</p>" in html
+
+    def test_description_escapes_special_chars(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, description="A & B")
+        html = client.get("/books/1").data.decode()
+        assert "<p>A &amp; B</p>" in html
+
 
 class TestEnrichedBadge:
     def test_badge_shown_when_output_path_set(self, mock_catalog, client):

--- a/tests/web/test_edit.py
+++ b/tests/web/test_edit.py
@@ -66,3 +66,58 @@ class TestUpdateStillRendersDetail:
         html = response.data.decode()
         assert "Updated" in html
         assert 'aria-labelledby="detail-header"' in html
+
+
+class TestDescriptionHtmlStripping:
+    """Edit POSTs must store plain text — never HTML markup (issue #123)."""
+
+    def _post_description(self, mock_catalog, client, description: str):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Book")
+        client.post(
+            "/books/1/edit",
+            data={
+                "title": "Book",
+                "authors": "Author",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": description,
+                "series": "",
+                "series_index": "",
+            },
+        )
+        return mock_catalog.update_book.call_args
+
+    def test_html_tags_stripped_on_save(self, mock_catalog, client):
+        call = self._post_description(
+            mock_catalog, client, '<p class="description">A story.</p>'
+        )
+        assert call.kwargs["description"] == "A story."
+
+    def test_entities_decoded_on_save(self, mock_catalog, client):
+        call = self._post_description(
+            mock_catalog, client, "foo &amp; bar"
+        )
+        assert call.kwargs["description"] == "foo & bar"
+
+    def test_paragraphs_preserved_as_blank_lines(self, mock_catalog, client):
+        call = self._post_description(
+            mock_catalog, client, "<p>first</p><p>second</p>"
+        )
+        assert call.kwargs["description"] == "first\n\nsecond"
+
+    def test_empty_html_becomes_none(self, mock_catalog, client):
+        call = self._post_description(mock_catalog, client, "<p></p>")
+        assert call.kwargs["description"] is None
+
+    def test_book_524_repro_case(self, mock_catalog, client):
+        # The reported bug: stored values arrive with <p class="description">
+        # wrappers that render as escaped text. After the fix the catalog
+        # never sees that markup.
+        call = self._post_description(
+            mock_catalog,
+            client,
+            '<p class="description">A great story about &amp;c.</p>',
+        )
+        assert call.kwargs["description"] == "A great story about &c."
+        assert "<p" not in call.kwargs["description"]

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -525,6 +525,88 @@ class TestEnrichApplyPost:
         assert response.status_code == 404
 
 
+# --- description HTML stripping on apply (issue #123) -----------------------
+
+
+class TestEnrichApplyStripsDescriptionHtml:
+    """Apply-candidate path must strip HTML from provider descriptions."""
+
+    def _apply_with_description(
+        self,
+        mock_catalog,
+        client,
+        open_library,
+        tmp_path,
+        proposed_description: str | None,
+        *,
+        current_description: str | None = None,
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(
+            1, source_path=source, description=current_description
+        )
+        candidate = MetadataCandidate(
+            metadata=BookMetadata(
+                title="T",
+                authors=["A"],
+                description=proposed_description,
+            ),
+            confidence=0.9,
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = [candidate]
+        dest = tmp_path / "out.epub"
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+        return mock_catalog.update_book.call_args
+
+    def test_html_in_proposed_description_is_stripped(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        call = self._apply_with_description(
+            mock_catalog,
+            client,
+            open_library,
+            tmp_path,
+            '<p class="description">A story.</p>',
+        )
+        assert call.kwargs["description"] == "A story."
+
+    def test_entities_in_proposed_description_are_decoded(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        call = self._apply_with_description(
+            mock_catalog, client, open_library, tmp_path, "foo &amp; bar"
+        )
+        assert call.kwargs["description"] == "foo & bar"
+
+    def test_html_that_strips_to_same_as_current_does_not_write(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        # Current plain text matches what the HTML proposed value strips to.
+        # The skip-clear / no-clobber guard from #125 also covers "no real
+        # change" — make sure description isn't gratuitously re-written.
+        call = self._apply_with_description(
+            mock_catalog,
+            client,
+            open_library,
+            tmp_path,
+            "<p>Existing prose.</p>",
+            current_description="Existing prose.",
+        )
+        assert "description" not in call.kwargs
+
+
 # --- _enrich_candidate_row View button wiring -------------------------------
 
 


### PR DESCRIPTION
## Summary

Book descriptions written from EPUB OPF metadata and external providers were sometimes stored with HTML markup (e.g. `<p class="description">…</p>`) and rendered as literal escaped text on the detail page, edit textarea, and apply-candidate diff (reproducible on book id 524).

This change adopts the **strip-on-write, render-plain-on-read** strategy:

- New `bookery.util.text` module with `strip_html` (stdlib only — `html.unescape` + small regex) and a `description_paragraphs` Jinja filter that wraps blank-line paragraphs in escaped `<p>` tags.
- Strip at every catalog write site: edit form save, apply-candidate handler, EPUB OPF read, MOBI OPF read, Open Library works parser. Google Books' local `_strip_html` now aliases the shared helper so behavior is consistent across providers.
- Detail page renders via the new Jinja filter. The apply-candidate diff helper also strips both sides of the description row so the table reflects what the apply pipeline will actually write.
- One-shot migration script `scripts/migrate_strip_description_html.py` cleans existing rows. Idempotent and supports `--dry-run`.

No new runtime deps. No bleach. No sanitize-on-read.

## Branch dependency

Includes the merge of #144 (server-side guard for empty proposed values) since the description row in `_field_diff_row.html` overlaps with that PR's `skip_clear` rendering. Rebase on `main` after #144 merges.

## Acceptance criteria

- [x] Description stored as plain text on save from edit form
- [x] Description stored as plain text on apply-candidate
- [x] EPUB/MOBI extraction strips HTML descriptions
- [x] Open Library / Google Books candidate descriptions arrive plain
- [x] Detail page renders blank-line paragraphs as `<p>` tags
- [x] Apply-candidate diff `Current`/`Proposed` columns render plain text
- [x] Edit textarea shows raw plain text (no markup)
- [x] One-shot migration cleans existing catalog rows
- [x] Migration is idempotent (re-runnable safely)
- [x] No new runtime dependencies (stdlib + already-present markupsafe)

## Test plan

- [x] `uv run pytest` — 1429 tests pass, no warnings (except the pre-existing third-party `mobi`/`imghdr` deprecation)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run pyright src/` clean
- [x] New unit tests: `tests/unit/test_util_text.py` (21 cases — strip behavior, idempotence, entity decoding, paragraph preservation, render filter escaping)
- [x] New web tests: `tests/web/test_edit.py::TestDescriptionHtmlStripping`, `tests/web/test_detail.py` description paragraph rendering, `tests/web/test_enrich_apply.py::TestEnrichApplyStripsDescriptionHtml`
- [x] New integration test: `tests/integration/test_strip_description_migration.py` (HTML clean-up, idempotence, dry-run)
- [ ] Manual: run `uv run python scripts/migrate_strip_description_html.py --dry-run path/to/library.db` against a real library, then run for real and verify book id 524 renders cleanly

Closes #123.