### PR TITLE
feat(web): sortable column headers on /books (#136)

### DIFF
--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -45,6 +45,38 @@ def _fts_match_expression(q: str) -> str:
     return " ".join('"' + tok.replace('"', '""') + '"' for tok in tokens)
 
 
+# Map URL-layer sort keys to the column expressions used in ORDER BY clauses.
+# ``added`` resolves to ``date_added`` (the schema column), with a stable
+# tiebreaker on ``id`` so equal timestamps still produce a deterministic order.
+# ``title`` and ``author`` carry ``title`` as a secondary key so two books by
+# the same author come back in alphabetical order.
+_SORT_COLUMNS: dict[str, str] = {
+    "title": "title COLLATE NOCASE",
+    "author": "author_sort COLLATE NOCASE, title COLLATE NOCASE",
+    "added": "date_added, id",
+}
+_DEFAULT_ORDER = "author_sort COLLATE NOCASE, title COLLATE NOCASE"
+
+
+def _order_clause_for(sort: str, dir: str) -> str:
+    """Build an ORDER BY fragment for the browse query.
+
+    Whitelist-driven — the inputs come from the trusted ``BrowseQuery`` layer
+    but the catalog re-validates because it's the actual SQL boundary. Unknown
+    keys fall back to the historical default ordering. The direction is
+    appended to every key in the column expression so multi-key sorts flip
+    together.
+    """
+    columns = _SORT_COLUMNS.get(sort)
+    direction = "DESC" if dir == "desc" else "ASC"
+    if columns is None:
+        return _DEFAULT_ORDER
+    # Apply the direction to each comma-separated key so secondary sort
+    # tiebreakers respect the user's chosen direction.
+    parts = [part.strip() for part in columns.split(",")]
+    return ", ".join(f"{part} {direction}" for part in parts)
+
+
 class LibraryCatalog:
     """Wraps a sqlite3 connection and provides typed CRUD for the books table."""
 
@@ -207,15 +239,23 @@ class LibraryCatalog:
         q: str = "",
         offset: int = 0,
         limit: int = 50,
+        sort: str = "",
+        dir: str = "",
     ) -> tuple[list[BookRecord], int]:
         """Paginated browse over the catalog.
 
-        Empty ``q`` returns rows ordered by ``author_sort, title``; a
-        non-empty ``q`` runs an FTS5 MATCH ranked by relevance. ``offset``
-        and ``limit`` are applied server-side so the caller never sees rows
-        beyond the requested page. The second tuple element is the total
-        count for the query (independent of ``offset`` and ``limit``) so the
-        controller can drive paging UI without a second round-trip.
+        Empty ``q`` returns rows ordered by ``sort`` + ``dir`` (default:
+        ``author_sort, title`` ascending). A non-empty ``q`` runs an FTS5
+        MATCH ranked by relevance and ignores ``sort`` — relevance is the
+        useful ordering for a search. ``offset`` and ``limit`` are applied
+        server-side so the caller never sees rows beyond the requested page.
+        The second tuple element is the total count for the query
+        (independent of ``offset`` and ``limit``) so the controller can drive
+        paging UI without a second round-trip.
+
+        Unknown ``sort`` / ``dir`` values fall back to the default ordering
+        silently — callers are expected to validate at the URL layer
+        (``BrowseQuery``) but the catalog stays robust on its own.
         """
         match = _fts_match_expression(q) if q else ""
         if match:
@@ -237,8 +277,9 @@ class LibraryCatalog:
         else:
             total_row = self._conn.execute("SELECT COUNT(*) FROM books").fetchone()
             total = int(total_row[0]) if total_row else 0
+            order_clause = _order_clause_for(sort, dir)
             cursor = self._conn.execute(
-                "SELECT * FROM books ORDER BY author_sort, title LIMIT ? OFFSET ?",
+                f"SELECT * FROM books ORDER BY {order_clause} LIMIT ? OFFSET ?",
                 (limit, offset),
             )
         records = [row_to_record(row) for row in cursor.fetchall()]

