### PR TITLE
test(import): lock in output_path invariant for unmatched imports (#59)

### DIFF
--- a/tests/e2e/test_import_cli.py
+++ b/tests/e2e/test_import_cli.py
@@ -444,3 +444,50 @@ class TestImportMetadataDedupCli:
         # Summary should contain breakdown info
         assert "hash" in result.output.lower()
         assert "title+author" in result.output.lower()
+
+
+class TestImporterOutputPath:
+    """E2E regression guard for output_path on unmatched imports (issue #59).
+
+    Plan-05 cluster: the CLI `import` command (without --match) must persist a
+    non-NULL output_path under library_root for every cataloged book. This
+    locks the invariant at the CLI boundary so a future refactor can't quietly
+    drop the copy-by-default behavior.
+    """
+
+    def test_unmatched_import_cli_populates_output_path(
+        self, sample_epub: Path, tmp_path: Path,
+    ) -> None:
+        """`bookery import` (no --match) records output_path under library_root."""
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        shutil.copy(sample_epub, scan_dir / "rose.epub")
+
+        db_path = tmp_path / "test.db"
+        library_root = tmp_path / "lib"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, [
+                "import", str(scan_dir),
+                "--db", str(db_path),
+                "-o", str(library_root),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            records = catalog.list_all()
+            assert len(records) == 1
+
+            output_path = records[0].output_path
+            assert output_path is not None, (
+                "unmatched CLI import left output_path NULL — regression on #59"
+            )
+            assert output_path.resolve().is_relative_to(library_root.resolve())
+            assert output_path.exists()
+        finally:
+            conn.close()

--- a/tests/integration/test_catalog_path_truth.py
+++ b/tests/integration/test_catalog_path_truth.py
@@ -1,0 +1,132 @@
+# ABOUTME: Regression guard locking the invariant that unmatched imports
+# ABOUTME: always populate books.output_path with a real file under library_root.
+
+from pathlib import Path
+
+from ebooklib import epub
+
+from bookery.core.importer import import_books
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+
+
+def _make_epub(path: Path, title: str, author: str | None = None) -> Path:
+    """Create a minimal EPUB for catalog-path-truth checks."""
+    book = epub.EpubBook()
+    book.set_identifier(f"id-{title}")
+    book.set_title(title)
+    book.set_language("en")
+    if author:
+        book.add_author(author)
+
+    chapter = epub.EpubHtml(
+        title="Chapter 1", file_name="chap01.xhtml", lang="en",
+    )
+    chapter.content = (
+        b"<html><body><h1>Chapter 1</h1>"
+        b"<p>Content for " + title.encode() + b".</p>"
+        b"</body></html>"
+    )
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+
+    epub.write_epub(str(path), book)
+    return path
+
+
+class TestImporterOutputPath:
+    """Lock in the output_path invariant for unmatched imports (issue #59).
+
+    Plan-05 cluster: the importer must always set books.output_path to a real
+    file under library_root, even when no match pipeline runs. This guards
+    against a future refactor silently leaving output_path NULL, which would
+    poison downstream lookups (web UI, sync, vault export).
+
+    A sibling branch (feature/64-matched-signal) may share this file; this
+    class is namespaced to keep both PRs mergeable.
+    """
+
+    def test_unmatched_import_populates_output_path_under_library_root(
+        self, tmp_path: Path,
+    ) -> None:
+        """Importing without --match sets output_path to a real file in library_root."""
+        db_path = tmp_path / "lib.db"
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        library_root = tmp_path / "lib"
+        library_root.mkdir()
+
+        epub_path = _make_epub(
+            source_dir / "rose.epub", "The Name of the Rose", "Umberto Eco",
+        )
+
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            result = import_books(
+                [epub_path], catalog, library_root=library_root,
+            )
+
+            assert result.added == 1
+            assert result.errors == 0
+
+            records = catalog.list_all()
+            assert len(records) == 1
+
+            output_path = records[0].output_path
+            # Invariant 1: catalog row has output_path populated.
+            assert output_path is not None, (
+                "unmatched import left output_path NULL — regression on #59"
+            )
+            # Invariant 2: output_path resolves under library_root.
+            resolved_root = library_root.resolve()
+            assert output_path.resolve().is_relative_to(resolved_root), (
+                f"output_path {output_path} is not under library_root "
+                f"{library_root}"
+            )
+            # Invariant 3: the file actually exists on disk at output_path.
+            assert output_path.exists(), (
+                f"output_path {output_path} does not exist on disk"
+            )
+        finally:
+            conn.close()
+
+    def test_unmatched_import_of_multiple_files_all_have_output_paths(
+        self, tmp_path: Path,
+    ) -> None:
+        """Every cataloged book from an unmatched batch import has output_path set."""
+        db_path = tmp_path / "lib.db"
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        library_root = tmp_path / "lib"
+        library_root.mkdir()
+
+        _make_epub(source_dir / "a.epub", "Alpha", "Author A")
+        _make_epub(source_dir / "b.epub", "Beta", "Author B")
+        _make_epub(source_dir / "c.epub", "Gamma", "Author C")
+        paths = sorted(source_dir.glob("*.epub"))
+
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            result = import_books(
+                paths, catalog, library_root=library_root,
+            )
+
+            assert result.added == 3
+            records = catalog.list_all()
+            assert len(records) == 3
+
+            resolved_root = library_root.resolve()
+            for record in records:
+                output_path = record.output_path
+                assert output_path is not None, (
+                    f"book {record.metadata.title!r} left output_path NULL"
+                )
+                assert output_path.resolve().is_relative_to(resolved_root)
+                assert output_path.exists()
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

Test-only PR adding a regression guard for the importer's copy-by-default
behavior. The behavior itself already lives on `main` in
`src/bookery/core/importer.py` (PR #65 / commit 152ae6b); these tests lock
the invariant so a future refactor can't silently leave `books.output_path`
NULL for unmatched imports.

Part of the plan-05 cluster (see `plans/plan-05-*.md`).

## Changes

- **`tests/integration/test_catalog_path_truth.py`** (new): drives
  `import_books` end-to-end without `--match` and asserts (1) the catalog
  row has `output_path is not None`, (2) it resolves under `library_root`,
  (3) the file actually exists on disk. Also covers a multi-file batch.
- **`tests/e2e/test_import_cli.py`**: appends `TestImporterOutputPath`
  with a `CliRunner` test asserting the same invariant at the CLI boundary
  (`bookery import -o <library_root>`).

The integration class is namespaced `TestImporterOutputPath` so the
parallel branch `feature/64-matched-signal` — which may also create
`test_catalog_path_truth.py` — remains mergeable.

## Test plan

- [x] `uv run pytest tests/integration/test_catalog_path_truth.py tests/e2e/test_import_cli.py::TestImporterOutputPath -v` — 3 passed on first try (behavior already exists on main)
- [x] `uv run pytest` — 1435 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] pre-commit (ruff + pyright) — clean

Closes #59