### PR TITLE
feat(web): heading hierarchy semantics pass (#126)

### DIFF
--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -61,14 +61,18 @@ body {
     padding: 1rem 2rem;
 }
 
-header h1 {
+header .logo {
+    display: inline-block;
     font-size: 1.5rem;
+    font-weight: bold;
     margin-bottom: 1.5rem;
-}
-
-header h1 a {
     color: var(--color-text);
     text-decoration: none;
+}
+
+.page-title {
+    font-size: 1.75rem;
+    margin: 0 0 1rem;
 }
 
 /* Search */

--- a/src/bookery/web/templates/_detail_classification.html
+++ b/src/bookery/web/templates/_detail_classification.html
@@ -2,10 +2,10 @@
 {# ABOUTME: Primary genres render first, marked with a primary badge. #}
 {% if tags or genres %}
 <section class="section" aria-labelledby="detail-classification">
-    <h3 id="detail-classification">Classification</h3>
+    <h2 id="detail-classification">Classification</h2>
     {% if tags %}
     <div class="tags">
-        <h4>Tags</h4>
+        <h3>Tags</h3>
         <ul>
             {% for tag in tags %}
             <li>{{ tag }}</li>
@@ -15,7 +15,7 @@
     {% endif %}
     {% if genres %}
     <div class="genres">
-        <h4>Genres</h4>
+        <h3>Genres</h3>
         <ul>
             {% for name, is_primary in genres|sort(attribute=1, reverse=true) %}
             <li>{{ name }}{% if is_primary %} <span class="primary-badge">(primary)</span>{% endif %}</li>

--- a/src/bookery/web/templates/_detail_description.html
+++ b/src/bookery/web/templates/_detail_description.html
@@ -2,7 +2,7 @@
 {# ABOUTME: Section is omitted entirely when no description is available. #}
 {% if book.metadata.description %}
 <section class="section" aria-labelledby="detail-description">
-    <h3 id="detail-description">Description</h3>
+    <h2 id="detail-description">Description</h2>
     {{ book.metadata.description | description_paragraphs }}
 </section>
 {% endif %}

--- a/src/bookery/web/templates/_detail_file.html
+++ b/src/bookery/web/templates/_detail_file.html
@@ -1,7 +1,7 @@
 {# ABOUTME: Detail file partial — format, size, paths, hash, dates. #}
 {# ABOUTME: Pure provenance — never mutated through the edit form. #}
 <section class="section" aria-labelledby="detail-file">
-    <h3 id="detail-file">File</h3>
+    <h2 id="detail-file">File</h2>
     <dl class="metadata-grid">
         <dt>Format</dt>
         <dd>{{ file_info.format or "—" }}</dd>

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -2,7 +2,7 @@
 {# ABOUTME: Toolbar wires Edit, Enrich, and Delete (confirm panel via htmx). #}
 <section class="section section-header" aria-labelledby="detail-header">
     <div class="header-titles">
-        <h2 id="detail-header">{{ book.metadata.title }}</h2>
+        <h1 id="detail-header">{{ book.metadata.title }}</h1>
         <p class="byline">by {{ book.metadata.author }}</p>
     </div>
     {% if book.metadata_matched_at %}

--- a/src/bookery/web/templates/_detail_identity.html
+++ b/src/bookery/web/templates/_detail_identity.html
@@ -2,7 +2,7 @@
 {# ABOUTME: Renders only when at least one identity field is set. #}
 {% if book.metadata.isbn or book.metadata.language or book.metadata.series %}
 <section class="section" aria-labelledby="detail-identity">
-    <h3 id="detail-identity">Identity</h3>
+    <h2 id="detail-identity">Identity</h2>
     <dl class="metadata-grid">
         {% if book.metadata.isbn %}
         <dt>ISBN</dt>

--- a/src/bookery/web/templates/_detail_publication.html
+++ b/src/bookery/web/templates/_detail_publication.html
@@ -2,7 +2,7 @@
 {# ABOUTME: Hidden when no publication metadata is set. #}
 {% if book.metadata.publisher %}
 <section class="section" aria-labelledby="detail-publication">
-    <h3 id="detail-publication">Publication</h3>
+    <h2 id="detail-publication">Publication</h2>
     <dl class="metadata-grid">
         <dt>Publisher</dt>
         <dd>{{ book.metadata.publisher }}</dd>

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -1,5 +1,6 @@
 {# ABOUTME: Inline edit form with read-only provenance panel and Esc-to-cancel. #}
 {# ABOUTME: Two-column on >=720px viewports, stacked on mobile (handled by CSS). #}
+<h1 class="page-title">Edit: {{ book.metadata.title }}</h1>
 <div class="edit-layout">
     <form class="edit-form"
           hx-post="{{ url_for('web.update_book', book_id=book.id) }}"

--- a/src/bookery/web/templates/_provenance.html
+++ b/src/bookery/web/templates/_provenance.html
@@ -1,7 +1,7 @@
 {# ABOUTME: Read-only provenance panel for the edit page — paths, hash, dates. #}
 {# ABOUTME: Mirrors _detail_file.html content so editors see file context alongside the form. #}
 <aside class="provenance" aria-labelledby="edit-provenance">
-    <h3 id="edit-provenance">Provenance</h3>
+    <h2 id="edit-provenance">Provenance</h2>
     <dl class="metadata-grid">
         <dt>Format</dt>
         <dd>{{ file_info.format or "—" }}</dd>

--- a/src/bookery/web/templates/base.html
+++ b/src/bookery/web/templates/base.html
@@ -10,7 +10,7 @@
 <body>
     <a class="skip-link" href="#main">Skip to main content</a>
     <header>
-        <h1><a href="{{ url_for('web.books') }}">Bookery</a></h1>
+        <a class="logo" href="{{ url_for('web.books') }}">Bookery</a>
     </header>
     <main id="main">
         {% with messages = get_flashed_messages(with_categories=True) %}

--- a/src/bookery/web/templates/list.html
+++ b/src/bookery/web/templates/list.html
@@ -3,6 +3,7 @@
 {% block title %}Library - Bookery{% endblock %}
 
 {% block content %}
+<h1 class="page-title">Library</h1>
 <div class="search-bar">
     <input type="search"
            name="q"

--- a/tests/web/test_detail.py
+++ b/tests/web/test_detail.py
@@ -24,7 +24,7 @@ class TestDetailSections:
 
         html = client.get("/books/1").data.decode()
         assert 'aria-labelledby="detail-identity"' in html
-        assert "<h3" in html and "Identity" in html
+        assert "<h2" in html and "Identity" in html
         assert "9780441172719" in html
         assert "en" in html
         assert "Dune Chronicles" in html

--- a/tests/web/test_heading_hierarchy.py
+++ b/tests/web/test_heading_hierarchy.py
@@ -1,0 +1,186 @@
+# ABOUTME: Plan-01 step 7 — heading hierarchy semantics tests (issue #126).
+# ABOUTME: Asserts one H1 per page, no heading-level skips, site name not a heading.
+
+from html.parser import HTMLParser
+
+import pytest
+
+from tests.web.conftest import make_book
+
+
+class HeadingCollector(HTMLParser):
+    """Collect headings (level + text) and `.logo` anchor presence in document order.
+
+    Uses only the stdlib to avoid adding a new dependency just for these tests.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.headings: list[tuple[int, str]] = []  # (level, text)
+        self.logo_texts: list[str] = []
+        self._stack: list[tuple[str, dict[str, str]]] = []
+        self._heading_buf: list[str] = []
+        self._logo_buf: list[str] = []
+
+    @staticmethod
+    def _heading_level(tag: str) -> int | None:
+        if len(tag) == 2 and tag[0] == "h" and tag[1].isdigit():
+            n = int(tag[1])
+            if 1 <= n <= 6:
+                return n
+        return None
+
+    def handle_starttag(self, tag, attrs):
+        attrs_d = {k: (v or "") for k, v in attrs}
+        self._stack.append((tag, attrs_d))
+        if tag == "a" and "logo" in attrs_d.get("class", "").split():
+            self._logo_buf = []
+
+    def handle_endtag(self, tag):
+        # Pop matching tag (most recent occurrence) — templates here are
+        # well-formed enough that a simple pop is safe.
+        for i in range(len(self._stack) - 1, -1, -1):
+            if self._stack[i][0] == tag:
+                _, attrs_d = self._stack.pop(i)
+                if tag == "a" and "logo" in attrs_d.get("class", "").split():
+                    self.logo_texts.append("".join(self._logo_buf).strip())
+                    self._logo_buf = []
+                if self._heading_level(tag) is not None:
+                    level = self._heading_level(tag)
+                    assert level is not None  # for type-checker
+                    text = "".join(self._heading_buf).strip()
+                    self.headings.append((level, text))
+                    self._heading_buf = []
+                break
+
+    def handle_data(self, data):
+        # Collect text for any currently-open heading or logo anchor.
+        inside_heading = any(self._heading_level(t) is not None for t, _ in self._stack)
+        if inside_heading:
+            self._heading_buf.append(data)
+        for t, a in self._stack:
+            if t == "a" and "logo" in a.get("class", "").split():
+                self._logo_buf.append(data)
+                break
+
+
+def collect(html: str) -> HeadingCollector:
+    p = HeadingCollector()
+    p.feed(html)
+    return p
+
+
+def assert_no_level_skips(headings: list[tuple[int, str]]) -> None:
+    """Allow same or smaller jumps; forbid increases of more than +1."""
+    prev = 0
+    for level, text in headings:
+        if prev == 0:
+            assert level == 1, f"First heading must be H1, got H{level} ({text!r})"
+        else:
+            assert level <= prev + 1, (
+                f"Heading skip: H{prev} -> H{level} ({text!r}); full sequence: {headings}"
+            )
+        prev = level
+
+
+class TestLogoIsNotHeading:
+    """Site name "Bookery" is an `<a class=logo>`, not a heading element."""
+
+    def test_list_page_logo_is_anchor_not_heading(self, mock_catalog, client):
+        mock_catalog.browse.return_value = ([], 0)
+        html = client.get("/books").data.decode()
+        p = collect(html)
+        # No heading should contain just the site brand text.
+        assert all("Bookery" not in t or level != 1 or t != "Bookery" for level, t in p.headings)
+        # Logo anchor present with brand text.
+        assert "Bookery" in p.logo_texts, (
+            f"Expected an <a class=logo>Bookery</a>; "
+            f"got logos={p.logo_texts}, headings={p.headings}"
+        )
+
+    def test_detail_page_logo_is_anchor_not_heading(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Frank Herbert"])
+        html = client.get("/books/1").data.decode()
+        p = collect(html)
+        assert "Bookery" in p.logo_texts
+
+
+class TestExactlyOneH1:
+    def test_list_page_has_one_h1_library(self, mock_catalog, client):
+        mock_catalog.browse.return_value = ([], 0)
+        html = client.get("/books").data.decode()
+        p = collect(html)
+        h1s = [t for level, t in p.headings if level == 1]
+        assert h1s == ["Library"], f"Expected exactly one H1 'Library', got {h1s}"
+
+    def test_detail_page_h1_is_book_title(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Frank Herbert"])
+        html = client.get("/books/1").data.decode()
+        p = collect(html)
+        h1s = [t for level, t in p.headings if level == 1]
+        assert h1s == ["Dune"], f"Expected exactly one H1 'Dune', got {h1s}"
+
+    def test_edit_partial_h1_is_edit_title(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+        html = client.get("/books/1/edit").data.decode()
+        p = collect(html)
+        h1s = [t for level, t in p.headings if level == 1]
+        assert h1s == ["Edit: Dune"], f"Expected exactly one H1 'Edit: Dune', got {h1s}"
+
+
+class TestNoHeadingLevelSkips:
+    def test_list_page_no_skips(self, mock_catalog, client):
+        mock_catalog.browse.return_value = ([], 0)
+        html = client.get("/books").data.decode()
+        p = collect(html)
+        assert_no_level_skips(p.headings)
+
+    def test_detail_page_no_skips_minimal(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+        html = client.get("/books/1").data.decode()
+        p = collect(html)
+        assert_no_level_skips(p.headings)
+
+    def test_detail_page_no_skips_with_tags_and_genres(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", isbn="9780441172719", series="Dune Chronicles"
+        )
+        mock_catalog.get_tags_for_book.return_value = ["sci-fi", "classic"]
+        mock_catalog.get_genres_for_book.return_value = [("Science Fiction", True)]
+        html = client.get("/books/1").data.decode()
+        p = collect(html)
+        assert_no_level_skips(p.headings)
+
+    def test_edit_partial_no_skips(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+        html = client.get("/books/1/edit").data.decode()
+        p = collect(html)
+        # Edit form is an HTMX partial — in its own context the H1 must
+        # be first and downstream headings must not skip levels.
+        assert_no_level_skips(p.headings)
+
+
+class TestSectionHeadingsAreH2:
+    """Detail section headings drop to H2 once the book title is H1."""
+
+    @pytest.mark.parametrize(
+        "section_text",
+        ["Identity", "Publication", "Classification", "File", "Description"],
+    )
+    def test_section_heading_is_h2_when_present(self, mock_catalog, client, section_text):
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            title="Dune",
+            isbn="9780441172719",
+            language="en",
+            publisher="Ace",
+            description="A novel.",
+        )
+        mock_catalog.get_tags_for_book.return_value = ["sci-fi"]
+        html = client.get("/books/1").data.decode()
+        p = collect(html)
+        matching = [level for level, text in p.headings if text == section_text]
+        assert matching, f"Expected a heading {section_text!r} on detail page"
+        assert all(level == 2 for level in matching), (
+            f"Expected {section_text!r} to be H2, got levels {matching}"
+        )


### PR DESCRIPTION
## Summary

Plan-01 step 7 (issue #126). Restructures heading hierarchy across the web UI so every page has exactly one H1, no level skips, and the site brand is no longer a heading element.

- `base.html`: site name "Bookery" becomes `<a class="logo">` (was `<h1>`)
- `/books`: gains H1 "Library"
- Detail page: H1 is the book title (was H2)
- Edit form: gains H1 "Edit: <title>"
- Section partials demoted: identity / publication / classification / file / description / provenance H3 → H2; classification's Tags & Genres H4 → H3
- `style.css`: adds `.logo` rule preserving the original brand appearance; adds `.page-title` for the new H1s

## Test plan

- [x] `tests/web/test_heading_hierarchy.py` (14 new cases) — parses each route with stdlib `html.parser` and asserts:
  - Site name renders as `<a class=logo>`, not a heading
  - Exactly one H1 per page with the expected subject text
  - No heading-level skips (e.g. H1 → H3)
  - Detail section headings render as H2
- [x] Updated `tests/web/test_detail.py::test_identity_section_present` to assert H2 (was H3)
- [x] Full suite: 1513 passed
- [x] `uv run ruff check src/ tests/` clean

## Refs

- Plan-01 master issue #146
- Step issue #126
- Built on PR #158 (paginated /books list)