--- a/src/bookery/web/browse.py
+++ b/src/bookery/web/browse.py
@@ -6,22 +6,33 @@ from dataclasses import dataclass, field
 
 DEFAULT_PAGE_SIZE = 50
 
+# Allowed sort keys for the /books list controller. Anything else falls back
+# to ``DEFAULT_SORT`` silently — we never 400 the front door on a malformed
+# query string. Bumping or renaming a key here is a behavior change and needs
+# the template's header links updated in lock-step.
+ALLOWED_SORTS: frozenset[str] = frozenset({"title", "author", "added"})
+ALLOWED_DIRS: frozenset[str] = frozenset({"asc", "desc"})
+# Default ordering matches the pre-sortable behavior of the list controller —
+# books sorted by ``author_sort`` then ``title``, ascending — so unbookmarked
+# users see no change after sortable columns land.
+DEFAULT_SORT = "author"
+DEFAULT_DIR = "asc"
+
 
 @dataclass(frozen=True)
 class BrowseQuery:
     """Parsed URL state for the /books list controller.
 
-    Fields not yet exercised by the controller (``sort``, ``dir``, ``filters``)
-    are reserved for plan-01 steps 3 and 4. Keeping them on the dataclass now
-    lets the route plumbing land once and the later steps add behavior in
-    isolation.
+    ``filters`` is reserved for plan-01 step 4. ``sort`` and ``dir`` are
+    validated at parse time so the controller and the catalog can trust them
+    without re-checking.
     """
 
     q: str = ""
     page: int = 1
     page_size: int = DEFAULT_PAGE_SIZE
-    sort: str = ""
-    dir: str = ""
+    sort: str = DEFAULT_SORT
+    dir: str = DEFAULT_DIR
     filters: Mapping[str, str] = field(default_factory=dict)
 
     @property
@@ -50,6 +61,25 @@ def _coerce_int(value: str | None, default: int, minimum: int) -> int:
     return max(minimum, parsed)
 
 
+def _coerce_sort(value: str | None) -> str:
+    """Return ``value`` if it's an allowed sort key; otherwise ``DEFAULT_SORT``.
+
+    Unknown values (including the empty string, mis-cased variants, and
+    obvious injection attempts) fall back silently — the list page is the
+    front door and a stale URL shouldn't 400.
+    """
+    if value in ALLOWED_SORTS:
+        return value
+    return DEFAULT_SORT
+
+
+def _coerce_dir(value: str | None) -> str:
+    """Return ``value`` if it's an allowed direction; otherwise ``DEFAULT_DIR``."""
+    if value in ALLOWED_DIRS:
+        return value
+    return DEFAULT_DIR
+
+
 def from_request_args(
     args: Mapping[str, str], *, default_page_size: int = DEFAULT_PAGE_SIZE
 ) -> BrowseQuery:
