### PR TITLE
feat(web): paginated /books with BrowseQuery + result count

### DIFF
--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -25,6 +25,26 @@ class DuplicateBookError(Exception):
     """Raised when attempting to add a book with a file_hash that already exists."""
 
 
+def _fts_match_expression(q: str) -> str:
+    """Build a safe FTS5 MATCH expression from raw user input.
+
+    FTS5 reserves characters like ``:`` (column filter), ``"`` (phrase),
+    ``*`` (prefix), ``()`` (grouping), and bare words ``AND``/``OR``/``NOT``/
+    ``NEAR`` as operators. Passing raw user input through directly will
+    raise ``sqlite3.OperationalError`` when those tokens appear (e.g.
+    ``dune:`` is read as a column filter against a non-existent column).
+
+    The fix is to wrap each whitespace-separated token as an FTS5 phrase
+    (``"token"``) with internal double-quotes doubled to escape them.
+    Multiple phrases combine via FTS5's implicit AND, so ``rose garden``
+    still requires both tokens.
+    """
+    tokens = q.split()
+    if not tokens:
+        return ""
+    return " ".join('"' + tok.replace('"', '""') + '"' for tok in tokens)
+
+
 class LibraryCatalog:
     """Wraps a sqlite3 connection and provides typed CRUD for the books table."""
 
@@ -169,12 +189,15 @@ class LibraryCatalog:
         Returns:
             List of matching BookRecords, best matches first.
         """
+        match = _fts_match_expression(query)
+        if not match:
+            return []
         cursor = self._conn.execute(
             "SELECT books.* FROM books "
             "JOIN books_fts ON books.id = books_fts.rowid "
             "WHERE books_fts MATCH ? "
             "ORDER BY books_fts.rank",
-            (query,),
+            (match,),
         )
         return [row_to_record(row) for row in cursor.fetchall()]
 
@@ -194,12 +217,13 @@ class LibraryCatalog:
         count for the query (independent of ``offset`` and ``limit``) so the
         controller can drive paging UI without a second round-trip.
         """
-        if q:
+        match = _fts_match_expression(q) if q else ""
+        if match:
             total_row = self._conn.execute(
                 "SELECT COUNT(*) FROM books "
                 "JOIN books_fts ON books.id = books_fts.rowid "
                 "WHERE books_fts MATCH ?",
-                (q,),
+                (match,),
             ).fetchone()
             total = int(total_row[0]) if total_row else 0
             cursor = self._conn.execute(
@@ -208,7 +232,7 @@ class LibraryCatalog:
                 "WHERE books_fts MATCH ? "
                 "ORDER BY books_fts.rank "
                 "LIMIT ? OFFSET ?",
-                (q, limit, offset),
+                (match, limit, offset),
             )
         else:
             total_row = self._conn.execute("SELECT COUNT(*) FROM books").fetchone()

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -178,6 +178,48 @@ class LibraryCatalog:
         )
         return [row_to_record(row) for row in cursor.fetchall()]
 
+    def browse(
+        self,
+        *,
+        q: str = "",
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[BookRecord], int]:
+        """Paginated browse over the catalog.
+
+        Empty ``q`` returns rows ordered by ``author_sort, title``; a
+        non-empty ``q`` runs an FTS5 MATCH ranked by relevance. ``offset``
+        and ``limit`` are applied server-side so the caller never sees rows
+        beyond the requested page. The second tuple element is the total
+        count for the query (independent of ``offset`` and ``limit``) so the
+        controller can drive paging UI without a second round-trip.
+        """
+        if q:
+            total_row = self._conn.execute(
+                "SELECT COUNT(*) FROM books "
+                "JOIN books_fts ON books.id = books_fts.rowid "
+                "WHERE books_fts MATCH ?",
+                (q,),
+            ).fetchone()
+            total = int(total_row[0]) if total_row else 0
+            cursor = self._conn.execute(
+                "SELECT books.* FROM books "
+                "JOIN books_fts ON books.id = books_fts.rowid "
+                "WHERE books_fts MATCH ? "
+                "ORDER BY books_fts.rank "
+                "LIMIT ? OFFSET ?",
+                (q, limit, offset),
+            )
+        else:
+            total_row = self._conn.execute("SELECT COUNT(*) FROM books").fetchone()
+            total = int(total_row[0]) if total_row else 0
+            cursor = self._conn.execute(
+                "SELECT * FROM books ORDER BY author_sort, title LIMIT ? OFFSET ?",
+                (limit, offset),
+            )
+        records = [row_to_record(row) for row in cursor.fetchall()]
+        return records, total
+
     def update_book(
         self,
         book_id: int,
@@ -250,8 +292,7 @@ class LibraryCatalog:
             cleared = [k for k in written if fields[k] in (None, "", "[]", "{}")]
             if cleared:
                 self._conn.executemany(
-                    "DELETE FROM book_field_provenance "
-                    "WHERE book_id = ? AND field_name = ?",
+                    "DELETE FROM book_field_provenance WHERE book_id = ? AND field_name = ?",
                     [(book_id, k) for k in cleared],
                 )
 
@@ -329,8 +370,7 @@ class LibraryCatalog:
             )
         else:
             self._conn.execute(
-                "UPDATE book_field_provenance SET locked = 0 "
-                "WHERE book_id = ? AND field_name = ?",
+                "UPDATE book_field_provenance SET locked = 0 WHERE book_id = ? AND field_name = ?",
                 (book_id, field_name),
             )
         self._conn.commit()
