### PR TITLE
feat(web): filter chips on /books (#137)

### DIFF
--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -241,6 +241,9 @@ class LibraryCatalog:
         limit: int = 50,
         sort: str = "",
         dir: str = "",
+        enriched: str | None = None,
+        format: str | None = None,
+        language: str | None = None,
     ) -> tuple[list[BookRecord], int]:
         """Paginated browse over the catalog.
 
@@ -253,37 +256,85 @@ class LibraryCatalog:
         (independent of ``offset`` and ``limit``) so the controller can drive
         paging UI without a second round-trip.
 
-        Unknown ``sort`` / ``dir`` values fall back to the default ordering
+        Filters (``enriched`` / ``format`` / ``language``) AND together and
+        with ``q``. ``enriched`` accepts the strings ``"1"`` / ``"0"`` and
+        maps to ``metadata_matched_at IS NOT NULL`` / ``IS NULL`` — the
+        explicit "matched against a provider" signal landed in V7. ``format``
+        is matched against the lowercase extension of ``source_path`` (the
+        only path column guaranteed to be present per the schema NOT NULL
+        constraint); ``output_path`` shares the same extension after a copy.
+        ``language`` is an exact match on the ``language`` column. Unknown
+        ``sort`` / ``dir`` values and unknown ``enriched`` values fall back
         silently — callers are expected to validate at the URL layer
-        (``BrowseQuery``) but the catalog stays robust on its own.
+        (``BrowseQuery``) but the catalog stays robust on its own. All
+        filter values bind as parameters; nothing string-interpolates.
         """
+        filter_sql, filter_params = self._filter_clauses(
+            enriched=enriched, format=format, language=language
+        )
         match = _fts_match_expression(q) if q else ""
         if match:
+            where = "WHERE books_fts MATCH ?" + (
+                " AND " + " AND ".join(filter_sql) if filter_sql else ""
+            )
+            params: list[object] = [match, *filter_params]
             total_row = self._conn.execute(
-                "SELECT COUNT(*) FROM books "
-                "JOIN books_fts ON books.id = books_fts.rowid "
-                "WHERE books_fts MATCH ?",
-                (match,),
+                f"SELECT COUNT(*) FROM books JOIN books_fts ON books.id = books_fts.rowid {where}",
+                params,
             ).fetchone()
             total = int(total_row[0]) if total_row else 0
             cursor = self._conn.execute(
-                "SELECT books.* FROM books "
-                "JOIN books_fts ON books.id = books_fts.rowid "
-                "WHERE books_fts MATCH ? "
-                "ORDER BY books_fts.rank "
-                "LIMIT ? OFFSET ?",
-                (match, limit, offset),
+                f"SELECT books.* FROM books "
+                f"JOIN books_fts ON books.id = books_fts.rowid {where} "
+                f"ORDER BY books_fts.rank "
+                f"LIMIT ? OFFSET ?",
+                [*params, limit, offset],
             )
         else:
-            total_row = self._conn.execute("SELECT COUNT(*) FROM books").fetchone()
+            where = ("WHERE " + " AND ".join(filter_sql)) if filter_sql else ""
+            total_row = self._conn.execute(
+                f"SELECT COUNT(*) FROM books {where}".strip(),
+                filter_params,
+            ).fetchone()
             total = int(total_row[0]) if total_row else 0
             order_clause = _order_clause_for(sort, dir)
             cursor = self._conn.execute(
-                f"SELECT * FROM books ORDER BY {order_clause} LIMIT ? OFFSET ?",
-                (limit, offset),
+                f"SELECT * FROM books {where} ORDER BY {order_clause} LIMIT ? OFFSET ?".strip(),
+                [*filter_params, limit, offset],
             )
         records = [row_to_record(row) for row in cursor.fetchall()]
         return records, total
