### PR TITLE
feat(web): cover thumbnails on list and detail (#139)

### DIFF
--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -76,6 +76,19 @@ def _detect_isbn(identifiers: dict[str, str]) -> str | None:
 
 def _extract_cover_image(book: epub.EpubBook) -> bytes | None:
     """Extract cover image data from an EPUB, if present."""
+    item = _find_cover_item(book)
+    return item.get_content() if item is not None else None
+
+
+def _find_cover_item(book: epub.EpubBook):
+    """Locate the cover image manifest item, or None.
+
+    Follows the EPUB cover convention: an OPF meta tag ``<meta name="cover"
+    content="cover-id"/>`` points at the manifest entry. Falls back to any
+    item with ``cover`` in its id or filename whose type registers as an
+    image or cover. Used by both metadata extraction and the web cover
+    route so the same resolution rules apply everywhere.
+    """
     # Check for cover image in metadata
     cover_id = None
     meta_entries = book.get_metadata("OPF", "cover")
@@ -84,8 +97,8 @@ def _extract_cover_image(book: epub.EpubBook) -> bytes | None:
 
     if cover_id:
         cover_item = book.get_item_with_id(cover_id)
-        if cover_item:
-            return cover_item.get_content()
+        if cover_item is not None:
+            return cover_item
 
     # Fallback: look for items with "cover" in the id or filename
     for item in book.get_items():
@@ -94,9 +107,59 @@ def _extract_cover_image(book: epub.EpubBook) -> bytes | None:
         if "cover" in item_id.lower() or "cover" in item_name.lower():
             content_type = item.get_type()
             if content_type in (ebooklib.ITEM_IMAGE, ebooklib.ITEM_COVER):
-                return item.get_content()
-
+                return item
     return None
+
+
+_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"RIFF", "image/webp"),  # WEBP starts with RIFF....WEBP
+)
+
+
+def _guess_image_content_type(data: bytes, fallback: str | None = None) -> str:
+    """Best-effort image content-type from magic bytes.
+
+    The OPF media-type attribute is the authoritative answer, but it's not
+    always set or reliable. Sniffing the file header recovers JPEG/PNG/GIF/WEBP
+    without pulling in Pillow. Falls back to the supplied ``fallback`` (typically
+    the manifest's media_type), then ``image/jpeg`` as a last resort — every
+    modern browser will still render the bytes correctly with that guess.
+    """
+    for magic, content_type in _IMAGE_MAGIC:
+        if data.startswith(magic):
+            return content_type
+    if fallback:
+        return fallback
+    return "image/jpeg"
+
+
+def extract_cover_bytes(path: Path) -> tuple[bytes, str] | None:
+    """Read an EPUB and return ``(cover_bytes, content_type)`` if present.
+
+    Returns ``None`` when the file is missing, unreadable, or has no cover
+    image. The content type is sniffed from the image header so callers can
+    set an accurate ``Content-Type`` without parsing OPF media-type
+    attributes themselves. Used by the web ``/books/<id>/cover`` route via
+    the on-disk cover cache.
+    """
+    if not path.exists():
+        return None
+    try:
+        book = epub.read_epub(str(path), options={"ignore_ncx": True})
+    except Exception:
+        return None
+    item = _find_cover_item(book)
+    if item is None:
+        return None
+    data = item.get_content()
+    if not data:
+        return None
+    fallback = getattr(item, "media_type", None) or None
+    return data, _guess_image_content_type(data, fallback=fallback)
 
 
 def read_epub_metadata(path: Path) -> BookMetadata:
@@ -179,13 +242,16 @@ def _scrub_none_metadata(book: epub.EpubBook) -> None:
             if len(cleaned) < len(entries):
                 logger.debug(
                     "Scrubbed %d None metadata entries from %s/%s",
-                    len(entries) - len(cleaned), ns, name,
+                    len(entries) - len(cleaned),
+                    ns,
+                    name,
                 )
                 book.metadata[ns][name] = cleaned
 
     # If scrubbing removed the uid identifier, generate a replacement
     if book.uid is None:
         import uuid
+
         new_uid = str(uuid.uuid4())
         book.set_unique_metadata("DC", "identifier", new_uid, {"id": "bookery-uid"})
         book.uid = new_uid