@@ -338,8 +378,7 @@ class LibraryCatalog:
     def get_locked_fields(self, book_id: int) -> set[str]:
         """Return the set of field names currently locked on this book."""
         rows = self._conn.execute(
-            "SELECT field_name FROM book_field_provenance "
-            "WHERE book_id = ? AND locked = 1",
+            "SELECT field_name FROM book_field_provenance WHERE book_id = ? AND locked = 1",
             (book_id,),
         ).fetchall()
         return {row["field_name"] for row in rows}

--- a/src/bookery/web/browse.py
+++ b/src/bookery/web/browse.py
@@ -1,0 +1,109 @@
+# ABOUTME: BrowseQuery + BrowsePage view models for the /books list controller.
+# ABOUTME: Single source of truth for URL-driven browse state (q, page, sort, filters).
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+DEFAULT_PAGE_SIZE = 50
+
+
+@dataclass(frozen=True)
+class BrowseQuery:
+    """Parsed URL state for the /books list controller.
+
+    Fields not yet exercised by the controller (``sort``, ``dir``, ``filters``)
+    are reserved for plan-01 steps 3 and 4. Keeping them on the dataclass now
+    lets the route plumbing land once and the later steps add behavior in
+    isolation.
+    """
+
+    q: str = ""
+    page: int = 1
+    page_size: int = DEFAULT_PAGE_SIZE
+    sort: str = ""
+    dir: str = ""
+    filters: Mapping[str, str] = field(default_factory=dict)
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    def with_page(self, page: int) -> "BrowseQuery":
+        return BrowseQuery(
+            q=self.q,
+            page=max(1, page),
+            page_size=self.page_size,
+            sort=self.sort,
+            dir=self.dir,
+            filters=self.filters,
+        )
+
+
+def _coerce_int(value: str | None, default: int, minimum: int) -> int:
+    """Parse ``value`` as an int >= ``minimum``; return ``default`` on garbage."""
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
+def from_request_args(
+    args: Mapping[str, str], *, default_page_size: int = DEFAULT_PAGE_SIZE
+) -> BrowseQuery:
+    """Build a ``BrowseQuery`` from a Flask ``request.args``-shaped mapping.
+
+    Tolerates missing or malformed inputs by falling back to defaults.
+    ``page`` is clamped to ``>= 1``; the upper bound (total pages) is the
+    controller's responsibility once it has a result count.
+    """
+    return BrowseQuery(
+        q=(args.get("q") or "").strip(),
+        page=_coerce_int(args.get("page"), default=1, minimum=1),
+        page_size=default_page_size,
+        sort=(args.get("sort") or "").strip(),
+        dir=(args.get("dir") or "").strip(),
+    )
+
+
+@dataclass(frozen=True)
+class BrowsePage:
+    """Result of paginating a browse against the catalog.
+
+    Combines the page's records with the totals derived from a single
+    catalog round-trip so the template doesn't have to recompute bounds.
+    """
+
+    books: list
+    total: int
+    page: int
+    page_size: int
+    query: BrowseQuery
+
+    @property
+    def total_pages(self) -> int:
+        if self.page_size <= 0 or self.total <= 0:
+            return 1
+        return (self.total + self.page_size - 1) // self.page_size
+
+    @property
+    def start(self) -> int:
+        if self.total == 0:
+            return 0
+        return (self.page - 1) * self.page_size + 1
+
+    @property
+    def end(self) -> int:
+        if self.total == 0:
+            return 0
+        return min(self.page * self.page_size, self.total)
+
+    @property
+    def has_prev(self) -> bool:
+        return self.page > 1
+
+    @property
+    def has_next(self) -> bool:
+        return self.page < self.total_pages

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -22,6 +22,7 @@ from bookery.core.remove import remove_book
 from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.provider import MetadataProvider
 from bookery.util.text import strip_html