+
+    @staticmethod
+    def _filter_clauses(
+        *,
+        enriched: str | None,
+        format: str | None,
+        language: str | None,
+    ) -> tuple[list[str], list[object]]:
+        """Translate browse filter args into SQL fragments + bind values.
+
+        Returns a list of WHERE-clause fragments (each fully parenthesized
+        and AND-safe) plus the parameters they consume, in order. Unknown
+        ``enriched`` values are dropped — defense in depth on top of the URL
+        layer's ``ALLOWED_FILTERS`` whitelist. Format matching uses
+        ``LOWER(source_path) LIKE '%.' || ?`` rather than SQLite's
+        ``substr``/``instr`` so the extension comparison is case-insensitive
+        without forcing the input to a particular case.
+        """
+        clauses: list[str] = []
+        params: list[object] = []
+        if enriched == "1":
+            clauses.append("metadata_matched_at IS NOT NULL")
+        elif enriched == "0":
+            clauses.append("metadata_matched_at IS NULL")
+        if format:
+            clauses.append("LOWER(source_path) LIKE '%.' || ?")
+            params.append(format.lower())
+        if language:
+            clauses.append("language = ?")
+            params.append(language)
+        return clauses, params
 
     def update_book(
         self,

--- a/src/bookery/web/browse.py
+++ b/src/bookery/web/browse.py
@@ -18,14 +18,27 @@ ALLOWED_DIRS: frozenset[str] = frozenset({"asc", "desc"})
 DEFAULT_SORT = "author"
 DEFAULT_DIR = "asc"
 
+# Allowed filter keys for the /books list controller. Anything else falls off
+# silently — bookmarks and stale links shouldn't be able to either crash the
+# query or smuggle unexpected SQL columns through. Bumping this set is a
+# behavior change and needs the chip template's label map updated in lock-step.
+ALLOWED_FILTERS: frozenset[str] = frozenset({"enriched", "format", "language"})
+
+# Value whitelists. ``enriched`` is a strict 0/1 toggle so any other value is
+# nonsense. ``format`` and ``language`` are open-ended (any extension or BCP-47
+# tag), but we lowercase and trim so the URL form is normalized for chip
+# rendering and parameter binding.
+_ENRICHED_VALUES: frozenset[str] = frozenset({"0", "1"})
+
 
 @dataclass(frozen=True)
 class BrowseQuery:
     """Parsed URL state for the /books list controller.
 
-    ``filters`` is reserved for plan-01 step 4. ``sort`` and ``dir`` are
-    validated at parse time so the controller and the catalog can trust them
-    without re-checking.
+    ``sort``, ``dir``, and ``filters`` are validated at parse time so the
+    controller and the catalog can trust them without re-checking. ``filters``
+    is a mapping of whitelisted filter keys (see ``ALLOWED_FILTERS``) to
+    their normalized values.
     """
 
     q: str = ""
@@ -47,6 +60,23 @@ class BrowseQuery:
             sort=self.sort,
             dir=self.dir,
             filters=self.filters,
+        )
+
+    def without_filter(self, key: str) -> "BrowseQuery":
+        """Return a copy with ``key`` removed from filters and page reset to 1.
+
+        Changing the active filter set invalidates the page index (same
+        convention as a sort change), so callers don't have to remember to
+        reset the page when wiring chip dismiss links.
+        """
+        new_filters = {k: v for k, v in self.filters.items() if k != key}
+        return BrowseQuery(
+            q=self.q,
+            page=1,
+            page_size=self.page_size,
+            sort=self.sort,
+            dir=self.dir,
+            filters=new_filters,
         )
 
 
@@ -80,6 +110,32 @@ def _coerce_dir(value: str | None) -> str:
     return DEFAULT_DIR
 
 