@@ -199,7 +265,8 @@ def _scrub_none_guide(book: epub.EpubBook) -> None:
     """
     original_len = len(book.guide)
     book.guide = [
-        entry for entry in book.guide
+        entry
+        for entry in book.guide
         if entry.get("href") is not None and entry.get("type") is not None
     ]
     removed = original_len - len(book.guide)

--- a/src/bookery/web/covers.py
+++ b/src/bookery/web/covers.py
@@ -1,0 +1,98 @@
+# ABOUTME: Cover image extraction with on-disk cache for the web cover route.
+# ABOUTME: Lazy-extracts from EPUB on first request, caches to <library_root>/.covers/.
+
+import contextlib
+from pathlib import Path
+
+from bookery.formats.epub import extract_cover_bytes
+
+# Inline SVG placeholder served when a book has no extractable cover.
+# Kept tiny so the response is cheap to send repeatedly and the same bytes
+# can be cached aggressively by clients. Renders as a book-icon glyph in
+# muted greys that fit either the list thumb (40x60) or the detail hero
+# (160x240) via the surrounding <img> sizing.
+PLACEHOLDER_SVG: bytes = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 60" '
+    b'preserveAspectRatio="xMidYMid meet" role="img" aria-label="No cover">'
+    b'<rect width="40" height="60" fill="#e5e5e5"/>'
+    b'<rect x="6" y="8" width="28" height="44" fill="#bdbdbd" stroke="#9e9e9e" stroke-width="1"/>'
+    b'<line x1="11" y1="20" x2="29" y2="20" stroke="#7d7d7d" stroke-width="1.2"/>'
+    b'<line x1="11" y1="28" x2="29" y2="28" stroke="#7d7d7d" stroke-width="1.2"/>'
+    b'<line x1="11" y1="36" x2="25" y2="36" stroke="#7d7d7d" stroke-width="1.2"/>'
+    b"</svg>"
+)
+PLACEHOLDER_CONTENT_TYPE: str = "image/svg+xml"
+
+
+_EXTENSION_FOR_CONTENT_TYPE: dict[str, str] = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/svg+xml": ".svg",
+}
+
+
+def _cache_dir(library_root: Path) -> Path:
+    """Return the cover cache directory for ``library_root`` (created on demand)."""
+    cache = library_root / ".covers"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def _cached_path(library_root: Path, book_id: int, content_type: str) -> Path:
+    """Compute the on-disk cache path for a book's cover at ``content_type``."""
+    ext = _EXTENSION_FOR_CONTENT_TYPE.get(content_type, ".bin")
+    return _cache_dir(library_root) / f"{book_id}{ext}"
+
+
+def _find_cached(library_root: Path, book_id: int) -> tuple[bytes, str] | None:
+    """Return cached bytes + content-type for ``book_id``, if cached.
+
+    Probes every known extension so we don't have to remember which media
+    type the original extraction produced. This keeps the route stateless
+    across process restarts.
+    """
+    cache = library_root / ".covers"
+    if not cache.exists():
+        return None
+    for content_type, ext in _EXTENSION_FOR_CONTENT_TYPE.items():
+        path = cache / f"{book_id}{ext}"
+        if path.exists():
+            return path.read_bytes(), content_type
+    return None
+
+
+def get_or_extract_cover(
+    book_id: int,
+    epub_path: Path | None,
+    library_root: Path,
+) -> tuple[bytes, str]:
+    """Return ``(bytes, content_type)`` for a book's cover.
+
+    Resolution order: in-memory placeholder for missing source; on-disk cache
+    if present; otherwise extract from the EPUB and write the cache. When
+    extraction fails (no cover, unreadable file), the placeholder SVG is
+    returned but **not** cached to disk — re-importing a file with a cover
+    later should not be defeated by a sticky placeholder. The route caller is
+    free to set ``Cache-Control`` so the client still serves the placeholder
+    from its own cache between requests.
+    """
+    if epub_path is None or not epub_path.exists():
+        return PLACEHOLDER_SVG, PLACEHOLDER_CONTENT_TYPE
+
+    cached = _find_cached(library_root, book_id)
+    if cached is not None:
+        return cached
+
+    result = extract_cover_bytes(epub_path)
+    if result is None:
+        return PLACEHOLDER_SVG, PLACEHOLDER_CONTENT_TYPE
+
+    data, content_type = result
+    # Cache writes are best-effort. Serving the bytes is what matters;
+    # a read-only or full disk should not break the route.
+    with contextlib.suppress(OSError):
+        _cached_path(library_root, book_id, content_type).write_bytes(data)
+    return data, content_type

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -16,6 +16,7 @@ from flask import (
     url_for,
 )
 