+from bookery.web.browse import BrowsePage, from_request_args
 from bookery.web.diff import metadata_diff
 
 
@@ -75,16 +76,42 @@ def index():
 
 @bp.route("/books")
 def books():
-    """List all books, with optional search via query param."""
-    catalog = current_app.config["CATALOG"]
-    query = request.args.get("q", "").strip()
+    """List books with URL-driven browse state (q, page).
 
-    book_list = catalog.search(query) if query else catalog.list_all_by_author()
+    Single source of truth is a parsed ``BrowseQuery``. Pagination is
+    server-side: ``catalog.browse`` returns the rows for the requested
+    page plus the total match count so the controller can clamp an
+    out-of-range page and render ``Showing X-Y of Z`` without a second
+    query. Both htmx and full-page responses go through the same
+    ``BrowsePage`` so the count, rows, and pager stay in lock-step.
+    """
+    catalog = current_app.config["CATALOG"]
+    query = from_request_args(request.args)
+
+    books_page, total = catalog.browse(q=query.q, offset=query.offset, limit=query.page_size)
+
+    # Clamp out-of-range page requests to the last valid page rather than
+    # 404ing — bookmarks and stale links shouldn't break the front door.
+    if total > 0 and not books_page and query.page > 1:
+        last_page = max(1, (total + query.page_size - 1) // query.page_size)
+        clamped = query.with_page(last_page)
+        books_page, total = catalog.browse(
+            q=clamped.q, offset=clamped.offset, limit=clamped.page_size
+        )
+        query = clamped
+
+    page = BrowsePage(
+        books=books_page,
+        total=total,
+        page=query.page,
+        page_size=query.page_size,
+        query=query,
+    )
 
     if request.headers.get("HX-Request"):
-        return render_template("_table.html", books=book_list, query=query)
+        return render_template("_book_list.html", page=page, query=query)
 
-    return render_template("list.html", books=book_list, query=query)
+    return render_template("list.html", page=page, query=query)
 
 
 @bp.route("/books/<int:book_id>")

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -1,0 +1,63 @@
+{# ABOUTME: Plan-01 paginated list partial — count label, table, pager. #}
+{# Rendered standalone for htmx swaps into #book-list. #}
+
+{% if page.total > 0 %}
+    <p class="result-count">Showing {{ page.start }}&ndash;{{ page.end }} of {{ page.total }}</p>
+
+    <table class="book-table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Author</th>
+                <th>ISBN</th>
+                <th>Language</th>
+                <th>Publisher</th>
+                <th>Enriched</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for book in page.books %}
+            <tr class="book-row">
+                <td class="book-row-title">
+                    <a href="{{ url_for('web.book_detail', book_id=book.id) }}">{{ book.metadata.title }}</a>
+                </td>
+                <td>{{ book.metadata.author }}</td>
+                <td>{{ book.metadata.isbn or '' }}</td>
+                <td>{{ book.metadata.language or '' }}</td>
+                <td>{{ book.metadata.publisher or '' }}</td>
+                <td>{% if book.metadata_matched_at %}&#10003;{% endif %}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% if page.total_pages > 1 %}
+    <nav class="pager" aria-label="Pagination">
+        {% if page.has_prev %}
+            <a class="pager-prev"
+               href="{{ url_for('web.books', q=query.q or none, page=page.page - 1) }}"
+               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page - 1) }}"
+               hx-target="#book-list"
+               hx-push-url="true">&laquo; Previous</a>
+        {% else %}
+            <span class="pager-prev pager-disabled" aria-hidden="true">&laquo; Previous</span>
+        {% endif %}
+
+        <span class="pager-status">Page {{ page.page }} of {{ page.total_pages }}</span>
+
+        {% if page.has_next %}
+            <a class="pager-next"
+               href="{{ url_for('web.books', q=query.q or none, page=page.page + 1) }}"
+               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page + 1) }}"
+               hx-target="#book-list"
+               hx-push-url="true">Next &raquo;</a>
+        {% else %}
+            <span class="pager-next pager-disabled" aria-hidden="true">Next &raquo;</span>
+        {% endif %}
+    </nav>
+    {% endif %}
+{% elif query.q %}
+    <p class="empty-state">No books matching '{{ query.q }}'</p>
+{% else %}
+    <p class="empty-state">Your library is empty. Run <code>bookery import</code> to add books.</p>
+{% endif %}