+def _coerce_filters(args: Mapping[str, str]) -> dict[str, str]:
+    """Pick out the known filter keys from ``args`` and normalize their values.
+
+    Unknown keys are dropped silently (stale URLs shouldn't 400 the front
+    door). Empty / whitespace-only values are also dropped — they encode
+    "no filter" and shouldn't show up as a chip. ``enriched`` is whitelisted
+    to ``{"0","1"}``; ``format`` and ``language`` are lowercased + trimmed so
+    the URL form normalizes for chip rendering and SQL binding.
+    """
+    out: dict[str, str] = {}
+    for key in ALLOWED_FILTERS:
+        raw = args.get(key)
+        if raw is None:
+            continue
+        value = raw.strip()
+        if not value:
+            continue
+        if key == "enriched":
+            if value not in _ENRICHED_VALUES:
+                continue
+            out[key] = value
+        else:
+            out[key] = value.lower()
+    return out
+
+
 def from_request_args(
     args: Mapping[str, str], *, default_page_size: int = DEFAULT_PAGE_SIZE
 ) -> BrowseQuery:
@@ -89,7 +145,9 @@ def from_request_args(
     ``page`` is clamped to ``>= 1``; the upper bound (total pages) is the
     controller's responsibility once it has a result count. ``sort`` and
     ``dir`` are validated against the allow-lists so unknown values render
-    the default ordering instead of crashing the catalog query.
+    the default ordering instead of crashing the catalog query. Filter
+    keys not in ``ALLOWED_FILTERS`` (and values failing per-key validation)
+    are dropped silently.
     """
     return BrowseQuery(
         q=(args.get("q") or "").strip(),
@@ -97,6 +155,7 @@ def from_request_args(
         page_size=default_page_size,
         sort=_coerce_sort(args.get("sort")),
         dir=_coerce_dir(args.get("dir")),
+        filters=_coerce_filters(args),
     )
 
 

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -94,6 +94,7 @@ def books():
         limit=query.page_size,
         sort=query.sort,
         dir=query.dir,
+        **query.filters,
     )
 
     # Clamp out-of-range page requests to the last valid page rather than
@@ -107,6 +108,7 @@ def books():
             limit=clamped.page_size,
             sort=clamped.sort,
             dir=clamped.dir,
+            **clamped.filters,
         )
         query = clamped
 

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -1,17 +1,20 @@
-{# ABOUTME: Plan-01 paginated list partial — count label, sortable table, pager. #}
+{# ABOUTME: Plan-01 paginated list partial — chip strip, count label, sortable table, pager. #}
 {# Rendered standalone for htmx swaps into #book-list. #}
+
+{% include "_filter_chips.html" %}
 
 {% if page.total > 0 %}
     <p class="result-count">Showing {{ page.start }}&ndash;{{ page.end }} of {{ page.total }}</p>
 
     {# Sortable header link macro. Clicking the active column flips direction;
        clicking an inactive column starts at ``asc``. Page resets to 1 on any
-       sort change — the user has new ordering, the old page index is stale. #}
+       sort change — the user has new ordering, the old page index is stale.
+       Active filters ride along so the user's filter set survives a re-sort. #}
     {% macro sort_link(label, key) -%}
         {%- set is_active = (query.sort == key) -%}
         {%- set next_dir = 'desc' if (is_active and query.dir == 'asc') else 'asc' -%}
         <a class="sort-link{% if is_active %} sort-active{% endif %}"
-           href="{{ url_for('web.books', q=query.q or none, sort=key, dir=next_dir) }}"
+           href="{{ url_for('web.books', q=query.q or none, sort=key, dir=next_dir, **query.filters) }}"
            aria-sort="{{ 'descending' if (is_active and query.dir == 'desc') else ('ascending' if is_active else 'none') }}">
             {{ label }}{% if is_active %} <span class="sort-chevron" aria-hidden="true">{% if query.dir == 'desc' %}&#9660;{% else %}&#9650;{% endif %}</span>{% endif %}
         </a>
@@ -50,8 +53,8 @@
     <nav class="pager" aria-label="Pagination">
         {% if page.has_prev %}
             <a class="pager-prev"
-               href="{{ url_for('web.books', q=query.q or none, page=page.page - 1, sort=query.sort, dir=query.dir) }}"
-               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page - 1, sort=query.sort, dir=query.dir) }}"
+               href="{{ url_for('web.books', q=query.q or none, page=page.page - 1, sort=query.sort, dir=query.dir, **query.filters) }}"
+               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page - 1, sort=query.sort, dir=query.dir, **query.filters) }}"
                hx-target="#book-list"
                hx-push-url="true">&laquo; Previous</a>
         {% else %}
@@ -62,8 +65,8 @@
 
         {% if page.has_next %}
             <a class="pager-next"
-               href="{{ url_for('web.books', q=query.q or none, page=page.page + 1, sort=query.sort, dir=query.dir) }}"
-               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page + 1, sort=query.sort, dir=query.dir) }}"
+               href="{{ url_for('web.books', q=query.q or none, page=page.page + 1, sort=query.sort, dir=query.dir, **query.filters) }}"
+               hx-get="{{ url_for('web.books', q=query.q or none, page=page.page + 1, sort=query.sort, dir=query.dir, **query.filters) }}"
                hx-target="#book-list"
                hx-push-url="true">Next &raquo;</a>
         {% else %}
@@ -71,6 +74,12 @@
         {% endif %}
     </nav>
     {% endif %}
+{% elif query.filters %}
+    {# Filtered-to-zero state. Preserve the search query in the clear-filters
+       link so a user who typed a query and then filtered into empty results
+       can drop only the filters, not their search. #}
+    <p class="empty-state">No books match these filters.</p>
+    <p><a class="clear-filters" href="{{ url_for('web.books', q=query.q or none) }}">Clear filters</a></p>
 {% elif query.q %}
     <p class="empty-state">No books matching '{{ query.q }}'</p>
 {% else %}

--- a/src/bookery/web/templates/_filter_chips.html
+++ b/src/bookery/web/templates/_filter_chips.html
@@ -1,0 +1,35 @@
+{# ABOUTME: Plan-01 step 4 chip strip — renders dismissible pills for the active filter set. #}
+{# Each chip's dismiss link rebuilds the /books URL without that filter (and resets page=1). #}
+
+{%- macro chip_label(key, value) -%}
+    {%- if key == 'enriched' -%}
+        {%- if value == '1' -%}Enriched{%- else -%}Not enriched{%- endif -%}
+    {%- elif key == 'format' -%}
+        Format: {{ value|upper }}
+    {%- elif key == 'language' -%}
+        Language: {{ value }}
+    {%- else -%}
+        {{ key }}: {{ value }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{% if query.filters %}
+<div class="filter-chips" aria-label="Active filters">
+    {% for key, value in query.filters.items() %}
+        {%- set remaining = {} -%}
+        {%- for fk, fv in query.filters.items() if fk != key -%}
+            {%- set _ = remaining.update({fk: fv}) -%}
+        {%- endfor -%}
+        <span class="filter-chip">
+            <span class="filter-chip-label">{{ chip_label(key, value) }}</span>
+            <a class="filter-chip-dismiss"
+               href="{{ url_for('web.books',
+                                q=query.q or none,
+                                sort=query.sort,
+                                dir=query.dir,
+                                **remaining) }}"
+               aria-label="Remove filter {{ chip_label(key, value) }}">&times;</a>
+        </span>
+    {% endfor %}
+</div>
+{% endif %}

--- a/tests/unit/test_catalog_browse.py
+++ b/tests/unit/test_catalog_browse.py
@@ -198,3 +198,111 @@ class TestBrowseSort:
         # Unknown key should not crash; behaves like default (author asc).
         rows, _ = catalog.browse(sort="bogus", dir="desc")
         assert len(rows) == 3
+
+
+class TestBrowseFilters:
+    def _seed_mix(self, catalog: LibraryCatalog) -> dict[str, int]:
+        """Seed a fixed catalog and return a name->id map for assertions.
+
+        Mix of formats (epub/pdf), languages (en/fr), and matched status so
+        each filter axis has signal to detect.
+        """
+        spec = [
+            ("en-epub-matched", "en", "/tmp/a.epub", True),
+            ("en-epub-unmatched", "en", "/tmp/b.epub", False),
+            ("fr-epub-matched", "fr", "/tmp/c.epub", True),
+            ("en-pdf-unmatched", "en", "/tmp/d.pdf", False),
+            ("fr-pdf-matched", "fr", "/tmp/e.pdf", True),
+        ]
+        name_to_id: dict[str, int] = {}
+        for name, lang, path, matched in spec:
+            meta = BookMetadata(
+                title=name,
+                authors=["A"],
+                language=lang,
+                source_path=Path(path),
+            )
+            book_id = catalog.add_book(meta, file_hash=name.ljust(64, "0"))
+            if matched:
+                catalog.set_matched_at(book_id)
+            name_to_id[name] = book_id
+        return name_to_id
+
+    def test_enriched_1_returns_only_matched_books(self, catalog):
+        ids = self._seed_mix(catalog)
+        rows, total = catalog.browse(enriched="1")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"en-epub-matched", "fr-epub-matched", "fr-pdf-matched"}
+        assert total == 3
+        del ids
+
+    def test_enriched_0_returns_only_unmatched_books(self, catalog):
+        self._seed_mix(catalog)
+        rows, total = catalog.browse(enriched="0")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"en-epub-unmatched", "en-pdf-unmatched"}
+        assert total == 2
+
+    def test_format_epub_matches_path_extension(self, catalog):
+        self._seed_mix(catalog)
+        rows, total = catalog.browse(format="epub")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"en-epub-matched", "en-epub-unmatched", "fr-epub-matched"}
+        assert total == 3
+
+    def test_format_pdf_matches_path_extension(self, catalog):
+        self._seed_mix(catalog)
+        rows, total = catalog.browse(format="pdf")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"en-pdf-unmatched", "fr-pdf-matched"}
+        assert total == 2
+
+    def test_language_filter_exact_match(self, catalog):
+        self._seed_mix(catalog)
+        rows, total = catalog.browse(language="fr")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"fr-epub-matched", "fr-pdf-matched"}
+        assert total == 2
+
+    def test_filters_combine_with_and(self, catalog):
+        self._seed_mix(catalog)
+        rows, total = catalog.browse(enriched="1", format="epub", language="fr")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"fr-epub-matched"}
+        assert total == 1
+
+    def test_total_reflects_filters(self, catalog):
+        self._seed_mix(catalog)
+        _, total = catalog.browse(enriched="0", limit=1)
+        # Total counts the filtered set, not the page.
+        assert total == 2
+
+    def test_unknown_filter_value_silently_ignored(self, catalog):
+        self._seed_mix(catalog)
+        # Bogus enriched value should be a no-op (return everything).
+        rows, total = catalog.browse(enriched="maybe")
+        assert total == 5
+        assert len(rows) == 5
+
+    def test_filters_apply_with_search_query(self, catalog):
+        self._seed_mix(catalog)
+        # FTS search for "epub" appears in titles — combined with enriched=0.
+        rows, total = catalog.browse(q="epub", enriched="0")
+        titles = {r.metadata.title for r in rows}
+        assert titles == {"en-epub-unmatched"}
+        assert total == 1
+
+    def test_format_uses_parameter_binding_not_string_interpolation(self, catalog):
+        """A malicious format value should not be able to inject SQL.
+
+        We don't expect to ever receive such input (the URL layer whitelists
+        format values too), but defense in depth — the catalog must use
+        parameter binding so the worst case is "no rows matched".
+        """
+        self._seed_mix(catalog)
+        rows, total = catalog.browse(format="epub'; DROP TABLE books; --")
+        assert rows == []
+        assert total == 0
+        # Sanity: catalog still has its rows.
+        all_rows, _ = catalog.browse()
+        assert len(all_rows) == 5

--- a/tests/web/test_list_browse.py
+++ b/tests/web/test_list_browse.py
@@ -336,3 +336,197 @@ class TestBooksRouteSort:
         # Both prev and next should carry the active sort + dir.
         assert "sort=author" in html
         assert "dir=desc" in html
+
+
+# --- BrowseQuery filter parsing ---
+
+
+class TestBrowseQueryFilterParsing:
+    def test_no_filters_when_args_empty(self):
+        q = from_request_args({})
+        assert dict(q.filters) == {}
+
+    def test_parses_known_filter_keys(self):
+        q = from_request_args({"enriched": "1", "format": "epub", "language": "en"})
+        assert q.filters == {"enriched": "1", "format": "epub", "language": "en"}
+
+    @pytest.mark.parametrize("bad", ["author", "title", "sort", "page", "q", "drop_table"])
+    def test_unknown_filter_keys_silently_dropped(self, bad):
+        q = from_request_args({bad: "anything"})
+        assert bad not in q.filters
+
+    @pytest.mark.parametrize("bad", ["yes", "true", "2", "", "-1"])
+    def test_enriched_only_accepts_0_or_1(self, bad):
+        q = from_request_args({"enriched": bad})
+        assert "enriched" not in q.filters
+
+    def test_enriched_zero_kept(self):
+        q = from_request_args({"enriched": "0"})
+        assert q.filters["enriched"] == "0"
+
+    def test_format_lowercased(self):
+        q = from_request_args({"format": "EPUB"})
+        assert q.filters["format"] == "epub"
+
+    def test_format_empty_dropped(self):
+        q = from_request_args({"format": ""})
+        assert "format" not in q.filters
+
+    def test_language_lowercased_and_trimmed(self):
+        q = from_request_args({"language": "  EN  "})
+        assert q.filters["language"] == "en"
+
+    def test_language_empty_dropped(self):
+        q = from_request_args({"language": ""})
+        assert "language" not in q.filters
+
+    def test_with_page_preserves_filters(self):
+        q = from_request_args({"enriched": "1", "format": "epub", "page": "2"})
+        bumped = q.with_page(5)
+        assert bumped.filters == {"enriched": "1", "format": "epub"}
+        assert bumped.page == 5
+
+
+# --- /books route: filter chips ---
+
+
+class TestBooksRouteFilters:
+    def test_route_passes_filters_to_catalog(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        client.get("/books?enriched=1&format=epub&language=en")
+
+        kwargs = mock_catalog.browse.call_args.kwargs
+        assert kwargs.get("enriched") == "1"
+        assert kwargs.get("format") == "epub"
+        assert kwargs.get("language") == "en"
+
+    def test_route_omits_filters_when_none_provided(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        client.get("/books")
+
+        kwargs = mock_catalog.browse.call_args.kwargs
+        # Filters absent or explicitly None — catalog default is "no filter".
+        assert kwargs.get("enriched") in (None, "")
+        assert kwargs.get("format") in (None, "")
+        assert kwargs.get("language") in (None, "")
+
+    def test_route_renders_chip_for_each_active_filter(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?enriched=0&format=epub&language=en")
+        html = response.data.decode()
+
+        # Each active filter shows up as a chip with its label
+        assert "filter-chip" in html
+        # Human-readable labels for known filter keys
+        assert "Not enriched" in html or "not enriched" in html.lower()
+        assert "epub" in html.lower()
+        assert "en" in html.lower()
+
+    def test_chip_dismiss_link_drops_that_filter_only(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?enriched=1&format=epub")
+        html = response.data.decode()
+
+        # The dismiss link for `format` should keep enriched=1 but drop format.
+        # We don't pin exact URL format, just that a link exists matching the
+        # remaining filter set.
+        assert "enriched=1" in html
+        # Look for a dismiss link that does NOT include format=epub
+        import re
+
+        dismiss_links = re.findall(r'href="([^"]*/books[^"]*)"', html)
+        # At least one chip dismiss link should drop format while keeping enriched.
+        assert any("enriched=1" in link and "format=epub" not in link for link in dismiss_links), (
+            f"no dismiss link drops format: {dismiss_links}"
+        )
+
+    def test_chip_dismiss_resets_page_to_one(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?enriched=1&format=epub&page=3")
+        html = response.data.decode()
+
+        # Chip dismiss links should not carry page=3 — filter changes reset
+        # to page 1 (same convention as sort).
+        import re
+
+        chip_links = re.findall(r'class="filter-chip-dismiss"[^>]*href="([^"]*)"', html)
+        for link in chip_links:
+            assert "page=3" not in link
+
+    def test_no_chips_rendered_when_no_filters_active(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books")
+        html = response.data.decode()
+
+        assert "filter-chip" not in html
+
+    def test_unknown_filter_value_silently_ignored(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?enriched=maybe")
+
+        assert response.status_code == 200
+        kwargs = mock_catalog.browse.call_args.kwargs
+        # Filter dropped at the query layer
+        assert kwargs.get("enriched") in (None, "")
+
+    def test_empty_filter_result_shows_clear_filters_action(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[], total=0)
+
+        response = client.get("/books?enriched=1&format=epub")
+        html = response.data.decode()
+
+        assert "No books match these filters." in html
+        # "Clear filters" link returns to /books (without the filter args).
+        assert "Clear filters" in html
+        import re
+
+        clear_links = re.findall(r'href="([^"]*)"[^>]*>\s*Clear filters', html)
+        assert clear_links, "Clear filters link missing"
+        for link in clear_links:
+            assert "enriched=" not in link
+            assert "format=" not in link
+
+    def test_filter_chip_preserves_search_query_in_dismiss(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?q=dune&enriched=1")
+        html = response.data.decode()
+
+        # Dismissing the enriched chip should retain q=dune.
+        import re
+
+        dismiss_links = re.findall(r'class="filter-chip-dismiss"[^>]*href="([^"]*)"', html)
+        assert dismiss_links
+        for link in dismiss_links:
+            assert "q=dune" in link
+
+    def test_pager_links_preserve_filters(self, mock_catalog, client):
+        books = [make_book(i) for i in range(1, 51)]
+        _stub_browse(mock_catalog, books=books, total=120)
+
+        response = client.get("/books?enriched=1&format=epub&page=2")
+        html = response.data.decode()
+
+        assert "enriched=1" in html
+        assert "format=epub" in html
+
+    def test_sort_header_links_preserve_filters(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        response = client.get("/books?enriched=1&sort=title&dir=asc")
+        html = response.data.decode()
+
+        # The author header link (inactive sort) should preserve the filter.
+        import re
+
+        sort_hrefs = re.findall(r'class="sort-link[^"]*"\s*href="([^"]*)"', html)
+        assert sort_hrefs
+        for href in sort_hrefs:
+            assert "enriched=1" in href


### PR DESCRIPTION
## Summary

Plan-01 step 4 — URL-driven, dismissible filter chips for **enriched**, **format**, and **language** on `/books`. Filters AND together with each other and with `q`/`sort`/`dir`, ride along on sort + pager links, reset to page 1 on change, and surface a dedicated "No books match these filters." empty state with a Clear filters action that preserves the active search query.

- `BrowseQuery`: `ALLOWED_FILTERS` whitelist + per-key value validation. `enriched` ∈ `{"0","1"}`; `format` / `language` lowercased + trimmed. Unknown keys/values silently dropped. New `without_filter()` helper for chip dismiss URLs.
- `LibraryCatalog.browse`: new `enriched` / `format` / `language` kwargs.
  - `enriched=1` → `metadata_matched_at IS NOT NULL` (and `=0` → `IS NULL`), wired to the explicit matched signal added in #157 / commit 545e9e5.
  - `format` matches the lowercased extension of `source_path` (the schema's NOT NULL path column; shares the same extension as `output_path` after a copy).
  - `language` exact-matches the `language` column.
  - All values bind as `?` parameters — no string interpolation.
- New `_filter_chips.html` partial included above the table; reusable in isolation.

Refs plan-01 master #146 and child #137.

## Test plan

- [x] `uv run pytest` — 1586 passed (+40 over main: 19 BrowseQuery filter cases, 11 catalog filter cases, 10 route/template cases).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run ruff format src/... tests/...` on touched files.
- [x] Pre-commit (`ruff check`, `pyright`) clean.
- [ ] Manual: visit `/books?enriched=0&format=epub`, dismiss a chip, hit "Clear filters" from a zero-result set.