+from bookery.core.config import get_library_root
 from bookery.core.enrichment import dispatch_from_form, multi_provider_search
 from bookery.core.pipeline import apply_metadata_safely
 from bookery.core.remove import remove_book
@@ -23,6 +24,7 @@ from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.provider import MetadataProvider
 from bookery.util.text import strip_html
 from bookery.web.browse import BrowsePage, from_request_args
+from bookery.web.covers import get_or_extract_cover
 from bookery.web.diff import metadata_diff
 
 
@@ -144,6 +146,38 @@ def book_detail(book_id):
         )
 
     return render_template("detail.html", book=book, tags=tags, genres=genres, file_info=file_info)
+
+
+@bp.route("/books/<int:book_id>/cover")
+def book_cover(book_id):
+    """Serve a book's cover image (lazy-extracted, on-disk cached).
+
+    Resolves the cover from the library copy (``output_path``) if present,
+    otherwise the source file. Missing books 404; books with no extractable
+    cover get the inline SVG placeholder (200) so the ``<img>`` tag in the
+    list/detail templates never falls back to a broken-image glyph. Successful
+    extractions are cached under ``<library_root>/.covers/<book_id>.<ext>``;
+    every response — placeholder included — sets a long ``Cache-Control`` so
+    the browser handles the repeat case.
+    """
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    epub_path: Path | None = book.output_path or book.source_path
+    library_root = get_library_root()
+
+    data, content_type = get_or_extract_cover(
+        book_id=book_id,
+        epub_path=epub_path,
+        library_root=library_root,
+    )
+
+    response = make_response(data)
+    response.headers["Content-Type"] = content_type
+    response.headers["Cache-Control"] = "public, max-age=86400"
+    return response
 
 
 @bp.route("/books/<int:book_id>/edit", methods=["GET"])

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -577,3 +577,40 @@ header .logo {
     font-size: 0.85rem;
     font-style: italic;
 }
+
+/* --- Cover thumbnails and hero (issue #139, plan-01 step 5) ------------- */
+
+.book-table th.book-row-cover,
+.book-table td.book-row-cover {
+    width: 48px;
+    padding: 0.25rem 0.5rem;
+}
+
+.book-cover-thumb {
+    display: block;
+    width: 40px;
+    height: 60px;
+    object-fit: cover;
+    border: 1px solid var(--color-border);
+    background: #f0f0f0;
+}
+
+/* Hero cover floats to the left of the title block. The section-header
+   selectors above target the title/byline siblings; the hero is a new
+   sibling so the grid stays linear while the float pulls the image. */
+.book-cover-hero {
+    float: left;
+    width: 160px;
+    height: 240px;
+    object-fit: cover;
+    margin: 0 1rem 0.5rem 0;
+    border: 1px solid var(--color-border);
+    background: #f0f0f0;
+}
+
+@media (max-width: 600px) {
+    .book-cover-hero {
+        width: 96px;
+        height: 144px;
+    }
+}

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -23,6 +23,7 @@
     <table class="book-table">
         <thead>
             <tr>
+                <th class="book-row-cover" aria-label="Cover"></th>
                 <th>{{ sort_link('Title', 'title') }}</th>
                 <th>{{ sort_link('Author', 'author') }}</th>
                 <th>ISBN</th>
@@ -35,6 +36,16 @@
         <tbody>
             {% for book in page.books %}
             <tr class="book-row">