--- a/src/bookery/web/templates/list.html
+++ b/src/bookery/web/templates/list.html
@@ -7,26 +7,15 @@
     <input type="search"
            name="q"
            placeholder="Search books..."
-           value="{{ query or '' }}"
+           value="{{ query.q }}"
            hx-get="{{ url_for('web.books') }}"
            hx-trigger="keyup changed delay:300ms"
-           hx-target="#book-table-body"
-           hx-include="this">
+           hx-target="#book-list"
+           hx-include="this"
+           hx-push-url="true">
 </div>
 
-<table class="book-table">
-    <thead>
-        <tr>
-            <th>Title</th>
-            <th>Author</th>
-            <th>ISBN</th>
-            <th>Language</th>
-            <th>Publisher</th>
-            <th>Enriched</th>
-        </tr>
-    </thead>
-    <tbody id="book-table-body">
-        {% include "_table.html" %}
-    </tbody>
-</table>
+<div id="book-list">
+    {% include "_book_list.html" %}
+</div>
 {% endblock %}

--- a/tests/unit/test_catalog_browse.py
+++ b/tests/unit/test_catalog_browse.py
@@ -97,6 +97,36 @@ class TestBrowseSearch:
         assert titles == ["Another Rose Story", "The Rose Garden"]
         assert total == 2
 