@@ -57,14 +87,16 @@ def from_request_args(
 
     Tolerates missing or malformed inputs by falling back to defaults.
     ``page`` is clamped to ``>= 1``; the upper bound (total pages) is the
-    controller's responsibility once it has a result count.
+    controller's responsibility once it has a result count. ``sort`` and
+    ``dir`` are validated against the allow-lists so unknown values render
+    the default ordering instead of crashing the catalog query.
     """
     return BrowseQuery(
         q=(args.get("q") or "").strip(),
         page=_coerce_int(args.get("page"), default=1, minimum=1),
         page_size=default_page_size,
-        sort=(args.get("sort") or "").strip(),
-        dir=(args.get("dir") or "").strip(),
+        sort=_coerce_sort(args.get("sort")),
+        dir=_coerce_dir(args.get("dir")),
     )
 
 

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -88,7 +88,13 @@ def books():
     catalog = current_app.config["CATALOG"]
     query = from_request_args(request.args)
 
-    books_page, total = catalog.browse(q=query.q, offset=query.offset, limit=query.page_size)
+    books_page, total = catalog.browse(
+        q=query.q,
+        offset=query.offset,
+        limit=query.page_size,
+        sort=query.sort,
+        dir=query.dir,
+    )
 
     # Clamp out-of-range page requests to the last valid page rather than
     # 404ing — bookmarks and stale links shouldn't break the front door.
@@ -96,7 +102,11 @@ def books():
         last_page = max(1, (total + query.page_size - 1) // query.page_size)
         clamped = query.with_page(last_page)
         books_page, total = catalog.browse(
-            q=clamped.q, offset=clamped.offset, limit=clamped.page_size
+            q=clamped.q,
+            offset=clamped.offset,
+            limit=clamped.page_size,
+            sort=clamped.sort,
+            dir=clamped.dir,
         )
         query = clamped
 

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -1,17 +1,31 @@
-{# ABOUTME: Plan-01 paginated list partial — count label, table, pager. #}
+{# ABOUTME: Plan-01 paginated list partial — count label, sortable table, pager. #}
 {# Rendered standalone for htmx swaps into #book-list. #}
 
 {% if page.total > 0 %}
     <p class="result-count">Showing {{ page.start }}&ndash;{{ page.end }} of {{ page.total }}</p>
 
+    {# Sortable header link macro. Clicking the active column flips direction;
+       clicking an inactive column starts at ``asc``. Page resets to 1 on any
+       sort change — the user has new ordering, the old page index is stale. #}
+    {% macro sort_link(label, key) -%}
+        {%- set is_active = (query.sort == key) -%}
+        {%- set next_dir = 'desc' if (is_active and query.dir == 'asc') else 'asc' -%}
+        <a class="sort-link{% if is_active %} sort-active{% endif %}"
+           href="{{ url_for('web.books', q=query.q or none, sort=key, dir=next_dir) }}"
+           aria-sort="{{ 'descending' if (is_active and query.dir == 'desc') else ('ascending' if is_active else 'none') }}">
+            {{ label }}{% if is_active %} <span class="sort-chevron" aria-hidden="true">{% if query.dir == 'desc' %}&#9660;{% else %}&#9650;{% endif %}</span>{% endif %}
+        </a>
+    {%- endmacro %}
+
     <table class="book-table">
         <thead>
             <tr>
-                <th>Title</th>
-                <th>Author</th>
+                <th>{{ sort_link('Title', 'title') }}</th>
+                <th>{{ sort_link('Author', 'author') }}</th>
                 <th>ISBN</th>
                 <th>Language</th>
                 <th>Publisher</th>
+                <th>{{ sort_link('Added', 'added') }}</th>
                 <th>Enriched</th>
             </tr>
         </thead>
@@ -25,6 +39,7 @@
                 <td>{{ book.metadata.isbn or '' }}</td>
                 <td>{{ book.metadata.language or '' }}</td>
                 <td>{{ book.metadata.publisher or '' }}</td>
+                <td>{{ book.date_added or '' }}</td>
                 <td>{% if book.metadata_matched_at %}&#10003;{% endif %}</td>
             </tr>
             {% endfor %}
@@ -35,8 +50,8 @@
     <nav class="pager" aria-label="Pagination">
         {% if page.has_prev %}
             <a class="pager-prev"
-               href="{{ url_for('web.books', q=query.q or none, page=page.page - 1) }}"
-               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page - 1) }}"
+               href="{{ url_for('web.books', q=query.q or none, page=page.page - 1, sort=query.sort, dir=query.dir) }}"
+               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page - 1, sort=query.sort, dir=query.dir) }}"
                hx-target="#book-list"
                hx-push-url="true">&laquo; Previous</a>
         {% else %}
@@ -47,8 +62,8 @@
 
         {% if page.has_next %}
             <a class="pager-next"
-               href="{{ url_for('web.books', q=query.q or none, page=page.page + 1) }}"
-               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page + 1) }}"
+               href="{{ url_for('web.books', q=query.q or none, page=page.page + 1, sort=query.sort, dir=query.dir) }}"
+               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page + 1, sort=query.sort, dir=query.dir) }}"
                hx-target="#book-list"
                hx-push-url="true">Next &raquo;</a>
         {% else %}

--- a/tests/unit/test_catalog_browse.py
+++ b/tests/unit/test_catalog_browse.py
@@ -116,9 +116,7 @@ class TestBrowseSearch:
     def test_q_multi_word_still_matches(self, catalog):
         """Phrase-escaping per token must preserve implicit AND across tokens."""
         for title in ["The Rose Garden", "Rose of Sharon", "Garden Tools"]:
-            meta = BookMetadata(
-                title=title, authors=["A"], source_path=Path(f"/tmp/{title}.epub")
-            )
+            meta = BookMetadata(title=title, authors=["A"], source_path=Path(f"/tmp/{title}.epub"))
             catalog.add_book(meta, file_hash=(title * 8).ljust(64, "0"))
         rows, total = catalog.browse(q="rose garden")
         titles = [r.metadata.title for r in rows]
@@ -143,3 +141,60 @@ class TestBrowseSearch:
         rows, total = catalog.browse(q="rose", limit=2, offset=0)
         assert total == 5
         assert len(rows) == 2
+
+
+class TestBrowseSort:
+    def _seed_three(self, catalog: LibraryCatalog) -> None:
+        for title, author in [
+            ("Apple", "Zelda"),
+            ("Banana", "Adams"),
+            ("Cherry", "Murphy"),
+        ]:
+            meta = BookMetadata(
+                title=title,
+                authors=[author],
+                author_sort=author,
+                source_path=Path(f"/tmp/{title}.epub"),
+            )
+            catalog.add_book(meta, file_hash=(title * 8).ljust(64, "0"))
+
+    def test_sort_by_title_asc(self, catalog):
+        self._seed_three(catalog)
+        rows, _ = catalog.browse(sort="title", dir="asc")
+        assert [r.metadata.title for r in rows] == ["Apple", "Banana", "Cherry"]
+
+    def test_sort_by_title_desc(self, catalog):
+        self._seed_three(catalog)
+        rows, _ = catalog.browse(sort="title", dir="desc")
+        assert [r.metadata.title for r in rows] == ["Cherry", "Banana", "Apple"]
+
+    def test_sort_by_author_asc(self, catalog):
+        self._seed_three(catalog)
+        rows, _ = catalog.browse(sort="author", dir="asc")
+        assert [r.metadata.author_sort for r in rows] == ["Adams", "Murphy", "Zelda"]
+
+    def test_sort_by_author_desc(self, catalog):
+        self._seed_three(catalog)
+        rows, _ = catalog.browse(sort="author", dir="desc")
+        assert [r.metadata.author_sort for r in rows] == ["Zelda", "Murphy", "Adams"]
+
+    def test_sort_by_added_desc_newest_first(self, catalog):
+        # Inserts happen in order; date_added defaults to "now". Use ids to
+        # confirm newest-first ordering since timestamps may collide at
+        # sub-second resolution.
+        self._seed_three(catalog)
+        rows, _ = catalog.browse(sort="added", dir="desc")
+        ids = [r.id for r in rows]
+        assert ids == sorted(ids, reverse=True)
+
+    def test_sort_by_added_asc_oldest_first(self, catalog):
+        self._seed_three(catalog)
+        rows, _ = catalog.browse(sort="added", dir="asc")
+        ids = [r.id for r in rows]
+        assert ids == sorted(ids)
+
+    def test_unknown_sort_falls_back_to_default(self, catalog):
+        self._seed_three(catalog)
+        # Unknown key should not crash; behaves like default (author asc).
+        rows, _ = catalog.browse(sort="bogus", dir="desc")
+        assert len(rows) == 3

--- a/tests/web/test_list_browse.py
+++ b/tests/web/test_list_browse.py
@@ -43,6 +43,46 @@ class TestBrowseQueryParsing:
         assert q.page_size == 10
 
 
+# --- BrowseQuery sort/dir parsing ---
+
+
+class TestBrowseQuerySortParsing:
+    def test_defaults_to_author_asc(self):
+        # Default matches the pre-sortable behavior of the list controller
+        # (author_sort, title ascending) so an unbookmarked /books visit
+        # renders the same order users were already used to.
+        q = from_request_args({})
+        assert q.sort == "author"
+        assert q.dir == "asc"
+
+    @pytest.mark.parametrize("key", ["title", "author", "added"])
+    def test_parses_allowed_sort_keys(self, key):
+        q = from_request_args({"sort": key})
+        assert q.sort == key
+
+    @pytest.mark.parametrize("direction", ["asc", "desc"])
+    def test_parses_allowed_directions(self, direction):
+        q = from_request_args({"sort": "title", "dir": direction})
+        assert q.dir == direction
+
+    @pytest.mark.parametrize("bad_sort", ["bogus", "id", "", "TITLE", "author;drop"])
+    def test_unknown_sort_falls_back_to_default(self, bad_sort):
+        q = from_request_args({"sort": bad_sort})
+        assert q.sort == "author"
+
+    @pytest.mark.parametrize("bad_dir", ["sideways", "", "ASC", "DESC", "ascending"])
+    def test_unknown_dir_falls_back_to_asc(self, bad_dir):
+        q = from_request_args({"sort": "title", "dir": bad_dir})
+        assert q.dir == "asc"
+
+    def test_with_page_preserves_sort_and_dir(self):
+        q = from_request_args({"sort": "author", "dir": "desc", "page": "3"})
+        bumped = q.with_page(5)
+        assert bumped.sort == "author"
+        assert bumped.dir == "desc"
+        assert bumped.page == 5
+
+
 # --- BrowsePage derivations ---
 
 
@@ -140,8 +180,8 @@ class TestBooksRoutePagination:
     def test_route_clamps_out_of_range_page(self, mock_catalog, client):
         books = [make_book(i) for i in range(1, 21)]
 
-        def fake_browse(*, q: str, offset: int, limit: int):
-            del q, limit
+        def fake_browse(*, q: str, offset: int, limit: int, sort: str = "", dir: str = ""):
+            del q, limit, sort, dir
             # First call: probe with the requested (out of range) offset returns
             # empty plus the real total. Route then re-queries with the clamped
             # offset and we return the actual books.
@@ -184,3 +224,115 @@ class TestBooksRoutePagination:
         assert "<html" not in html
         assert "Solo Book" in html
         assert "Showing 1&ndash;1 of 1" in html
+
+
+# --- /books route: sortable columns ---
+
+
+class TestBooksRouteSort:
+    def test_route_passes_sort_and_dir_to_catalog(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        client.get("/books?sort=author&dir=desc")
+
+        kwargs = mock_catalog.browse.call_args.kwargs
+        assert kwargs["sort"] == "author"
+        assert kwargs["dir"] == "desc"
+
+    def test_route_defaults_to_author_asc(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        client.get("/books")
+
+        kwargs = mock_catalog.browse.call_args.kwargs
+        assert kwargs["sort"] == "author"
+        assert kwargs["dir"] == "asc"
+
+    def test_route_silently_ignores_unknown_sort(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        response = client.get("/books?sort=bogus&dir=sideways")
+
+        assert response.status_code == 200
+        kwargs = mock_catalog.browse.call_args.kwargs
+        assert kwargs["sort"] == "author"
+        assert kwargs["dir"] == "asc"
+
+    def test_active_column_has_descending_chevron(self, mock_catalog, client):
+        # Matrix row: 1280px, sort=author dir=desc → first row matches expected,
+        # chevron on header.
+        books = [
+            make_book(1, title="Zeppelin", authors=["Zelda"]),
+            make_book(2, title="Apple", authors=["Adams"]),
+        ]
+        _stub_browse(mock_catalog, books=books, total=2)
+
+        response = client.get("/books?sort=author&dir=desc")
+        html = response.data.decode()
+
+        # Chevron on the active Author header — descending arrow.
+        assert "Author" in html
+        assert "▼" in html or "&#9660;" in html or "▼" in html
+        # First rendered row matches the order the catalog returned.
+        first_row_idx = html.find("Zeppelin")
+        second_row_idx = html.find("Apple")
+        assert first_row_idx != -1 and second_row_idx != -1
+        assert first_row_idx < second_row_idx
+
+    def test_inactive_columns_have_no_chevron(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?sort=title&dir=asc")
+        html = response.data.decode()
+        # Active column shows ascending chevron. Match the HTML entity the
+        # template emits as well as the literal glyph in case either form
+        # is in use.
+        assert "▲" in html or "&#9650;" in html
+        # Inactive columns must not carry the chevron — exactly one chevron
+        # appears in the rendered headers.
+        chevron_count = (
+            html.count("▲") + html.count("▼") + html.count("&#9650;") + html.count("&#9660;")
+        )
+        assert chevron_count == 1
+
+    def test_header_link_toggles_direction_when_active(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?sort=title&dir=asc")
+        html = response.data.decode()
+        # Clicking the active title header again should flip to desc.
+        assert "sort=title&amp;dir=desc" in html or "sort=title&dir=desc" in html
+
+    def test_header_link_uses_asc_for_inactive_columns(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?sort=title&dir=asc")
+        html = response.data.decode()
+        # Inactive Author header defaults to asc on first click.
+        assert "sort=author&amp;dir=asc" in html or "sort=author&dir=asc" in html
+        assert "sort=added&amp;dir=asc" in html or "sort=added&dir=asc" in html
+
+    def test_header_link_resets_page_to_one_on_sort_change(self, mock_catalog, client):
+        books = [make_book(i) for i in range(1, 51)]
+        _stub_browse(mock_catalog, books=books, total=120)
+
+        response = client.get("/books?page=3&sort=title&dir=asc")
+        html = response.data.decode()
+        # Header links must not carry page=3 — switching sort resets to page 1.
+        # Find the author header link and assert there's no page param on it.
+        author_link_idx = html.find("sort=author")
+        assert author_link_idx != -1
+        # Search the surrounding link tag — page=3 should be absent within
+        # ~120 chars before/after the sort=author hit (within the href).
+        window = html[max(0, author_link_idx - 200) : author_link_idx + 200]
+        assert "page=3" not in window
+
+    def test_pager_links_preserve_sort_and_dir(self, mock_catalog, client):
+        books = [make_book(i) for i in range(1, 51)]
+        _stub_browse(mock_catalog, books=books, total=120)
+
+        response = client.get("/books?sort=author&dir=desc&page=2")
+        html = response.data.decode()
+        # Both prev and next should carry the active sort + dir.
+        assert "sort=author" in html
+        assert "dir=desc" in html


### PR DESCRIPTION
## Summary

Plan-01 step 3 — make the title, author, and added columns on `/books` sortable via URL-driven state (`?sort=...&dir=...`).

- `BrowseQuery` validates `sort` / `dir` against allow-lists and falls back to the historical default (author asc) on unknown values — stale URLs render the default ordering instead of 400ing.
- `catalog.browse()` honors `sort` + `dir` via a whitelisted ORDER BY map, with `date_added` driving the `added` key. FTS search continues to rank by relevance regardless of sort param.
- Sortable header links toggle direction when re-clicked, default to `asc` on first click, and reset `page` to 1 on any sort change. The active column shows a chevron (▲/▼) reflecting the current direction.
- Pager links preserve `sort` + `dir` so paging through a non-default order doesn't snap back to the default ordering.

Refs plan-01 master issue #146, closes #136.

## Decisions

- **Default sort = author asc** (not title) to preserve the pre-sortable list behavior — unbookmarked users see no change after this lands.
- **Page resets to 1 on sort change** per the plan doc ("deliberately"). Pager links keep the current sort.
- **Unknown sort/dir silently fall back** at both the `BrowseQuery` and catalog layers (defense in depth at the SQL boundary).
- **Added the "Added" column to the table** since a sortable header with no visible column is awkward UX.

## Test plan

- [x] `uv run pytest` — 1532 passed (+33 new tests)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — clean
- [x] Test matrix row covered: `1280px, sort=author dir=desc → first row matches expected, chevron on header` in `tests/web/test_list_browse.py::TestBooksRouteSort::test_active_column_has_descending_chevron`
- [x] Catalog-layer integration tests cover title/author/added × asc/desc and unknown-key fallback
- [x] Route tests cover defaults, unknown-value tolerance, header toggle, page reset on sort change, pager-preserves-sort