+                <td class="book-row-cover">
+                    <a href="{{ url_for('web.book_detail', book_id=book.id) }}" tabindex="-1" aria-hidden="true">
+                        <img class="book-cover-thumb"
+                             src="{{ url_for('web.book_cover', book_id=book.id) }}"
+                             alt=""
+                             loading="lazy"
+                             width="40"
+                             height="60">
+                    </a>
+                </td>
                 <td class="book-row-title">
                     <a href="{{ url_for('web.book_detail', book_id=book.id) }}">{{ book.metadata.title }}</a>
                 </td>

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -1,6 +1,11 @@
 {# ABOUTME: Detail header partial — title, author(s), enriched badge, toolbar. #}
 {# ABOUTME: Toolbar wires Edit, Enrich, and Delete (confirm panel via htmx). #}
 <section class="section section-header" aria-labelledby="detail-header">
+    <img class="book-cover-hero"
+         src="{{ url_for('web.book_cover', book_id=book.id) }}"
+         alt=""
+         width="160"
+         height="240">
     <div class="header-titles">
         <h1 id="detail-header">{{ book.metadata.title }}</h1>
         <p class="byline">by {{ book.metadata.author }}</p>

--- a/tests/unit/test_cover_cache.py
+++ b/tests/unit/test_cover_cache.py
@@ -1,0 +1,150 @@
+# ABOUTME: Unit tests for the on-disk cover cache used by the web cover route.
+# ABOUTME: Verifies cache hits, misses, and the placeholder fallback for missing covers.
+
+from pathlib import Path
+
+import pytest
+from ebooklib import epub
+
+from bookery.web.covers import (
+    PLACEHOLDER_CONTENT_TYPE,
+    PLACEHOLDER_SVG,
+    get_or_extract_cover,
+)
+
+
+def _epub_with_cover(path: Path) -> Path:
+    book = epub.EpubBook()
+    book.set_identifier("cache-fixture-id")
+    book.set_title("Cache Fixture")
+    book.set_language("en")
+    book.add_author("Test Author")
+
+    jpeg = b"\xff\xd8\xff\xe0" + b"cache-fixture-jpeg" * 4
+    book.set_cover("cover.jpg", jpeg)
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = b"<html><body><p>x</p></body></html>"
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+
+    epub.write_epub(str(path), book)
+    return path
+
+
+@pytest.fixture
+def epub_path(tmp_path: Path) -> Path:
+    return _epub_with_cover(tmp_path / "fixture.epub")
+
+
+class TestGetOrExtractCover:
+    def test_extracts_and_caches_on_first_call(self, tmp_path: Path, epub_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        data, content_type = get_or_extract_cover(
+            book_id=42, epub_path=epub_path, library_root=library_root
+        )
+
+        assert content_type == "image/jpeg"
+        assert data.startswith(b"\xff\xd8\xff")
+        # Cache file should have been written under .covers/.
+        cached = library_root / ".covers" / "42.jpg"
+        assert cached.exists()
+        assert cached.read_bytes() == data
+
+    def test_returns_cached_bytes_on_second_call(self, tmp_path: Path, epub_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        get_or_extract_cover(book_id=7, epub_path=epub_path, library_root=library_root)
+
+        # Replace the cached file with sentinel bytes to prove the second
+        # call serves from disk and does not re-extract.
+        cached = library_root / ".covers" / "7.jpg"
+        sentinel = b"cached-sentinel-bytes"
+        cached.write_bytes(sentinel)
+
+        data, content_type = get_or_extract_cover(
+            book_id=7, epub_path=epub_path, library_root=library_root
+        )
+        assert data == sentinel
+        assert content_type == "image/jpeg"
+
+    def test_returns_placeholder_when_epub_has_no_cover(self, tmp_path: Path) -> None:
+        # Build an EPUB with no cover.
+        book = epub.EpubBook()
+        book.set_identifier("no-cover")
+        book.set_title("No Cover")
+        book.set_language("en")
+        book.add_author("Anon")
+        chapter = epub.EpubHtml(title="c", file_name="c.xhtml", lang="en")
+        chapter.content = b"<html><body><p>x</p></body></html>"
+        book.add_item(chapter)
+        book.toc = [epub.Link("c.xhtml", "c", "c")]
+        book.add_item(epub.EpubNcx())
+        book.add_item(epub.EpubNav())
+        book.spine = ["nav", chapter]
+        epub_path = tmp_path / "blank.epub"
+        epub.write_epub(str(epub_path), book)
+
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        data, content_type = get_or_extract_cover(
+            book_id=1, epub_path=epub_path, library_root=library_root
+        )
+        assert data == PLACEHOLDER_SVG
+        assert content_type == PLACEHOLDER_CONTENT_TYPE
+
+    def test_returns_placeholder_when_epub_path_is_none(self, tmp_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        data, content_type = get_or_extract_cover(
+            book_id=1, epub_path=None, library_root=library_root
+        )
+        assert data == PLACEHOLDER_SVG
+        assert content_type == PLACEHOLDER_CONTENT_TYPE
+
+    def test_returns_placeholder_when_epub_missing_on_disk(self, tmp_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        data, content_type = get_or_extract_cover(
+            book_id=1, epub_path=tmp_path / "missing.epub", library_root=library_root
+        )
+        assert data == PLACEHOLDER_SVG
+        assert content_type == PLACEHOLDER_CONTENT_TYPE
+
+    def test_caches_png_with_png_extension(self, tmp_path: Path) -> None:
+        book = epub.EpubBook()
+        book.set_identifier("png-cover")
+        book.set_title("PNG Cover")
+        book.set_language("en")
+        book.add_author("Anon")
+        png = b"\x89PNG\r\n\x1a\n" + b"pngdata" * 4
+        book.set_cover("cover.png", png)
+        chapter = epub.EpubHtml(title="c", file_name="c.xhtml", lang="en")
+        chapter.content = b"<html><body><p>x</p></body></html>"
+        book.add_item(chapter)
+        book.toc = [epub.Link("c.xhtml", "c", "c")]
+        book.add_item(epub.EpubNcx())
+        book.add_item(epub.EpubNav())
+        book.spine = ["nav", chapter]
+        epub_path = tmp_path / "pngfix.epub"
+        epub.write_epub(str(epub_path), book)
+
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        data, content_type = get_or_extract_cover(
+            book_id=99, epub_path=epub_path, library_root=library_root
+        )
+        assert content_type == "image/png"
+        assert data.startswith(b"\x89PNG")
+        # Cache extension matches the media type for browser-friendliness.
+        assert (library_root / ".covers" / "99.png").exists()

--- a/tests/unit/test_cover_extract.py
+++ b/tests/unit/test_cover_extract.py
@@ -1,0 +1,99 @@
+# ABOUTME: Unit tests for the cover extractor used by the web cover route.
+# ABOUTME: Covers EPUB-with-cover, EPUB-without-cover, and content-type detection.
+
+from pathlib import Path
+
+import pytest
+from ebooklib import epub
+
+from bookery.formats.epub import extract_cover_bytes
+
+
+def _make_epub_with_cover(path: Path, image_bytes: bytes, media_type: str = "image/jpeg") -> Path:
+    """Build a minimal EPUB carrying a designated cover image."""
+    book = epub.EpubBook()
+    book.set_identifier("cover-fixture-id")
+    book.set_title("Cover Fixture")
+    book.set_language("en")
+    book.add_author("Test Author")
+
+    # set_cover wires the cover-image manifest entry and the OPF meta
+    # name="cover" tag — the convention extract_cover_bytes searches for.
+    book.set_cover("cover.jpg" if media_type == "image/jpeg" else "cover.png", image_bytes)
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = b"<html><body><p>x</p></body></html>"
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+
+    epub.write_epub(str(path), book)
+    return path
+
+
+@pytest.fixture
+def epub_with_cover(tmp_path: Path) -> Path:
+    """EPUB with a designated cover image (JPEG bytes)."""
+    # Fake JPEG bytes — magic header is enough; we never decode the image.
+    jpeg = b"\xff\xd8\xff\xe0" + b"bookery-cover-fixture" * 4
+    return _make_epub_with_cover(tmp_path / "with_cover.epub", jpeg)
+
+
+@pytest.fixture
+def epub_without_cover(tmp_path: Path) -> Path:
+    """EPUB with no cover image declared."""
+    book = epub.EpubBook()
+    book.set_identifier("no-cover-id")
+    book.set_title("No Cover")
+    book.set_language("en")
+    book.add_author("Test Author")
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = b"<html><body><p>x</p></body></html>"
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+
+    path = tmp_path / "no_cover.epub"
+    epub.write_epub(str(path), book)
+    return path
+
+
+class TestExtractCoverBytes:
+    def test_returns_bytes_and_content_type_for_epub_with_cover(
+        self, epub_with_cover: Path
+    ) -> None:
+        result = extract_cover_bytes(epub_with_cover)
+        assert result is not None
+        data, content_type = result
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+        # JPEG magic bytes survive the round-trip.
+        assert data.startswith(b"\xff\xd8\xff")
+        assert content_type == "image/jpeg"
+
+    def test_returns_none_for_epub_without_cover(self, epub_without_cover: Path) -> None:
+        assert extract_cover_bytes(epub_without_cover) is None
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        assert extract_cover_bytes(tmp_path / "does_not_exist.epub") is None
+
+    def test_returns_none_for_non_epub_file(self, tmp_path: Path) -> None:
+        bad = tmp_path / "not_an_epub.epub"
+        bad.write_text("not actually an epub")
+        assert extract_cover_bytes(bad) is None
+
+    def test_detects_png_content_type(self, tmp_path: Path) -> None:
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"bookery-png" * 4
+        path = _make_epub_with_cover(
+            tmp_path / "png_cover.epub", png_bytes, media_type="image/png"
+        )
+        result = extract_cover_bytes(path)
+        assert result is not None
+        data, content_type = result
+        assert data.startswith(b"\x89PNG")
+        assert content_type == "image/png"

--- a/tests/web/test_book_cover.py
+++ b/tests/web/test_book_cover.py
@@ -1,0 +1,150 @@
+# ABOUTME: Tests for the /books/<id>/cover route, list thumbnail, and detail hero.
+# ABOUTME: Covers happy path, 404, placeholder fallback, cache headers, template wiring.
+
+from pathlib import Path
+
+import pytest
+from ebooklib import epub
+
+from tests.web.conftest import make_book
+
+
+def _epub_with_cover(path: Path) -> Path:
+    book = epub.EpubBook()
+    book.set_identifier("route-fixture-id")
+    book.set_title("Route Fixture")
+    book.set_language("en")
+    book.add_author("Test Author")
+
+    jpeg = b"\xff\xd8\xff\xe0" + b"route-cover-bytes" * 4
+    book.set_cover("cover.jpg", jpeg)
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = b"<html><body><p>x</p></body></html>"
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+
+    epub.write_epub(str(path), book)
+    return path
+
+
+@pytest.fixture
+def library_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "library"
+    root.mkdir()
+    monkeypatch.setenv("BOOKERY_LIBRARY_ROOT", str(root))
+    return root
+
+
+class TestCoverRoute:
+    def test_returns_cover_bytes_for_book_with_cover(
+        self, mock_catalog, client, library_root: Path, tmp_path: Path
+    ) -> None:
+        epub_path = _epub_with_cover(tmp_path / "fixture.epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=epub_path)
+
+        response = client.get("/books/1/cover")
+
+        assert response.status_code == 200
+        assert response.content_type.startswith("image/jpeg")
+        assert response.data.startswith(b"\xff\xd8\xff")
+
+    def test_sets_cache_control_header(
+        self, mock_catalog, client, library_root: Path, tmp_path: Path
+    ) -> None:
+        epub_path = _epub_with_cover(tmp_path / "fixture.epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=epub_path)
+
+        response = client.get("/books/1/cover")
+
+        cache_control = response.headers.get("Cache-Control", "")
+        assert "max-age=86400" in cache_control
+        assert "public" in cache_control
+
+    def test_404_for_unknown_book(self, mock_catalog, client, library_root: Path) -> None:
+        mock_catalog.get_by_id.return_value = None
+        response = client.get("/books/999/cover")
+        assert response.status_code == 404
+
+    def test_returns_placeholder_when_book_has_no_cover(
+        self, mock_catalog, client, library_root: Path, tmp_path: Path
+    ) -> None:
+        # Build an EPUB without a cover image declared.
+        book = epub.EpubBook()
+        book.set_identifier("nope")
+        book.set_title("Nope")
+        book.set_language("en")
+        book.add_author("Anon")
+        chapter = epub.EpubHtml(title="c", file_name="c.xhtml", lang="en")
+        chapter.content = b"<html><body><p>x</p></body></html>"
+        book.add_item(chapter)
+        book.toc = [epub.Link("c.xhtml", "c", "c")]
+        book.add_item(epub.EpubNcx())
+        book.add_item(epub.EpubNav())
+        book.spine = ["nav", chapter]
+        path = tmp_path / "nocover.epub"
+        epub.write_epub(str(path), book)
+
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=path)
+
+        response = client.get("/books/1/cover")
+        assert response.status_code == 200
+        assert response.content_type.startswith("image/svg+xml")
+        # Placeholder SVG carries a recognizable marker.
+        assert b"<svg" in response.data
+
+    def test_returns_placeholder_when_source_file_missing(
+        self, mock_catalog, client, library_root: Path
+    ) -> None:
+        mock_catalog.get_by_id.return_value = make_book(
+            1, source_path=Path("/nonexistent/missing.epub")
+        )
+
+        response = client.get("/books/1/cover")
+        assert response.status_code == 200
+        assert response.content_type.startswith("image/svg+xml")
+
+    def test_prefers_output_path_over_source_path(
+        self, mock_catalog, client, library_root: Path, tmp_path: Path
+    ) -> None:
+        # source_path points at a missing file; output_path has the real EPUB.
+        output_epub = _epub_with_cover(tmp_path / "output.epub")
+        mock_catalog.get_by_id.return_value = make_book(
+            1,
+            source_path=Path("/nonexistent/source.epub"),
+            output_path=output_epub,
+        )
+
+        response = client.get("/books/1/cover")
+        assert response.status_code == 200
+        assert response.content_type.startswith("image/jpeg")
+
+
+class TestListThumbnail:
+    def test_list_renders_lazy_loading_thumbnail_per_book(self, mock_catalog, client) -> None:
+        mock_catalog.browse.return_value = (
+            [make_book(1, title="Dune"), make_book(2, title="Foundation")],
+            2,
+        )
+
+        html = client.get("/books").data.decode()
+
+        # One <img> per book with lazy loading and the cover URL.
+        assert html.count('loading="lazy"') >= 2
+        assert "/books/1/cover" in html
+        assert "/books/2/cover" in html
+        # Thumb class is present for CSS sizing.
+        assert "book-cover-thumb" in html
+
+
+class TestDetailHero:
+    def test_detail_renders_hero_cover(self, mock_catalog, client) -> None:
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+
+        html = client.get("/books/1").data.decode()
+
+        assert "/books/1/cover" in html
+        assert "book-cover-hero" in html


### PR DESCRIPTION
## Summary

Plan-01 step 5 — cover thumbnails. Closes #139, part of plan-01 master #146.

- New route `GET /books/<id>/cover` lazy-extracts the EPUB cover, caches bytes under `<library_root>/.covers/<book_id>.<ext>`, and serves with `Cache-Control: public, max-age=86400`.
- List template: 40x60 thumbnail column at the left with `loading="lazy"` and `width`/`height` attrs so the row reserves layout space before paint.
- Detail template: 160x240 hero cover floated next to the title block (scales to 96x144 below 600px).
- Inline SVG placeholder served (200 OK, `image/svg+xml`) when a book has no extractable cover, so the `<img>` never breaks layout. Placeholder is **not** persisted to the disk cache — re-importing a file with a real cover later still picks it up on next request.
- Content-type sniffed from image magic bytes (JPEG/PNG/GIF/WEBP) with the OPF `media_type` as fallback, default `image/jpeg`.

## Design decisions

- **Lazy + disk cache** under `<library_root>/.covers/<id>.<ext>` (matches plan wording "lazy on first request"). Eager extraction during import was out of scope for this step.
- **Placeholder = 200 OK with inline SVG** (not 404) so the `<img>` tag renders the placeholder without CSS fallback gymnastics. Single source of bytes for the route makes browser caching straightforward.
- **Source resolution**: prefer `output_path` (library copy) then `source_path`. Mirrors how the rest of the detail page picks a file.
- **No new dependencies** — extractor is built on the existing `ebooklib` cover walk in `formats/epub.py`. Refactored the private `_extract_cover_image` to share the manifest-lookup helper.

## Test plan

- [x] `uv run pytest` — 1605 passed (+19 new)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` on touched files — clean
- [ ] Manual: start `bookery serve`, visit `/books`, confirm thumbs render with lazy loading; visit a detail page, confirm hero renders; check `.covers/` populates.

## Out of scope (per plan)

- Cover resize / thumbnail variants (browser does the sizing for now)
- Dominant-color extraction
- Cover refresh UI / cache invalidation command (lazy re-extract works by deleting `.covers/<id>.<ext>`)