+    def test_q_with_fts_punctuation_does_not_crash(self, catalog):
+        """User input like 'dune:' is FTS5 column-filter syntax that crashes
+        sqlite if passed through raw. browse() must treat it as plain text."""
+        meta = BookMetadata(
+            title="Dune Chronicles",
+            authors=["Herbert"],
+            source_path=Path("/tmp/dune.epub"),
+        )
+        catalog.add_book(meta, file_hash="dune".ljust(64, "0"))
+        # All of these are valid user input that previously raised
+        # sqlite3.OperationalError because FTS5 reserves these characters.
+        for raw in ["dune:", 'dune"', "dune AND", "AND", "*foo", "(dune)"]:
+            rows, total = catalog.browse(q=raw)
+            assert isinstance(rows, list)
+            assert isinstance(total, int)
+
+    def test_q_multi_word_still_matches(self, catalog):
+        """Phrase-escaping per token must preserve implicit AND across tokens."""
+        for title in ["The Rose Garden", "Rose of Sharon", "Garden Tools"]:
+            meta = BookMetadata(
+                title=title, authors=["A"], source_path=Path(f"/tmp/{title}.epub")
+            )
+            catalog.add_book(meta, file_hash=(title * 8).ljust(64, "0"))
+        rows, total = catalog.browse(q="rose garden")
+        titles = [r.metadata.title for r in rows]
+        assert "The Rose Garden" in titles
+        assert "Garden Tools" not in titles
+        assert "Rose of Sharon" not in titles
+        assert total == 1
+
     def test_q_with_pagination(self, catalog):
         for i in range(5):
             meta = BookMetadata(

--- a/tests/unit/test_catalog_browse.py
+++ b/tests/unit/test_catalog_browse.py
@@ -1,0 +1,115 @@
+# ABOUTME: LibraryCatalog.browse() — paginated list/search against a real SQLite.
+# ABOUTME: Covers offset/limit, FTS5 q matching, and total-count semantics.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture
+def catalog(tmp_path: Path):
+    conn = open_library(tmp_path / "lib.db")
+    try:
+        yield LibraryCatalog(conn)
+    finally:
+        conn.close()
+
+
+def _seed_n(catalog: LibraryCatalog, n: int) -> None:
+    """Insert ``n`` books with predictable titles and author_sort keys."""
+    for i in range(n):
+        meta = BookMetadata(
+            title=f"Title {i:03d}",
+            authors=[f"Author {i:03d}"],
+            source_path=Path(f"/tmp/book-{i:03d}.epub"),
+        )
+        catalog.add_book(meta, file_hash=f"hash-{i:03d}".ljust(64, "0"))
+
+
+class TestBrowsePagination:
+    def test_empty_catalog_returns_empty_list_zero_total(self, catalog):
+        rows, total = catalog.browse()
+        assert rows == []
+        assert total == 0
+
+    def test_total_is_independent_of_limit(self, catalog):
+        _seed_n(catalog, 25)
+        _, total = catalog.browse(limit=5)
+        assert total == 25
+
+    def test_limit_caps_returned_rows(self, catalog):
+        _seed_n(catalog, 25)
+        rows, _ = catalog.browse(limit=10)
+        assert len(rows) == 10
+
+    def test_offset_skips_rows(self, catalog):
+        _seed_n(catalog, 25)
+        page1, _ = catalog.browse(limit=10, offset=0)
+        page2, _ = catalog.browse(limit=10, offset=10)
+        page3, _ = catalog.browse(limit=10, offset=20)
+        ids1 = [r.id for r in page1]
+        ids2 = [r.id for r in page2]
+        assert len(set(ids1) & set(ids2)) == 0
+        assert len(page3) == 5
+
+    def test_offset_past_end_returns_empty_but_total_nonzero(self, catalog):
+        _seed_n(catalog, 3)
+        rows, total = catalog.browse(limit=10, offset=100)
+        assert rows == []
+        assert total == 3
+
+    def test_default_ordering_is_by_author_then_title(self, catalog):
+        for title, author in [
+            ("Zebra", "Adams, John"),
+            ("Apple", "Brown, Dan"),
+            ("Banana", "Adams, John"),
+        ]:
+            meta = BookMetadata(
+                title=title,
+                authors=[author],
+                author_sort=author,
+                source_path=Path(f"/tmp/{title}.epub"),
+            )
+            catalog.add_book(meta, file_hash=(title * 8).ljust(64, "0"))
+        rows, _ = catalog.browse()
+        titles = [r.metadata.title for r in rows]
+        # Adams's Banana before Zebra (both Adams), then Brown's Apple.
+        assert titles == ["Banana", "Zebra", "Apple"]
+
+
+class TestBrowseSearch:
+    def test_q_filters_by_fts_match(self, catalog):
+        for title, author in [
+            ("The Rose Garden", "Smith"),
+            ("A Different Book", "Jones"),
+            ("Another Rose Story", "Lee"),
+        ]:
+            meta = BookMetadata(
+                title=title, authors=[author], source_path=Path(f"/tmp/{title}.epub")
+            )
+            catalog.add_book(meta, file_hash=(title * 8).ljust(64, "0"))
+        rows, total = catalog.browse(q="rose")
+        titles = sorted(r.metadata.title for r in rows)
+        assert titles == ["Another Rose Story", "The Rose Garden"]
+        assert total == 2
+
+    def test_q_with_pagination(self, catalog):
+        for i in range(5):
+            meta = BookMetadata(
+                title=f"Rose Book {i}",
+                authors=[f"Author {i}"],
+                source_path=Path(f"/tmp/rose-{i}.epub"),
+            )
+            catalog.add_book(meta, file_hash=f"rose-{i}".ljust(64, "0"))
+        # Unrelated row should not be counted in the q total.
+        catalog.add_book(
+            BookMetadata(title="Tulip", authors=["A"], source_path=Path("/tmp/tulip.epub")),
+            file_hash="tulip".ljust(64, "0"),
+        )
+        rows, total = catalog.browse(q="rose", limit=2, offset=0)
+        assert total == 5
+        assert len(rows) == 2

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -55,6 +55,7 @@ def mock_catalog():
     catalog = Mock()
     catalog.list_all_by_author.return_value = []
     catalog.search.return_value = []
+    catalog.browse.return_value = ([], 0)
     catalog.get_by_id.return_value = None
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
@@ -100,7 +101,7 @@ class TestBookList:
     def test_books_lists_all_books_sorted_by_author(self, mock_catalog, client):
         book_a = _make_book(1, title="Zebra", authors=["Adams, John"], author_sort="Adams, John")
         book_b = _make_book(2, title="Apple", authors=["Brown, Dan"], author_sort="Brown, Dan")
-        mock_catalog.list_all_by_author.return_value = [book_a, book_b]
+        mock_catalog.browse.return_value = ([book_a, book_b], 2)
 
         response = client.get("/books")
         html = response.data.decode()
@@ -123,7 +124,7 @@ class TestBookList:
             output_path=Path("/out/plain.epub"),
             metadata_matched_at=None,
         )
