### PR TITLE
feat(cli): add bookery prune to remove rows with missing files (#101, #74)

### DIFF
--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -17,6 +17,7 @@ from bookery.cli.commands import (
     inventory_cmd,
     ls_cmd,
     match_cmd,
+    prune_cmd,
     rematch_cmd,
     remove_cmd,
     search_cmd,
@@ -66,6 +67,7 @@ cli.add_command(inspect_cmd.inspect)
 cli.add_command(inventory_cmd.inventory)
 cli.add_command(ls_cmd.ls)
 cli.add_command(match_cmd.match)
+cli.add_command(prune_cmd.prune)
 cli.add_command(rematch_cmd.rematch)
 cli.add_command(remove_cmd.remove)
 cli.add_command(search_cmd.search)

--- a/src/bookery/cli/commands/prune_cmd.py
+++ b/src/bookery/cli/commands/prune_cmd.py
@@ -1,0 +1,179 @@
+# ABOUTME: The `bookery prune` command for deleting catalog rows whose files are gone.
+# ABOUTME: Default dry-run preview; `-y/--yes` deletes orphans and relies on FK cascade.
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from bookery.cli.options import db_option, resolve_db_path
+from bookery.core.prune import (
+    CheckMode,
+    PruneCandidate,
+    PruneState,
+    classify_catalog,
+)
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+
+console = Console()
+
+
+def _state_label(state: PruneState) -> str:
+    """Render a PruneState as a short, colorized table cell."""
+    if state is PruneState.ORPHAN:
+        return "[red]orphan[/red]"
+    if state is PruneState.SOURCE_MISSING_OUTPUT_PRESENT:
+        return "[yellow]source missing[/yellow]"
+    return "[green]healthy[/green]"
+
+
+def _action_label(state: PruneState, *, dry_run: bool) -> str:
+    """Render the action that will (or would) be taken for this row."""
+    if state is PruneState.ORPHAN:
+        return "would delete" if dry_run else "delete"
+    if state is PruneState.SOURCE_MISSING_OUTPUT_PRESENT:
+        return "warn (keep)"
+    return "keep"
+
+
+def _render_table(
+    candidates: list[PruneCandidate], *, dry_run: bool
+) -> Table:
+    """Build the Rich preview/result table for a prune run."""
+    table = Table(title="Prune candidates")
+    table.add_column("ID", style="dim", width=6, justify="right")
+    table.add_column("Title", style="bold")
+    table.add_column("Source", style="dim")
+    table.add_column("Output", style="dim")
+    table.add_column("State")
+    table.add_column("Action")
+
+    for candidate in candidates:
+        table.add_row(
+            str(candidate.record.id),
+            candidate.record.metadata.title,
+            "ok" if candidate.source_exists else "[red]missing[/red]",
+            (
+                "n/a"
+                if candidate.record.output_path is None
+                else "ok"
+                if candidate.output_exists
+                else "[red]missing[/red]"
+            ),
+            _state_label(candidate.state),
+            _action_label(candidate.state, dry_run=dry_run),
+        )
+
+    return table
+
+
+@click.command("prune")
+@db_option
+@click.option(
+    "--check",
+    "check",
+    type=click.Choice(["source", "output", "both"]),
+    default="both",
+    show_default=True,
+    help="Which paths to test for existence when classifying rows.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    "dry_run",
+    default=True,
+    show_default=True,
+    help="Preview only; do not delete any rows. Defaults to on.",
+)
+@click.option(
+    "-y",
+    "--yes",
+    "auto_accept",
+    is_flag=True,
+    default=False,
+    help="Actually delete orphan rows. Mutually exclusive with --dry-run.",
+)
+def prune(
+    db_path: Path | None,
+    check: CheckMode,
+    dry_run: bool,
+    auto_accept: bool,
+) -> None:
+    """Remove catalog rows whose underlying files are missing.
+
+    Walks the catalog and, for each book, checks the existence of
+    ``source_path`` and/or ``output_path`` (per ``--check``). Three
+    states are reported:
+
+    \b
+      orphan
+          All checked path(s) are missing. Eligible for deletion.
+      source missing
+          ``source_path`` is gone but ``output_path`` is still on disk.
+          The row is kept; rewriting the source pointer is left to a
+          future flag.
+      healthy
+          Nothing to do.
+
+    By default the command runs in dry-run mode and prints a preview
+    table. Pass ``-y/--yes`` to delete the orphan rows. Deletes cascade
+    via foreign keys to ``book_tags``, ``book_genres``, and
+    ``book_field_provenance``.
+    """
+    # Mutual exclusion: --dry-run with -y is operator error. Click's
+    # boolean default means dry_run is True unless the user explicitly
+    # passes --no-dry-run, so we only complain when -y was supplied and
+    # --no-dry-run was not — detected here via the conflict.
+    if auto_accept and dry_run:
+        # If the operator passed -y, treat that as intent to mutate;
+        # only block when they also passed an explicit --dry-run flag.
+        ctx = click.get_current_context()
+        dry_run_source = ctx.get_parameter_source("dry_run")
+        if dry_run_source is click.core.ParameterSource.COMMANDLINE:
+            raise click.UsageError("--dry-run and -y/--yes are mutually exclusive.")
+        dry_run = False
+
+    conn = open_library(resolve_db_path(db_path))
+    try:
+        catalog = LibraryCatalog(conn)
+        candidates = classify_catalog(catalog, check=check)
+
+        if not candidates:
+            console.print("[green]No stale rows found.[/green]")
+            return
+
+        console.print(_render_table(candidates, dry_run=dry_run))
+
+        orphans = [c for c in candidates if c.state is PruneState.ORPHAN]
+        warnings = [
+            c
+            for c in candidates
+            if c.state is PruneState.SOURCE_MISSING_OUTPUT_PRESENT
+        ]
+
+        for candidate in warnings:
+            console.print(
+                f"[yellow]warning:[/yellow] book {candidate.record.id} "
+                f'"{candidate.record.metadata.title}" — source missing but '
+                "output present; row kept (future flag will rewrite source_path)."
+            )
+
+        if dry_run:
+            console.print(
+                f"\n[dim]dry-run:[/dim] {len(orphans)} orphan row(s) would be "
+                f"deleted, {len(warnings)} warning(s). Re-run with -y to apply."
+            )
+            return
+
+        deleted = 0
+        for candidate in orphans:
+            catalog.delete_book(candidate.record.id)
+            deleted += 1
+
+        console.print(
+            f"\n[green]Pruned {deleted} row(s).[/green] "
+            f"{len(warnings)} warning(s) kept."
+        )
+    finally:
+        conn.close()

--- a/src/bookery/core/prune.py
+++ b/src/bookery/core/prune.py
@@ -1,0 +1,96 @@
+# ABOUTME: Orphan-row detection for `bookery prune`.
+# ABOUTME: Classifies catalog rows by on-disk presence of source_path and output_path.
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Literal
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.mapping import BookRecord
+
+CheckMode = Literal["source", "output", "both"]
+
+
+class PruneState(StrEnum):
+    """The disposition of a single catalog row under a prune walk."""
+
+    HEALTHY = "healthy"
+    ORPHAN = "orphan"
+    SOURCE_MISSING_OUTPUT_PRESENT = "source-missing-output-present"
+
+
+@dataclass(frozen=True, slots=True)
+class PruneCandidate:
+    """A single row's prune classification.
+
+    Bundles the record alongside the two on-disk existence flags so the
+    CLI layer can render a table without re-stat'ing files.
+    """
+
+    record: BookRecord
+    source_exists: bool
+    output_exists: bool
+    state: PruneState
+
+
+def classify_row(
+    record: BookRecord, *, check: CheckMode
+) -> PruneCandidate:
+    """Classify a single catalog row by on-disk presence.
+
+    The ``check`` flag controls which paths participate in the orphan
+    decision:
+
+    - ``source``: a row is an orphan iff its ``source_path`` is missing.
+    - ``output``: a row is an orphan iff its ``output_path`` is missing
+      (rows with no ``output_path`` set are treated as healthy under this
+      mode — there's nothing to check).
+    - ``both``: a row is an orphan only when every path under
+      consideration is missing. A row whose source is gone but whose
+      output is still on disk is flagged
+      ``SOURCE_MISSING_OUTPUT_PRESENT`` — a future flag will let the
+      operator rewrite ``source_path`` instead of deleting the row.
+    """
+    source_exists = record.source_path.exists()
+    output_exists = (
+        record.output_path.exists() if record.output_path is not None else False
+    )
+
+    if check == "source":
+        state = PruneState.HEALTHY if source_exists else PruneState.ORPHAN
+    elif check == "output":
+        if record.output_path is None:
+            state = PruneState.HEALTHY
+        else:
+            state = PruneState.HEALTHY if output_exists else PruneState.ORPHAN
+    else:  # both
+        if not source_exists and (record.output_path is None or not output_exists):
+            state = PruneState.ORPHAN
+        elif not source_exists and output_exists:
+            state = PruneState.SOURCE_MISSING_OUTPUT_PRESENT
+        else:
+            state = PruneState.HEALTHY
+
+    return PruneCandidate(
+        record=record,
+        source_exists=source_exists,
+        output_exists=output_exists,
+        state=state,
+    )
+
+
+def classify_catalog(
+    catalog: LibraryCatalog, *, check: CheckMode
+) -> list[PruneCandidate]:
+    """Walk every catalog row and classify each one.
+
+    Healthy rows are omitted — only orphans and the source-missing
+    warning state are returned, in catalog order.
+    """
+    candidates: list[PruneCandidate] = []
+    for record in catalog.list_all():
+        candidate = classify_row(record, check=check)
+        if candidate.state is PruneState.HEALTHY:
+            continue
+        candidates.append(candidate)
+    return candidates

--- a/tests/e2e/test_prune_cli.py
+++ b/tests/e2e/test_prune_cli.py
@@ -1,0 +1,245 @@
+# ABOUTME: End-to-end tests for the `bookery prune` CLI command.
+# ABOUTME: Covers dry-run preview, -y deletion + FK cascade, and source-vs-output check matrix.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+def _seed_book(
+    db_path: Path,
+    *,
+    title: str,
+    file_hash: str,
+    source_path: Path,
+    output_path: Path | None,
+) -> int:
+    """Insert a row pointing at the given source/output paths.
+
+    Caller decides whether each path is on disk — this helper only writes
+    the catalog row.
+    """
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    book_id = catalog.add_book(
+        BookMetadata(
+            title=title,
+            authors=["Test Author"],
+            source_path=source_path,
+        ),
+        file_hash=file_hash,
+        output_path=output_path,
+    )
+    conn.close()
+    return book_id
+
+
+class TestPruneDryRun:
+    def test_default_invocation_is_dry_run_and_renders_table(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        # One healthy book on disk.
+        healthy_src = library_root / "healthy_src.epub"
+        healthy_src.write_bytes(b"src")
+        healthy_out = library_root / "healthy_out.epub"
+        healthy_out.write_bytes(b"out")
+        healthy_id = _seed_book(
+            db_path,
+            title="Healthy",
+            file_hash="hh",
+            source_path=healthy_src,
+            output_path=healthy_out,
+        )
+
+        # One orphan: both paths missing.
+        orphan_id = _seed_book(
+            db_path,
+            title="Orphan",
+            file_hash="ho",
+            source_path=library_root / "gone_src.epub",
+            output_path=library_root / "gone_out.epub",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["prune", "--db", str(db_path)])
+
+        assert result.exit_code == 0, result.output
+        assert str(orphan_id) in result.output
+        assert "Orphan" in result.output
+        assert "dry-run" in result.output.lower()
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        assert catalog.get_by_id(orphan_id) is not None
+        assert catalog.get_by_id(healthy_id) is not None
+        conn.close()
+
+    def test_dry_run_and_yes_are_mutually_exclusive(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        open_library(db_path).close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["prune", "--dry-run", "-y", "--db", str(db_path)]
+        )
+
+        assert result.exit_code != 0
+        out_lower = result.output.lower()
+        assert "mutually exclusive" in out_lower or "cannot" in out_lower
+
+
+class TestPruneSourceMissingOutputPresent:
+    def test_source_gone_output_present_warns_and_keeps_row(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        output_path = library_root / "present_out.epub"
+        output_path.write_bytes(b"out")
+        book_id = _seed_book(
+            db_path,
+            title="Half Orphan",
+            file_hash="hp",
+            source_path=library_root / "gone_src.epub",
+            output_path=output_path,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["prune", "--check", "both", "-y", "--db", str(db_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        out_lower = result.output.lower()
+        assert "warn" in out_lower or "source" in out_lower
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        assert catalog.get_by_id(book_id) is not None, (
+            "row with output present must not be deleted"
+        )
+        conn.close()
+
+
+class TestPruneDelete:
+    def test_both_missing_with_yes_deletes_row_and_cascades(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        book_id = _seed_book(
+            db_path,
+            title="Doomed",
+            file_hash="hd",
+            source_path=library_root / "gone_src.epub",
+            output_path=library_root / "gone_out.epub",
+        )
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        catalog.add_tag(book_id, "favorites")
+        catalog.add_genre(book_id, "Fantasy")
+        catalog.update_book(book_id, source="user", publisher="Acme")
+        assert conn.execute(
+            "SELECT COUNT(*) FROM book_tags WHERE book_id = ?", (book_id,)
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM book_genres WHERE book_id = ?", (book_id,)
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM book_field_provenance WHERE book_id = ?", (book_id,)
+        ).fetchone()[0] >= 1
+        conn.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["prune", "--check", "both", "-y", "--db", str(db_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        assert catalog.get_by_id(book_id) is None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM book_tags WHERE book_id = ?", (book_id,)
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM book_genres WHERE book_id = ?", (book_id,)
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM book_field_provenance WHERE book_id = ?", (book_id,)
+        ).fetchone()[0] == 0
+        conn.close()
+
+    def test_summary_line_reports_deletion_count(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        _seed_book(
+            db_path,
+            title="DoomedA",
+            file_hash="ha",
+            source_path=library_root / "a_src.epub",
+            output_path=library_root / "a_out.epub",
+        )
+        _seed_book(
+            db_path,
+            title="DoomedB",
+            file_hash="hb",
+            source_path=library_root / "b_src.epub",
+            output_path=library_root / "b_out.epub",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["prune", "--check", "both", "-y", "--db", str(db_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "2" in result.output
+
+
+class TestPruneCheckFlag:
+    def test_check_output_ignores_missing_source(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "lib.db"
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        output_path = library_root / "out.epub"
+        output_path.write_bytes(b"out")
+        book_id = _seed_book(
+            db_path,
+            title="OutputOnly",
+            file_hash="ho2",
+            source_path=library_root / "gone.epub",
+            output_path=output_path,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["prune", "--check", "output", "-y", "--db", str(db_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        conn = open_library(db_path)
+        assert LibraryCatalog(conn).get_by_id(book_id) is not None
+        conn.close()
+
+
+class TestPruneHelp:
+    def test_help_lists_prune(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "prune" in result.output

--- a/tests/unit/test_core_prune.py
+++ b/tests/unit/test_core_prune.py
@@ -1,0 +1,148 @@
+# ABOUTME: Unit tests for the orphan-detection helper used by `bookery prune`.
+# ABOUTME: Exercises every (check_mode, source_exists, output_exists) cell on classify_row.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.core.prune import PruneState, classify_row
+from bookery.db.mapping import BookRecord
+from bookery.metadata.types import BookMetadata
+
+
+def _record(
+    *,
+    source_path: Path,
+    output_path: Path | None,
+    book_id: int = 1,
+) -> BookRecord:
+    """Build a BookRecord with just enough fields to drive classify_row."""
+    return BookRecord(
+        id=book_id,
+        metadata=BookMetadata(title="t", authors=["a"], source_path=source_path),
+        file_hash="h",
+        source_path=source_path,
+        output_path=output_path,
+        date_added="now",
+        date_modified="now",
+    )
+
+
+class TestClassifyRowCheckBoth:
+    def test_both_present_is_healthy(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.epub"
+        out = tmp_path / "out.epub"
+        src.write_bytes(b"x")
+        out.write_bytes(b"y")
+
+        result = classify_row(_record(source_path=src, output_path=out), check="both")
+        assert result.state is PruneState.HEALTHY
+        assert result.source_exists
+        assert result.output_exists
+
+    def test_both_missing_is_orphan(self, tmp_path: Path) -> None:
+        result = classify_row(
+            _record(
+                source_path=tmp_path / "gone_src.epub",
+                output_path=tmp_path / "gone_out.epub",
+            ),
+            check="both",
+        )
+        assert result.state is PruneState.ORPHAN
+
+    def test_source_missing_output_present_is_warning(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.epub"
+        out.write_bytes(b"y")
+
+        result = classify_row(
+            _record(source_path=tmp_path / "gone.epub", output_path=out),
+            check="both",
+        )
+        assert result.state is PruneState.SOURCE_MISSING_OUTPUT_PRESENT
+
+    def test_source_present_output_missing_is_orphan(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.epub"
+        src.write_bytes(b"x")
+
+        # source present, output set but missing → not orphan under "both"
+        # because at least one checked path exists.
+        result = classify_row(
+            _record(source_path=src, output_path=tmp_path / "missing_out.epub"),
+            check="both",
+        )
+        assert result.state is PruneState.HEALTHY
+
+    def test_no_output_path_with_source_present_is_healthy(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.epub"
+        src.write_bytes(b"x")
+
+        result = classify_row(
+            _record(source_path=src, output_path=None), check="both"
+        )
+        assert result.state is PruneState.HEALTHY
+
+    def test_no_output_path_with_source_missing_is_orphan(self, tmp_path: Path) -> None:
+        result = classify_row(
+            _record(source_path=tmp_path / "gone.epub", output_path=None),
+            check="both",
+        )
+        assert result.state is PruneState.ORPHAN
+
+
+class TestClassifyRowCheckSource:
+    def test_source_missing_is_orphan_regardless_of_output(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.epub"
+        out.write_bytes(b"y")
+
+        result = classify_row(
+            _record(source_path=tmp_path / "gone.epub", output_path=out),
+            check="source",
+        )
+        assert result.state is PruneState.ORPHAN
+
+    def test_source_present_is_healthy(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.epub"
+        src.write_bytes(b"x")
+
+        result = classify_row(
+            _record(source_path=src, output_path=None), check="source"
+        )
+        assert result.state is PruneState.HEALTHY
+
+
+class TestClassifyRowCheckOutput:
+    def test_output_missing_is_orphan(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.epub"
+        src.write_bytes(b"x")
+
+        result = classify_row(
+            _record(source_path=src, output_path=tmp_path / "missing.epub"),
+            check="output",
+        )
+        assert result.state is PruneState.ORPHAN
+
+    def test_no_output_path_is_healthy(self, tmp_path: Path) -> None:
+        # Nothing to check → no orphan call.
+        result = classify_row(
+            _record(source_path=tmp_path / "gone.epub", output_path=None),
+            check="output",
+        )
+        assert result.state is PruneState.HEALTHY
+
+    def test_output_present_is_healthy(self, tmp_path: Path) -> None:
+        out = tmp_path / "out.epub"
+        out.write_bytes(b"y")
+        result = classify_row(
+            _record(source_path=tmp_path / "gone.epub", output_path=out),
+            check="output",
+        )
+        assert result.state is PruneState.HEALTHY
+
+
+@pytest.mark.parametrize("mode", ["source", "output", "both"])
+def test_state_enum_values_round_trip(mode: str) -> None:
+    """Sanity: enum values are stable strings (used in table rendering)."""
+    assert PruneState.HEALTHY.value == "healthy"
+    assert PruneState.ORPHAN.value == "orphan"
+    assert PruneState.SOURCE_MISSING_OUTPUT_PRESENT.value == "source-missing-output-present"
+    assert mode in {"source", "output", "both"}


### PR DESCRIPTION
## Summary

- Add `bookery prune` to walk the catalog and detect rows whose `source_path` / `output_path` no longer exist on disk.
- Default `--dry-run` renders a Rich preview table; `-y/--yes` deletes orphan rows and relies on the existing FK `ON DELETE CASCADE` to clear `book_tags`, `book_genres`, and `book_field_provenance`.
- Rows whose source is missing but whose output is still on disk are flagged as warnings and kept (a future flag will rewrite the source pointer).

Implements step 4 of [plans/05-catalog-path-truth-hygiene.md](plans/05-catalog-path-truth-hygiene.md). Sync remains read-only — this is the operator-driven hygiene tool the plan calls for.

## CLI surface

```
bookery prune [--check source|output|both] [--dry-run | -y/--yes] [--db PATH]
```

- `--check` defaults to `both`.
- `--dry-run` is on by default and is mutually exclusive with `-y/--yes`.
- Orphan-detection logic factored into `bookery.core.prune.classify_row` for unit testing.

## Test plan

- [x] `uv run pytest tests/unit/test_core_prune.py tests/e2e/test_prune_cli.py` — 21 new tests pass
- [x] `uv run pytest` — full suite (1453 tests) passes
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run bookery prune --help` — help text renders correctly
- [x] Plan test-matrix rows covered:
  - source missing, output present, `prune --check both` → warns, row kept
  - both missing, `prune --check both -y` → row deleted, FK cascades verified for `book_tags` / `book_genres` / `book_field_provenance`
  - `prune` default → dry-run table renders; no DB mutation

Closes #101.
Closes #74.