### PR TITLE
test: guardrail against tests touching real ~/.bookery (#77)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,46 @@ uv run pytest tests/unit/test_scoring.py -v  # single file, verbose
 
 Test output must be clean — no warnings, no captured errors unless explicitly tested.
 
+### Test Isolation
+
+A session-scoped guardrail in `tests/conftest.py` wraps `sqlite3.connect` and
+raises `RuntimeError` if any test tries to open the real user catalog at
+`~/.bookery/library.db` or anywhere under `~/.bookery/library/`. Combined with
+the autouse `_isolate_library_root` fixture (which sets `BOOKERY_DB` and
+`BOOKERY_LIBRARY_ROOT` to per-test tmp paths), this prevents the regression in
+issue #77 where test runs polluted the user's real catalog with rows pointing
+at `/private/var/folders/.../pytest-of-...` paths that no longer exist.
+
+The guardrail is best-effort against subprocesses (a subprocess that re-imports
+`bookery.db` will not inherit the in-process monkeypatch) — but the env-var
+isolation already covers child processes, and the test suite does not currently
+shell out to the bookery CLI.
+
+### Recovering from test pollution
+
+If you have a pre-guardrail catalog that already contains rows pointing at
+deleted `pytest` tmp directories, you'll see warnings like this from
+`bookery sync kobo`:
+
+```
+- book.epub: source missing: /private/var/folders/.../pytest-of-joec/pytest-48/.../library/Unknown/book.epub
+```
+
+To prune them, run the following against your catalog (replace the path if
+yours is non-default):
+
+```bash
+sqlite3 ~/.bookery/library.db <<'SQL'
+DELETE FROM books
+ WHERE source_path LIKE '/tmp/%'
+    OR source_path LIKE '/private/var/folders/%';
+SQL
+```
+
+Foreign-key cascades will clean up the associated `book_genres`, `book_tags`,
+and `book_field_provenance` rows. The forthcoming `bookery prune` command
+(#101) will do this in a guided, dry-run-by-default form.
+
 ## Architecture
 
 ### Core Abstraction: BookMetadata

--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ uv run ruff check src/ tests/
 uv run pytest tests/unit/test_scoring.py -v
 ```
 
+Tests are isolated from your real `~/.bookery/library.db` by an autouse
+guardrail. If you previously ran the suite without this guardrail and your
+catalog now reports `source missing: /private/var/folders/.../pytest-of-...`,
+see ["Recovering from test pollution"](CONTRIBUTING.md#recovering-from-test-pollution)
+in `CONTRIBUTING.md`.
+
 ## Roadmap
 
 Bookery is being built in phases:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,76 @@ from pathlib import Path
 import pytest
 from ebooklib import epub
 
+# Real user paths that tests must never touch. Compared with resolved absolute
+# paths so symlinks and relative segments cannot sneak past the check.
+_REAL_BOOKERY_DIR = (Path.home() / ".bookery").resolve()
+_REAL_LIBRARY_DB = (_REAL_BOOKERY_DIR / "library.db").resolve()
+_REAL_LIBRARY_DIR = (_REAL_BOOKERY_DIR / "library").resolve()
+
+
+def _is_real_user_path(path: Path) -> bool:
+    """Return True if ``path`` points at the user's real catalog DB or any
+    location under their real library directory.
+    """
+    try:
+        resolved = path.expanduser().resolve()
+    except (OSError, RuntimeError):
+        # Unresolvable paths cannot be the real user path.
+        return False
+    if resolved == _REAL_LIBRARY_DB:
+        return True
+    try:
+        resolved.relative_to(_REAL_LIBRARY_DIR)
+    except ValueError:
+        return False
+    return True
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _guardrail_block_real_user_paths():
+    """Session-scoped guardrail: wrap ``sqlite3.connect`` so any test that
+    resolves to the user's real ``~/.bookery/library.db`` or anywhere under
+    ``~/.bookery/library/`` fails fast with a clear message.
+
+    Patching at the ``sqlite3.connect`` layer (rather than only
+    ``bookery.db.open_library``) catches callers that imported the helper as
+    ``from bookery.db import open_library`` — those bind the original function
+    object at import time, so monkeypatching the module attribute would miss
+    them.
+
+    This is best-effort: subprocesses that re-import the module do not inherit
+    this monkeypatch, but the autouse env-isolation fixture already covers that
+    case by pre-setting ``BOOKERY_DB`` and ``BOOKERY_LIBRARY_ROOT`` for child
+    processes. Audit shows no test currently spawns the bookery CLI via
+    ``subprocess`` (all ``subprocess.run`` references in ``tests/`` mock
+    external binaries like ``kepubify``).
+
+    See issue #77 (plan-05 step 5).
+    """
+    import sqlite3
+
+    real_connect = sqlite3.connect
+
+    def guarded_connect(database, *args, **kwargs):
+        # ``database`` is typically a str or PathLike. In-memory dbs (":memory:")
+        # and URIs are always safe — only filesystem paths can hit the user dir.
+        if isinstance(database, (str, Path)) and str(database) not in {":memory:", ""}:
+            candidate = Path(str(database))
+            if _is_real_user_path(candidate):
+                raise RuntimeError(
+                    "test isolation guardrail tripped: test attempted to open "
+                    f"the real user catalog path {candidate!s}. Use a "
+                    "tmp_path-scoped DB instead. See CONTRIBUTING.md "
+                    "'Recovering from test pollution'."
+                )
+        return real_connect(database, *args, **kwargs)
+
+    sqlite3.connect = guarded_connect  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        sqlite3.connect = real_connect  # type: ignore[assignment]
+
 
 @pytest.fixture(autouse=True)
 def _isolate_library_root(

--- a/tests/unit/test_guardrail.py
+++ b/tests/unit/test_guardrail.py
@@ -1,0 +1,39 @@
+# ABOUTME: Meta-test for the test-isolation guardrail that blocks tests from
+# ABOUTME: opening the real ~/.bookery/library.db or writing under ~/.bookery/library/.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db import open_library
+
+
+def test_guardrail_blocks_real_user_db() -> None:
+    '''Attempting to open the real user DB path must raise a clear RuntimeError.
+
+    This is the meta-test for the session-scoped guardrail installed by
+    ``tests/conftest.py``. If the guardrail is ever removed or weakened, this
+    test will start touching the user's actual ~/.bookery/library.db -- which
+    is exactly the regression we are guarding against (issue #77).
+    '''
+    real_db = Path.home() / '.bookery' / 'library.db'
+    with pytest.raises(RuntimeError, match=r'test isolation guardrail'):
+        open_library(real_db)
+
+
+def test_guardrail_blocks_paths_under_real_library_dir() -> None:
+    '''Paths inside ~/.bookery/library/ must also be refused.'''
+    nested = Path.home() / '.bookery' / 'library' / 'subdir' / 'library.db'
+    with pytest.raises(RuntimeError, match=r'test isolation guardrail'):
+        open_library(nested)
+
+
+def test_guardrail_allows_tmp_paths(tmp_path: Path) -> None:
+    '''Tmp paths from the autouse fixture must still work normally.'''
+    db_path = tmp_path / 'library.db'
+    conn = open_library(db_path)
+    try:
+        cursor = conn.execute('SELECT 1')
+        assert cursor.fetchone()[0] == 1
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Implements **plan-05 step 5** (`plans/05-catalog-path-truth-hygiene.md`) — a test-isolation guardrail that prevents the regression in #77, where running the full pytest suite was silently writing rows into the user's real `~/.bookery/library.db` (pointing at `/private/var/folders/.../pytest-of-...` paths that no longer existed by the time `bookery sync kobo` ran).

### Strategy

Patch at the `sqlite3.connect` layer rather than wrapping `bookery.db.open_library`. Rationale: most call sites import the helper as `from bookery.db import open_library`, which binds the original function at import time. Monkeypatching the module attribute would miss those callers; patching `sqlite3.connect` catches every code path that ultimately opens a SQLite file. The check resolves the candidate path with `expanduser().resolve()` so symlinks and relative segments cannot sneak past, then refuses anything equal to `~/.bookery/library.db` or under `~/.bookery/library/`.

The guardrail is best-effort against subprocesses (a subprocess that re-imports `bookery.db` will not inherit the in-process monkeypatch). The autouse `_isolate_library_root` fixture already pre-sets `BOOKERY_DB` and `BOOKERY_LIBRARY_ROOT` in `os.environ` for child processes, and an audit of `rg -nP "subprocess\.(run|Popen)" tests/` confirms that no test currently shells out to the bookery CLI — every `subprocess.run` reference in `tests/` mocks external binaries like `kepubify`.

### Pre-existing pollution culprits

**None found.** After installing the guardrail, the full suite (1435 tests) still passes — no existing test was silently touching the real user path. The autouse env-isolation fixture already added in an earlier step was doing its job; the guardrail just makes that guarantee enforceable rather than implicit.

### Changes

- `tests/conftest.py` — new session-scoped autouse fixture `_guardrail_block_real_user_paths` plus a `_is_real_user_path` helper.
- `tests/unit/test_guardrail.py` (new) — meta-test that proves the guardrail fires on the real DB and on nested paths under `~/.bookery/library/`, and that ordinary `tmp_path` DBs still work.
- `CONTRIBUTING.md` — new "Test Isolation" and "Recovering from test pollution" subsections with the `DELETE FROM books WHERE source_path LIKE '/private/var/folders/%' OR source_path LIKE '/tmp/%'` recovery query.
- `README.md` — short pointer to the recovery section.

Closes #77.

## Test plan

- [x] `uv run pytest tests/unit/test_guardrail.py -v` — 3/3 pass (red → green confirmed during TDD)
- [x] `uv run pytest` — 1435 passed, 1 warning (mobi `imghdr` deprecation, unrelated)
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] pre-commit hook (ruff + pyright) — passed