-        mock_catalog.list_all_by_author.return_value = [enriched, plain]
+        mock_catalog.browse.return_value = ([enriched, plain], 2)
 
         response = client.get("/books")
         html = response.data.decode()
@@ -139,7 +140,7 @@ class TestBookList:
             language="en",
             publisher="Scribner",
         )
-        mock_catalog.list_all_by_author.return_value = [book]
+        mock_catalog.browse.return_value = ([book], 1)
 
         response = client.get("/books")
         html = response.data.decode()
@@ -225,23 +226,24 @@ class TestBookDetail:
 class TestSearch:
     def test_search_returns_matching_books(self, mock_catalog, client):
         book = _make_book(1, title="The Rose Garden")
-        mock_catalog.search.return_value = [book]
+        mock_catalog.browse.return_value = ([book], 1)
 
         response = client.get("/books?q=rose")
         html = response.data.decode()
         assert response.status_code == 200
         assert "The Rose Garden" in html
-        mock_catalog.search.assert_called_once_with("rose")
+        mock_catalog.browse.assert_called_once()
+        assert mock_catalog.browse.call_args.kwargs["q"] == "rose"
 
     def test_search_no_results_message(self, mock_catalog, client):
-        mock_catalog.search.return_value = []
+        mock_catalog.browse.return_value = ([], 0)
 
         response = client.get("/books?q=zzzzz")
         html = response.data.decode()
         assert "No books matching &#39;zzzzz&#39;" in html or "No books matching 'zzzzz'" in html
 
     def test_htmx_request_returns_partial_only(self, mock_catalog, client):
-        mock_catalog.search.return_value = []
+        mock_catalog.browse.return_value = ([], 0)
 
         response = client.get("/books?q=test", headers={"HX-Request": "true"})
         html = response.data.decode()
@@ -249,7 +251,7 @@ class TestSearch:
         assert "<head" not in html
 
     def test_non_htmx_search_returns_full_page(self, mock_catalog, client):
-        mock_catalog.search.return_value = []
+        mock_catalog.browse.return_value = ([], 0)
 
         response = client.get("/books?q=test")
         html = response.data.decode()

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -116,6 +116,7 @@ def mock_catalog():
     catalog = Mock()
     catalog.list_all_by_author.return_value = []
     catalog.search.return_value = []
+    catalog.browse.return_value = ([], 0)
     catalog.get_by_id.return_value = None
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []

--- a/tests/web/test_accessibility.py
+++ b/tests/web/test_accessibility.py
@@ -52,26 +52,27 @@ class TestBookListRowAnchors:
     """Issue #124 — book list rows must use real anchors, not onclick JS."""
 
     def test_row_has_real_anchor_to_detail(self, mock_catalog, client):
-        mock_catalog.list_all_by_author.return_value = [
-            make_book(book_id=42, title="The Test Book", authors=["Jane Author"])
-        ]
+        mock_catalog.browse.return_value = (
+            [make_book(book_id=42, title="The Test Book", authors=["Jane Author"])],
+            1,
+        )
         html = client.get("/books").data.decode()
         assert 'href="/books/42"' in html
 
     def test_row_has_no_onclick_attribute(self, mock_catalog, client):
-        mock_catalog.list_all_by_author.return_value = [
-            make_book(book_id=42, title="The Test Book", authors=["Jane Author"])
-        ]
+        mock_catalog.browse.return_value = (
+            [make_book(book_id=42, title="The Test Book", authors=["Jane Author"])],
+            1,
+        )
         html = client.get("/books").data.decode()
         assert "onclick" not in html.lower()
 
     def test_anchor_wraps_title_text(self, mock_catalog, client):
-        mock_catalog.list_all_by_author.return_value = [
-            make_book(book_id=42, title="The Test Book", authors=["Jane Author"])
-        ]
+        mock_catalog.browse.return_value = (
+            [make_book(book_id=42, title="The Test Book", authors=["Jane Author"])],
+            1,
+        )
         html = client.get("/books").data.decode()
         # Anchor must contain the title text so keyboard users land on a
         # focusable element whose accessible name is the book title.
-        assert re.search(
-            r'<a[^>]+href="/books/42"[^>]*>\s*The Test Book\s*</a>', html
-        )
+        assert re.search(r'<a[^>]+href="/books/42"[^>]*>\s*The Test Book\s*</a>', html)

