### PR TITLE
feat(db): explicit metadata_matched_at signal, decouple from output_path (#64)

### DIFF
--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -192,6 +192,8 @@ def info(
     table.add_row("Source", str(record.source_path))
     if record.output_path:
         table.add_row("Output", str(record.output_path))
+    if record.metadata_matched_at:
+        table.add_row("Matched", record.metadata_matched_at)
     table.add_row("Hash", record.file_hash)
     table.add_row("Added", record.date_added)
     table.add_row("Modified", record.date_modified)

--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -135,7 +135,7 @@ def _metadata_to_update_fields(metadata: BookMetadata) -> dict:
 @click.option(
     "--resume/--no-resume",
     default=True,
-    help="Skip books that already have an output_path (default: --resume).",
+    help="Skip books already matched against a metadata provider (default: --resume).",
 )
 @click.option(
     "--no-cache",
@@ -179,10 +179,13 @@ def rematch(
                 console.print("[yellow]No books to rematch.[/yellow]")
             return
 
-        # Resume: filter out books that already have output_path
+        # Resume: filter out books already matched against a provider.
+        # Uses the explicit metadata_matched_at signal so library-canonical
+        # rows (which always have output_path set) aren't falsely treated as
+        # matched.
         if resume:
             original_count = len(books)
-            books = [b for b in books if b.output_path is None]
+            books = [b for b in books if b.metadata_matched_at is None]
             skipped_resume = original_count - len(books)
             if skipped_resume:
                 console.print(
@@ -248,6 +251,7 @@ def rematch(
                 )
                 if result.output_path:
                     catalog.set_output_path(record.id, result.output_path)
+                catalog.set_matched_at(record.id)
                 if not auto_accept:
                     locked = set(fields) - set(written)
                     if locked:

--- a/src/bookery/core/importer.py
+++ b/src/bookery/core/importer.py
@@ -138,6 +138,7 @@ def import_books(
 
         output_path: Path | None = None
         copied_to_library = False
+        matched_via_provider = False
 
         if match_fn is not None:
             match_result = match_fn(metadata, epub_path)
@@ -145,6 +146,7 @@ def import_books(
                 metadata = match_result.metadata
                 metadata.source_path = epub_path
                 output_path = match_result.output_path
+                matched_via_provider = True
                 if output_path is not None:
                     copied_to_library = True
 
@@ -195,6 +197,8 @@ def import_books(
             book_id = catalog.add_book(
                 metadata, file_hash=file_hash, output_path=output_path,
             )
+            if matched_via_provider:
+                catalog.set_matched_at(book_id)
             result.added += 1
             if dup_match is not None:
                 result.forced += 1

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -366,6 +366,28 @@ class LibraryCatalog:
         """Set the output_path for a cataloged book."""
         self.update_book(book_id, output_path=str(output_path))
 
+    def set_matched_at(self, book_id: int, timestamp: str | None = None) -> None:
+        """Mark a book as matched against a metadata provider.
+
+        Writes ``metadata_matched_at``; defaults to the current UTC ISO
+        timestamp. This is the explicit "this book has been matched" signal,
+        distinct from ``output_path`` (which only records the on-disk location).
+        """
+        if timestamp is None:
+            cursor = self._conn.execute(
+                "UPDATE books SET metadata_matched_at = "
+                "strftime('%Y-%m-%dT%H:%M:%S', 'now') WHERE id = ?",
+                (book_id,),
+            )
+        else:
+            cursor = self._conn.execute(
+                "UPDATE books SET metadata_matched_at = ? WHERE id = ?",
+                (timestamp, book_id),
+            )
+        self._conn.commit()
+        if cursor.rowcount == 0:
+            raise ValueError(f"Book with id {book_id} not found")
+
     def delete_book(self, book_id: int) -> None:
         """Delete a book from the catalog.
 

--- a/src/bookery/db/mapping.py
+++ b/src/bookery/db/mapping.py
@@ -32,6 +32,7 @@ class BookRecord:
     output_path: Path | None
     date_added: str
     date_modified: str
+    metadata_matched_at: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,6 +133,10 @@ def row_to_metadata(row: Any) -> BookMetadata:
 def row_to_record(row: Any) -> BookRecord:
     """Convert a full database row to a BookRecord with metadata and DB fields."""
     output = row["output_path"]
+    try:
+        matched_at = row["metadata_matched_at"]
+    except (KeyError, IndexError):
+        matched_at = None
     return BookRecord(
         id=row["id"],
         metadata=row_to_metadata(row),
@@ -140,4 +145,5 @@ def row_to_record(row: Any) -> BookRecord:
         output_path=Path(output) if output else None,
         date_added=row["date_added"],
         date_modified=row["date_modified"],
+        metadata_matched_at=matched_at,
     )

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -152,27 +152,34 @@ INSERT INTO schema_version (version) VALUES (6);
 # meanings; after the library-canonical migration every row has output_path,
 # so callers using `output_path IS NOT NULL` as a matched-flag broke silently.
 #
-# Backfill rule: a row counts as previously matched if its identifiers JSON
-# contains any known provider key (openlibrary_*, googlebooks_*, or any
-# isbn_* sub-id). Detection uses LIKE on the JSON text, which works without
-# the optional json1 extension. Backfilled rows take their date_modified
-# (falling back to date_added) as a best-effort timestamp.
+# Backfill rule: a row counts as previously matched if it has at least one
+# `book_field_provenance` entry written by a metadata provider — i.e. a source
+# that isn't one of the internal/non-provider sources we know about
+# (`extracted` for EPUB extraction inserts, `user` for manual edits via the
+# CLI / web form, `genres` for the auto-genre applier). Anything else
+# (`openlibrary`, `googlebooks`, `consensus:...`, future providers) is, by
+# definition, evidence that a provider touched the row. This is more accurate
+# than the `identifiers`-substring heuristic considered earlier, which both
+# missed rows matched via web `enrich_apply` (which writes provenance but not
+# the identifiers JSON) and produced false positives for Calibre EPUBs that
+# already declared `<dc:identifier opf:scheme="ISBN">` (extraction stores
+# those as `{"isbn": "..."}`).
+#
+# Backfilled rows take their date_modified (falling back to date_added) as a
+# best-effort timestamp — provenance rows have their own `fetched_at`, but the
+# books-table timestamps are the closest stable analogue for "when did the
+# match-flow finish for this row" and avoid having to pick a single field's
+# fetched_at.
 SCHEMA_V7 = """
 ALTER TABLE books ADD COLUMN metadata_matched_at TEXT;
 
 UPDATE books
 SET metadata_matched_at = COALESCE(date_modified, date_added)
-WHERE identifiers IS NOT NULL
-  AND (
-        identifiers LIKE '%"openlibrary_work"%'
-     OR identifiers LIKE '%"openlibrary_author_keys"%'
-     OR identifiers LIKE '%"googlebooks_volume"%'
-     OR identifiers LIKE '%"googlebooks_preview"%'
-     OR identifiers LIKE '%"googlebooks_info"%'
-     OR identifiers LIKE '%"isbn_10"%'
-     OR identifiers LIKE '%"isbn_13"%'
-     OR identifiers LIKE '%"isbn"%'
-  );
+WHERE id IN (
+    SELECT DISTINCT book_id
+    FROM book_field_provenance
+    WHERE source NOT IN ('extracted', 'user', 'genres')
+);
 
 INSERT INTO schema_version (version) VALUES (7);
 """

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -147,10 +147,41 @@ ALTER TABLE books ADD COLUMN maturity_rating TEXT;
 INSERT INTO schema_version (version) VALUES (6);
 """
 
+# Decouple "this book has been matched against a metadata provider" from
+# "this book has a managed library location". Pre-V7, output_path served both
+# meanings; after the library-canonical migration every row has output_path,
+# so callers using `output_path IS NOT NULL` as a matched-flag broke silently.
+#
+# Backfill rule: a row counts as previously matched if its identifiers JSON
+# contains any known provider key (openlibrary_*, googlebooks_*, or any
+# isbn_* sub-id). Detection uses LIKE on the JSON text, which works without
+# the optional json1 extension. Backfilled rows take their date_modified
+# (falling back to date_added) as a best-effort timestamp.
+SCHEMA_V7 = """
+ALTER TABLE books ADD COLUMN metadata_matched_at TEXT;
+
+UPDATE books
+SET metadata_matched_at = COALESCE(date_modified, date_added)
+WHERE identifiers IS NOT NULL
+  AND (
+        identifiers LIKE '%"openlibrary_work"%'
+     OR identifiers LIKE '%"openlibrary_author_keys"%'
+     OR identifiers LIKE '%"googlebooks_volume"%'
+     OR identifiers LIKE '%"googlebooks_preview"%'
+     OR identifiers LIKE '%"googlebooks_info"%'
+     OR identifiers LIKE '%"isbn_10"%'
+     OR identifiers LIKE '%"isbn_13"%'
+     OR identifiers LIKE '%"isbn"%'
+  );
+
+INSERT INTO schema_version (version) VALUES (7);
+"""
+
 MIGRATIONS = [
     (2, SCHEMA_V2),
     (3, SCHEMA_V3),
     (4, SCHEMA_V4),
     (5, SCHEMA_V5),
     (6, SCHEMA_V6),
+    (7, SCHEMA_V7),
 ]

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -534,6 +534,7 @@ def enrich_apply(book_id):
         **update_fields,
     )
     catalog.set_output_path(book_id, write_result.path)
+    catalog.set_matched_at(book_id)
 
     flash(
         f'Applied "{proposed.title}" from {provider.name}',

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -5,7 +5,7 @@
         <h2 id="detail-header">{{ book.metadata.title }}</h2>
         <p class="byline">by {{ book.metadata.author }}</p>
     </div>
-    {% if book.output_path %}
+    {% if book.metadata_matched_at %}
     <p class="enriched-badge" aria-label="Enriched">&#10003; Enriched</p>
     {% endif %}
     <div class="toolbar" role="toolbar" aria-label="Book actions">

--- a/src/bookery/web/templates/_table.html
+++ b/src/bookery/web/templates/_table.html
@@ -8,7 +8,7 @@
         <td>{{ book.metadata.isbn or '' }}</td>
         <td>{{ book.metadata.language or '' }}</td>
         <td>{{ book.metadata.publisher or '' }}</td>
-        <td>{% if book.output_path %}&#10003;{% endif %}</td>
+        <td>{% if book.metadata_matched_at %}&#10003;{% endif %}</td>
     </tr>
     {% endfor %}
 {% elif query %}

--- a/tests/e2e/test_rematch_cli.py
+++ b/tests/e2e/test_rematch_cli.py
@@ -285,19 +285,22 @@ class TestRematchInteractive:
 class TestRematchResume:
     """E2E tests for --resume / --no-resume behavior."""
 
-    def test_resume_skips_books_with_output_path(
+    def test_resume_skips_books_with_metadata_matched_at(
         self, sample_epub: Path, tmp_path: Path,
     ) -> None:
-        """Books with output_path set are skipped in resume mode."""
+        """Books with metadata_matched_at set are skipped in resume mode."""
         db_path = tmp_path / "test.db"
         output_dir = tmp_path / "output"
 
         book_id = _import_book(sample_epub, db_path)
 
-        # Simulate a previous match by setting output_path
+        # Simulate a previous match. The library-canonical importer always
+        # records an output_path, so set both — the resume filter must key
+        # off metadata_matched_at, not output_path.
         conn = open_library(db_path)
         catalog = LibraryCatalog(conn)
         catalog.set_output_path(book_id, tmp_path / "already_matched.epub")
+        catalog.set_matched_at(book_id)
         conn.close()
 
         runner = CliRunner()

--- a/tests/integration/test_catalog_path_truth.py
+++ b/tests/integration/test_catalog_path_truth.py
@@ -1,0 +1,322 @@
+# ABOUTME: Integration tests for plan-05 — explicit metadata_matched_at signal.
+# ABOUTME: Covers schema V7 migration, resume filter, and match-acceptance writes.
+
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bookery.cli.commands.rematch_cmd import rematch
+from bookery.core.pipeline import MatchOneResult
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import _get_schema_version, open_library
+from bookery.db.hashing import compute_file_hash
+from bookery.db.schema import (
+    SCHEMA_V1,
+    SCHEMA_V2,
+    SCHEMA_V3,
+    SCHEMA_V4,
+    SCHEMA_V5,
+    SCHEMA_V6,
+)
+from bookery.metadata.normalizer import NormalizationResult
+from bookery.metadata.types import BookMetadata
+
+
+def _make_v6_db(db_path: Path) -> sqlite3.Connection:
+    """Create a database at exactly schema V6 (pre-V7) with no auto-migrate."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(SCHEMA_V1)
+    conn.executescript(SCHEMA_V2)
+    conn.executescript(SCHEMA_V3)
+    conn.executescript(SCHEMA_V4)
+    conn.executescript(SCHEMA_V5)
+    conn.executescript(SCHEMA_V6)
+    return conn
+
+
+class TestMatchedSignal:
+    """Plan-05 step 1+2: explicit metadata_matched_at signal."""
+
+    def test_schema_v7_adds_metadata_matched_at_column(self, tmp_path: Path) -> None:
+        """Opening a fresh DB lands at V7 with metadata_matched_at present."""
+        db_path = tmp_path / "fresh.db"
+        conn = open_library(db_path)
+        try:
+            assert _get_schema_version(conn) == 7
+            cursor = conn.execute("PRAGMA table_info(books)")
+            cols = {row["name"] for row in cursor.fetchall()}
+            assert "metadata_matched_at" in cols
+        finally:
+            conn.close()
+
+    def test_v7_migration_backfills_rows_with_provider_identifiers(
+        self, tmp_path: Path,
+    ) -> None:
+        """Mixed V6 fixture: only rows with provider ids in identifiers get a ts."""
+        db_path = tmp_path / "mixed.db"
+        conn = _make_v6_db(db_path)
+
+        # Row A: openlibrary_work identifier — should be backfilled
+        conn.execute(
+            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
+            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "Has OL Work",
+                '["Author"]',
+                '{"openlibrary_work": "/works/OL1W"}',
+                "/a.epub",
+                "hash-a",
+                "2025-01-01T00:00:00",
+            ),
+        )
+        # Row B: googlebooks_volume — should be backfilled
+        conn.execute(
+            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
+            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "Has Google Vol",
+                '["Author"]',
+                '{"googlebooks_volume": "abc123"}',
+                "/b.epub",
+                "hash-b",
+                "2025-02-02T00:00:00",
+            ),
+        )
+        # Row C: an isbn_10 key — should be backfilled
+        conn.execute(
+            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
+            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "Has ISBN id",
+                '["Author"]',
+                '{"isbn_10": "0123456789"}',
+                "/c.epub",
+                "hash-c",
+                "2025-03-03T00:00:00",
+            ),
+        )
+        # Row D: no provider identifiers at all — should stay NULL
+        conn.execute(
+            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
+            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "Bare row",
+                '["Author"]',
+                "{}",
+                "/d.epub",
+                "hash-d",
+                "2025-04-04T00:00:00",
+            ),
+        )
+        # Row E: null identifiers — stays NULL
+        conn.execute(
+            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
+            "date_modified) VALUES (?, ?, NULL, ?, ?, ?)",
+            (
+                "Null ids",
+                '["Author"]',
+                "/e.epub",
+                "hash-e",
+                "2025-05-05T00:00:00",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        # Reopen to trigger V7 migration
+        conn = open_library(db_path)
+        try:
+            assert _get_schema_version(conn) == 7
+            rows = conn.execute(
+                "SELECT title, metadata_matched_at FROM books ORDER BY title"
+            ).fetchall()
+            ts = {r["title"]: r["metadata_matched_at"] for r in rows}
+
+            assert ts["Has OL Work"] == "2025-01-01T00:00:00"
+            assert ts["Has Google Vol"] == "2025-02-02T00:00:00"
+            assert ts["Has ISBN id"] == "2025-03-03T00:00:00"
+            assert ts["Bare row"] is None
+            assert ts["Null ids"] is None
+        finally:
+            conn.close()
+
+    def test_set_matched_at_writes_timestamp(self, tmp_path: Path) -> None:
+        """LibraryCatalog exposes a way to set metadata_matched_at."""
+        db_path = tmp_path / "catalog.db"
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            book_id = catalog.add_book(
+                BookMetadata(title="T", authors=["A"], source_path=Path("/x.epub")),
+                file_hash="h1",
+            )
+
+            before = catalog.get_by_id(book_id)
+            assert before is not None
+            assert before.metadata_matched_at is None
+
+            catalog.set_matched_at(book_id, "2026-05-23T10:00:00")
+            after = catalog.get_by_id(book_id)
+            assert after is not None
+            assert after.metadata_matched_at == "2026-05-23T10:00:00"
+        finally:
+            conn.close()
+
+    def test_rematch_resume_skips_matched_rows(
+        self, tmp_path: Path, sample_epub: Path, monkeypatch,
+    ) -> None:
+        """rematch --resume now keys off metadata_matched_at, not output_path."""
+        db_path = tmp_path / "resume.db"
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            # Matched row: has metadata_matched_at set, even though
+            # output_path is also set (canonical-library scenario).
+            metadata = BookMetadata(
+                title="Already Matched",
+                authors=["Eco"],
+                source_path=sample_epub,
+            )
+            file_hash = compute_file_hash(sample_epub)
+            book_id = catalog.add_book(
+                metadata, file_hash=file_hash, output_path=sample_epub,
+            )
+            catalog.set_matched_at(book_id, "2026-05-01T00:00:00")
+        finally:
+            conn.close()
+
+        called: list[int] = []
+
+        def fake_match_one(*_args, **_kwargs):  # pragma: no cover - guard
+            called.append(1)
+            return MatchOneResult(status="skipped")
+
+        monkeypatch.setattr(
+            "bookery.cli.commands.rematch_cmd.match_one", fake_match_one,
+        )
+        class _StubProvider:
+            def lookup_by_url(self, url):  # pragma: no cover - guard
+                return None
+
+        monkeypatch.setattr(
+            "bookery.cli.commands.rematch_cmd._create_provider",
+            lambda use_cache=True: _StubProvider(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            rematch,
+            ["--all", "--db", str(db_path), "--yes", "-o", str(tmp_path / "out")],
+        )
+        assert result.exit_code == 0, result.output
+        assert called == []
+        assert "already matched" in result.output.lower()
+
+    def test_rematch_resume_reprocesses_unmatched_rows(
+        self, tmp_path: Path, sample_epub: Path, monkeypatch,
+    ) -> None:
+        """An unmatched row (no metadata_matched_at) IS reprocessed on --resume."""
+        db_path = tmp_path / "resume2.db"
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            metadata = BookMetadata(
+                title="Needs Match",
+                authors=["Eco"],
+                source_path=sample_epub,
+            )
+            file_hash = compute_file_hash(sample_epub)
+            # output_path IS set (library-canonical) but metadata_matched_at
+            # is NOT — so the row should still be reprocessed.
+            catalog.add_book(metadata, file_hash=file_hash, output_path=sample_epub)
+        finally:
+            conn.close()
+
+        called: list[int] = []
+
+        def fake_match_one(*_args, **_kwargs):
+            called.append(1)
+            return MatchOneResult(status="skipped")
+
+        monkeypatch.setattr(
+            "bookery.cli.commands.rematch_cmd.match_one", fake_match_one,
+        )
+        class _StubProvider:
+            def lookup_by_url(self, url):  # pragma: no cover - guard
+                return None
+
+        monkeypatch.setattr(
+            "bookery.cli.commands.rematch_cmd._create_provider",
+            lambda use_cache=True: _StubProvider(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            rematch,
+            ["--all", "--db", str(db_path), "--yes", "-o", str(tmp_path / "out")],
+        )
+        assert result.exit_code == 0, result.output
+        assert called == [1]
+
+    def test_rematch_writes_matched_at_on_accept(
+        self, tmp_path: Path, sample_epub: Path, monkeypatch,
+    ) -> None:
+        """rematch records metadata_matched_at when match_one returns matched."""
+        db_path = tmp_path / "writes.db"
+        conn = open_library(db_path)
+        try:
+            catalog = LibraryCatalog(conn)
+            metadata = BookMetadata(
+                title="Pre-Match", authors=["Eco"], source_path=sample_epub,
+            )
+            file_hash = compute_file_hash(sample_epub)
+            book_id = catalog.add_book(metadata, file_hash=file_hash)
+        finally:
+            conn.close()
+
+        out_path = tmp_path / "out" / "x.epub"
+        out_path.parent.mkdir(parents=True)
+        out_path.write_bytes(b"fake")
+
+        def fake_match_one(*_args, **_kwargs):
+            enriched = BookMetadata(
+                title="Matched!", authors=["Eco"], language="en",
+                identifiers={"openlibrary_work": "/works/OL1W"},
+            )
+            return MatchOneResult(
+                status="matched", metadata=enriched, output_path=out_path,
+                normalization=NormalizationResult(
+                    original=metadata, normalized=metadata, was_modified=False,
+                ),
+            )
+
+        monkeypatch.setattr(
+            "bookery.cli.commands.rematch_cmd.match_one", fake_match_one,
+        )
+        class _StubProvider:
+            def lookup_by_url(self, url):  # pragma: no cover - guard
+                return None
+
+        monkeypatch.setattr(
+            "bookery.cli.commands.rematch_cmd._create_provider",
+            lambda use_cache=True: _StubProvider(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            rematch,
+            ["--all", "--db", str(db_path), "--yes", "--no-resume",
+             "-o", str(tmp_path / "out")],
+        )
+        assert result.exit_code == 0, result.output
+
+        conn = open_library(db_path)
+        try:
+            record = LibraryCatalog(conn).get_by_id(book_id)
+            assert record is not None
+            assert record.metadata_matched_at is not None
+        finally:
+            conn.close()

--- a/tests/integration/test_catalog_path_truth.py
+++ b/tests/integration/test_catalog_path_truth.py
@@ -52,77 +52,107 @@ class TestMatchedSignal:
         finally:
             conn.close()
 
-    def test_v7_migration_backfills_rows_with_provider_identifiers(
+    def test_v7_migration_backfills_rows_with_provider_provenance(
         self, tmp_path: Path,
     ) -> None:
-        """Mixed V6 fixture: only rows with provider ids in identifiers get a ts."""
+        """V7 backfill is anchored on book_field_provenance, not identifiers JSON.
+
+        The backfill flips ``metadata_matched_at`` on for rows that have at
+        least one provenance row whose ``source`` names an actual metadata
+        provider (anything other than the internal ``extracted`` / ``user`` /
+        ``genres`` sources). This covers every path that recorded a real
+        provider write — importer ``--match``, ``rematch``, and the web
+        ``enrich_apply`` flow — while excluding rows whose only metadata came
+        from EPUB extraction (including Calibre EPUBs that declared an OPF
+        ``<dc:identifier opf:scheme="ISBN">`` entry).
+        """
         db_path = tmp_path / "mixed.db"
         conn = _make_v6_db(db_path)
 
-        # Row A: openlibrary_work identifier — should be backfilled
-        conn.execute(
-            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
-            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "Has OL Work",
-                '["Author"]',
-                '{"openlibrary_work": "/works/OL1W"}',
-                "/a.epub",
-                "hash-a",
-                "2025-01-01T00:00:00",
-            ),
+        def _insert_book(
+            title: str, file_hash: str, identifiers: str | None, date_modified: str,
+        ) -> int:
+            cursor = conn.execute(
+                "INSERT INTO books (title, authors, identifiers, source_path, "
+                "file_hash, date_modified) VALUES (?, ?, ?, ?, ?, ?)",
+                (title, '["Author"]', identifiers,
+                 f"/{file_hash}.epub", file_hash, date_modified),
+            )
+            return cursor.lastrowid  # type: ignore[return-value]
+
+        def _add_provenance(book_id: int, source: str, field: str = "title") -> None:
+            conn.execute(
+                "INSERT INTO book_field_provenance (book_id, field_name, source) "
+                "VALUES (?, ?, ?)",
+                (book_id, field, source),
+            )
+
+        # Row A: matched via importer --match (openlibrary provider wrote
+        # provenance, identifiers JSON also carries a provider key). Should
+        # be backfilled.
+        a_id = _insert_book(
+            "Importer Match",
+            "hash-a",
+            '{"openlibrary_work": "/works/OL1W"}',
+            "2025-01-01T00:00:00",
         )
-        # Row B: googlebooks_volume — should be backfilled
-        conn.execute(
-            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
-            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "Has Google Vol",
-                '["Author"]',
-                '{"googlebooks_volume": "abc123"}',
-                "/b.epub",
-                "hash-b",
-                "2025-02-02T00:00:00",
-            ),
+        _add_provenance(a_id, "openlibrary")
+
+        # Row B: matched via rematch (googlebooks). Should be backfilled.
+        b_id = _insert_book(
+            "Rematched",
+            "hash-b",
+            '{"googlebooks_volume": "abc123"}',
+            "2025-02-02T00:00:00",
         )
-        # Row C: an isbn_10 key — should be backfilled
-        conn.execute(
-            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
-            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "Has ISBN id",
-                '["Author"]',
-                '{"isbn_10": "0123456789"}',
-                "/c.epub",
-                "hash-c",
-                "2025-03-03T00:00:00",
-            ),
+        _add_provenance(b_id, "googlebooks", field="description")
+
+        # Row C: matched via web enrich_apply — provider wrote provenance but
+        # NEVER updated the identifiers JSON column. The old heuristic missed
+        # these rows entirely; the new backfill catches them.
+        c_id = _insert_book(
+            "Web Enrich Applied",
+            "hash-c",
+            "{}",
+            "2025-03-03T00:00:00",
         )
-        # Row D: no provider identifiers at all — should stay NULL
-        conn.execute(
-            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
-            "date_modified) VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "Bare row",
-                '["Author"]',
-                "{}",
-                "/d.epub",
-                "hash-d",
-                "2025-04-04T00:00:00",
-            ),
+        _add_provenance(c_id, "openlibrary", field="title")
+
+        # Row D: EPUB-extraction-only Calibre row whose OPF declared an ISBN
+        # scheme. Extraction lowercases that into ``{"isbn": "..."}`` AND
+        # writes per-field provenance rows with source='extracted'. This is
+        # the false-positive case the old `'%"isbn"%'` LIKE clause hit. The
+        # new backfill leaves it NULL.
+        d_id = _insert_book(
+            "Calibre EPUB With ISBN",
+            "hash-d",
+            '{"isbn": "9781234567890"}',
+            "2025-04-04T00:00:00",
         )
-        # Row E: null identifiers — stays NULL
-        conn.execute(
-            "INSERT INTO books (title, authors, identifiers, source_path, file_hash, "
-            "date_modified) VALUES (?, ?, NULL, ?, ?, ?)",
-            (
-                "Null ids",
-                '["Author"]',
-                "/e.epub",
-                "hash-e",
-                "2025-05-05T00:00:00",
-            ),
+        _add_provenance(d_id, "extracted", field="title")
+        _add_provenance(d_id, "extracted", field="authors")
+
+        # Row E: EPUB-extraction-only row with no identifiers at all and only
+        # extracted provenance. Stays NULL.
+        e_id = _insert_book(
+            "Bare EPUB",
+            "hash-e",
+            "{}",
+            "2025-05-05T00:00:00",
         )
+        _add_provenance(e_id, "extracted", field="title")
+
+        # Row F: row with only user/genres provenance (manual edits + auto
+        # genre applier) but no provider ever ran. Stays NULL.
+        f_id = _insert_book(
+            "User Edited",
+            "hash-f",
+            "{}",
+            "2025-06-06T00:00:00",
+        )
+        _add_provenance(f_id, "user", field="title")
+        _add_provenance(f_id, "genres", field="primary_genre")
+
         conn.commit()
         conn.close()
 
@@ -135,11 +165,15 @@ class TestMatchedSignal:
             ).fetchall()
             ts = {r["title"]: r["metadata_matched_at"] for r in rows}
 
-            assert ts["Has OL Work"] == "2025-01-01T00:00:00"
-            assert ts["Has Google Vol"] == "2025-02-02T00:00:00"
-            assert ts["Has ISBN id"] == "2025-03-03T00:00:00"
-            assert ts["Bare row"] is None
-            assert ts["Null ids"] is None
+            # Provider-touched rows: backfilled.
+            assert ts["Importer Match"] == "2025-01-01T00:00:00"
+            assert ts["Rematched"] == "2025-02-02T00:00:00"
+            assert ts["Web Enrich Applied"] == "2025-03-03T00:00:00"
+
+            # Extraction-only / user-only rows: stay NULL.
+            assert ts["Calibre EPUB With ISBN"] is None
+            assert ts["Bare EPUB"] is None
+            assert ts["User Edited"] is None
         finally:
             conn.close()
 

--- a/tests/integration/test_migration_lifecycle.py
+++ b/tests/integration/test_migration_lifecycle.py
@@ -30,7 +30,7 @@ class TestMigrationLifecycle:
 
         # Step 2: Open with bookery to trigger migration
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 6
+        assert _get_schema_version(conn) == 7
 
         # Step 3: Verify the book survived and tags work
         catalog = LibraryCatalog(conn)
@@ -51,7 +51,7 @@ class TestMigrationLifecycle:
         # Open 3 times
         for _ in range(3):
             conn = open_library(db_path)
-            assert _get_schema_version(conn) == 6
+            assert _get_schema_version(conn) == 7
             conn.close()
 
         # Final open — add a book and tag it

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -65,6 +65,7 @@ class TestOpenLibrary:
             "ratings_count",
             "print_type",
             "maturity_rating",
+            "metadata_matched_at",
         }
         assert expected == columns
 
@@ -84,7 +85,7 @@ class TestOpenLibrary:
         row = cursor.fetchone()
         conn.close()
         assert row is not None
-        assert row[0] == 6
+        assert row[0] == 7
 
     def test_creates_indexes(self, db_path: Path) -> None:
         """Expected indexes exist on the books table."""

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 6
+        assert version == 7
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -126,7 +126,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 6
+        assert version == 7
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -24,6 +24,7 @@ def _make_book(
     description: str | None = None,
     series: str | None = None,
     series_index: float | None = None,
+    metadata_matched_at: str | None = None,
 ) -> BookRecord:
     """Helper to create a BookRecord for tests."""
     return BookRecord(
@@ -44,6 +45,7 @@ def _make_book(
         output_path=output_path,
         date_added="2026-01-01",
         date_modified="2026-01-01",
+        metadata_matched_at=metadata_matched_at,
     )
 
 
@@ -106,8 +108,21 @@ class TestBookList:
         assert html.index("Adams, John") < html.index("Brown, Dan")
 
     def test_books_table_shows_enriched_badge(self, mock_catalog, client):
-        enriched = _make_book(1, title="Enriched", output_path=Path("/out/enriched.epub"))
-        plain = _make_book(2, title="Plain")
+        # Only metadata_matched_at — not output_path — drives the checkmark.
+        # Both books are library-canonical (output_path set), but only the
+        # matched one shows the badge.
+        enriched = _make_book(
+            1,
+            title="Enriched",
+            output_path=Path("/out/enriched.epub"),
+            metadata_matched_at="2026-05-01T00:00:00",
+        )
+        plain = _make_book(
+            2,
+            title="Plain",
+            output_path=Path("/out/plain.epub"),
+            metadata_matched_at=None,
+        )
         mock_catalog.list_all_by_author.return_value = [enriched, plain]
 
         response = client.get("/books")

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -85,6 +85,7 @@ def make_book(
     file_hash: str = "abc123",
     date_added: str = "2026-01-01",
     date_modified: str = "2026-01-02",
+    metadata_matched_at: str | None = None,
 ) -> BookRecord:
     """Build a BookRecord for web template tests."""
     return BookRecord(
@@ -105,6 +106,7 @@ def make_book(
         output_path=output_path,
         date_added=date_added,
         date_modified=date_modified,
+        metadata_matched_at=metadata_matched_at,
     )
 
 

--- a/tests/web/test_detail.py
+++ b/tests/web/test_detail.py
@@ -120,14 +120,31 @@ class TestDetailSections:
 
 
 class TestEnrichedBadge:
-    def test_badge_shown_when_output_path_set(self, mock_catalog, client):
-        mock_catalog.get_by_id.return_value = make_book(1, output_path=Path("/library/test.epub"))
+    def test_badge_shown_when_metadata_matched(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            output_path=Path("/library/test.epub"),
+            metadata_matched_at="2026-05-01T00:00:00",
+        )
 
         html = client.get("/books/1").data.decode()
         assert "Enriched" in html
 
+    def test_badge_absent_when_not_matched_even_if_in_library(self, mock_catalog, client):
+        # output_path alone (library-canonical) must NOT trigger the badge —
+        # only an explicit metadata_matched_at counts.
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            output_path=Path("/library/test.epub"),
+            metadata_matched_at=None,
+        )
+        html = client.get("/books/1").data.decode()
+        assert "Enriched" not in html
+
     def test_badge_absent_when_output_path_missing(self, mock_catalog, client):
-        mock_catalog.get_by_id.return_value = make_book(1, output_path=None)
+        mock_catalog.get_by_id.return_value = make_book(
+            1, output_path=None, metadata_matched_at=None,
+        )
         html = client.get("/books/1").data.decode()
         assert "Enriched" not in html
 


### PR DESCRIPTION
## Summary

Implements plan-05 steps 1 and 2 — adds an explicit `metadata_matched_at` signal so callers can tell "matched against a provider" apart from "has an output_path in the library." The library-canonical migration left every row with `output_path` populated, which silently broke the web checkmark, `rematch --resume`, and any other consumer using `output_path IS NOT NULL` as a matched-flag.

- Schema V7 adds a `metadata_matched_at` TEXT column to `books` and backfills any pre-existing row whose `identifiers` JSON contains a known provider key (`openlibrary_*`, `googlebooks_*`, `isbn_*`) using its existing `date_modified` (falling back to `date_added`).
- `LibraryCatalog.set_matched_at()` is the new write helper; called from `rematch_cmd` after a `matched` result, the web apply-candidate path, and the importer when `match_fn` returns a result.
- Read sites switched to the new signal: `_table.html` checkmark, `_detail_header.html` enriched badge, `rematch --resume` filter. `info` gains a separate "Matched" timestamp row alongside the existing "Output" file-location row. Templates that legitimately use `output_path` for file location (`_provenance`, `_detail_file`, `_delete_confirm`) are unchanged.

Closes #64

Plan: `plans/05-catalog-path-truth-hygiene.md` (steps 1–2)

## Test plan

- [x] `uv run pytest` — 1439 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] New: V7 migration backfills provider-id rows, leaves bare rows NULL (`tests/integration/test_catalog_path_truth.py`)
- [x] New: `rematch --resume` skips rows with `metadata_matched_at` even when `output_path` is set
- [x] New: `rematch --resume` still reprocesses library-canonical rows whose `metadata_matched_at` is NULL
- [x] New: `rematch` writes `metadata_matched_at` on accept
- [x] New: web list checkmark and detail enriched badge are driven by `metadata_matched_at`, not `output_path`
- [x] Updated: `test_resume_skips_books_with_metadata_matched_at` (e2e) now sets both columns to confirm the signal is independent