--- a/tests/web/test_list_browse.py
+++ b/tests/web/test_list_browse.py
@@ -1,0 +1,186 @@
+# ABOUTME: Plan-01 list browse surface tests — BrowseQuery, pagination, count label.
+# ABOUTME: Covers the cells of the test matrix that exist after PR 1 (steps 1+2 of plan-01).
+
+import pytest
+
+from bookery.web.browse import (
+    DEFAULT_PAGE_SIZE,
+    BrowsePage,
+    BrowseQuery,
+    from_request_args,
+)
+
+from .conftest import make_book
+
+# --- BrowseQuery parsing ---
+
+
+class TestBrowseQueryParsing:
+    def test_defaults_when_args_empty(self):
+        q = from_request_args({})
+        assert q.q == ""
+        assert q.page == 1
+        assert q.page_size == DEFAULT_PAGE_SIZE
+        assert q.offset == 0
+
+    def test_parses_q_and_page(self):
+        q = from_request_args({"q": "dune", "page": "3"})
+        assert q.q == "dune"
+        assert q.page == 3
+        assert q.offset == 2 * DEFAULT_PAGE_SIZE
+
+    def test_strips_whitespace_in_q(self):
+        q = from_request_args({"q": "  dune  "})
+        assert q.q == "dune"
+
+    @pytest.mark.parametrize("bad", ["0", "-5", "abc", "", "1.5"])
+    def test_invalid_page_clamps_to_one(self, bad):
+        q = from_request_args({"page": bad})
+        assert q.page == 1
+
+    def test_custom_default_page_size(self):
+        q = from_request_args({}, default_page_size=10)
+        assert q.page_size == 10
+
+
+# --- BrowsePage derivations ---
+
+
+class TestBrowsePageDerivations:
+    def _page(self, total: int, page: int, page_size: int = 50) -> BrowsePage:
+        return BrowsePage(
+            books=[],
+            total=total,
+            page=page,
+            page_size=page_size,
+            query=BrowseQuery(page=page, page_size=page_size),
+        )
+
+    def test_start_end_for_first_page(self):
+        p = self._page(total=120, page=1)
+        assert (p.start, p.end) == (1, 50)
+
+    def test_start_end_for_middle_page(self):
+        p = self._page(total=120, page=2)
+        assert (p.start, p.end) == (51, 100)
+
+    def test_end_clamps_to_total_on_last_page(self):
+        p = self._page(total=120, page=3)
+        assert (p.start, p.end) == (101, 120)
+
+    def test_empty_results_zero_bounds(self):
+        p = self._page(total=0, page=1)
+        assert (p.start, p.end) == (0, 0)
+
+    def test_total_pages_rounds_up(self):
+        assert self._page(total=120, page=1).total_pages == 3
+        assert self._page(total=100, page=1).total_pages == 2
+        assert self._page(total=1, page=1).total_pages == 1
+        assert self._page(total=0, page=1).total_pages == 1
+
+    def test_has_prev_next(self):
+        first = self._page(total=120, page=1)
+        middle = self._page(total=120, page=2)
+        last = self._page(total=120, page=3)
+        assert first.has_prev is False and first.has_next is True
+        assert middle.has_prev is True and middle.has_next is True
+        assert last.has_prev is True and last.has_next is False
+
+
+# --- /books route: pagination + count ---
+
+
+def _stub_browse(mock_catalog, *, books, total):
+    """Wire ``mock_catalog.browse`` to return the supplied books + total."""
+    mock_catalog.browse.return_value = (books, total)
+
+
+class TestBooksRoutePagination:
+    def test_route_calls_catalog_browse_with_parsed_query(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        client.get("/books?q=dune&page=2")
+
+        mock_catalog.browse.assert_called_once()
+        kwargs = mock_catalog.browse.call_args.kwargs
+        assert kwargs["q"] == "dune"
+        assert kwargs["offset"] == DEFAULT_PAGE_SIZE
+        assert kwargs["limit"] == DEFAULT_PAGE_SIZE
+
+    def test_route_renders_only_one_page_of_results(self, mock_catalog, client):
+        books = [make_book(i, title=f"Book {i:03d}") for i in range(1, 51)]
+        _stub_browse(mock_catalog, books=books, total=120)
+
+        response = client.get("/books")
+        html = response.data.decode()
+        assert "Book 001" in html
+        assert "Book 050" in html
+        # Catalog was asked for 50 rows — anything beyond is the catalog's concern.
+        kwargs = mock_catalog.browse.call_args.kwargs
+        assert kwargs["limit"] == 50
+
+    def test_route_renders_count_label(self, mock_catalog, client):
+        books = [make_book(i) for i in range(51, 101)]
+        _stub_browse(mock_catalog, books=books, total=120)
+
+        response = client.get("/books?page=2")
+        html = response.data.decode()
+        # Use the en-dash form rendered in the template
+        assert "Showing 51&ndash;100 of 120" in html
+
+    def test_route_renders_empty_count_when_no_results(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        response = client.get("/books")
+        html = response.data.decode()
+        assert "Your library is empty" in html
+        # No "Showing X of Y" label when there is nothing to show.
+        assert "Showing" not in html
+
+    def test_route_clamps_out_of_range_page(self, mock_catalog, client):
+        books = [make_book(i) for i in range(1, 21)]
+
+        def fake_browse(*, q: str, offset: int, limit: int):
+            del q, limit
+            # First call: probe with the requested (out of range) offset returns
+            # empty plus the real total. Route then re-queries with the clamped
+            # offset and we return the actual books.
+            return (books if offset == 0 else [], len(books))
+
+        mock_catalog.browse.side_effect = fake_browse
+
+        response = client.get("/books?page=99")
+        assert response.status_code == 200
+        html = response.data.decode()
+        # Page label reflects the clamped page (1, since 20 < 50)
+        assert "Showing 1&ndash;20 of 20" in html
+
+    def test_pager_links_preserve_search_query(self, mock_catalog, client):
+        books = [make_book(i) for i in range(1, 51)]
+        _stub_browse(mock_catalog, books=books, total=120)
+
+        response = client.get("/books?q=dune&page=2")
+        html = response.data.decode()
+        # Both prev and next should carry q=dune
+        assert "q=dune" in html
+        assert "page=1" in html
+        assert "page=3" in html
+
+    def test_no_pager_when_results_fit_one_page(self, mock_catalog, client):
+        books = [make_book(i) for i in range(1, 11)]
+        _stub_browse(mock_catalog, books=books, total=10)
+
+        response = client.get("/books")
+        html = response.data.decode()
+        # No nav pager rendered
+        assert 'class="pager"' not in html
+
+    def test_htmx_request_returns_partial_with_count_and_rows(self, mock_catalog, client):
+        books = [make_book(1, title="Solo Book")]
+        _stub_browse(mock_catalog, books=books, total=1)
+
+        response = client.get("/books", headers={"HX-Request": "true"})
+        html = response.data.decode()
+        assert "<html" not in html
+        assert "Solo Book" in html
+        assert "Showing 1&ndash;1 of 1" in html


### PR DESCRIPTION
## Summary

Plan-01 steps 1–2 (closes #128, #138). The `/books` controller is rebuilt around a parsed `BrowseQuery` (q, page, page_size + reserved sort/dir/filter slots) — the single source of truth for URL-driven browse state in this and subsequent plan-01 PRs.

- `catalog.browse(*, q, offset, limit)` runs the underlying list/FTS query and returns `(rows, total)` in one round-trip
- `BrowsePage` derives `start`, `end`, `total_pages`, `has_prev`, `has_next` so the template renders the count label and pager without recomputing bounds
- Out-of-range page requests (bookmarks, stale links) clamp to the last valid page rather than 404ing
- htmx search submissions still target `#book-list`, but the swap now refreshes count + pager + rows in lock-step
- `BrowseQuery.sort/dir/filters` are reserved for plan-01 steps 3 (#136) and 4 (#137); plumbing lands once

## What's not in this PR

- Sortable column headers (#136) — step 3
- Filter chip strip (#137) — step 4
- Cover thumbnails (#139) — step 5
- Mobile card layout (#129) — step 6
- Heading semantics pass (#126) — step 7

## Test plan

- [x] `tests/unit/test_catalog_browse.py` — 8 tests against real SQLite covering empty catalog, offset/limit semantics, default ordering, FTS `q` matching, and `q` + pagination
- [x] `tests/web/test_list_browse.py` — 23 tests covering BrowseQuery parsing (defaults, page coercion, whitespace), BrowsePage derivations (start/end/total_pages/prev/next), and the route (calls catalog.browse correctly, renders count label, clamps out-of-range page, preserves `q` in pager links, hides pager when results fit one page, htmx returns partial)
- [x] Full suite: 1497 passed (+31 from main)
- [x] ruff clean
- [ ] Manual smoke: load `/books` on a real library, click through pages, use search, hit a bookmark with a bad `?page=`