### PR TITLE
feat(web): responsive mobile card layout on /books (#129)

### DIFF
--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -614,3 +614,88 @@ header .logo {
         height: 144px;
     }
 }
+
+/* --- Mobile card layout for /books (issue #129, plan-01 step 6) ---------- */
+
+/* Default state: cards hidden, desktop table visible. The 768px media query
+   below flips the visibility — same markup serves both viewports without JS. */
+.book-cards {
+    display: none;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.book-cards > li {
+    margin: 0 0 0.5rem 0;
+}
+
+.book-card {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: white;
+    color: var(--color-text);
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.book-card:hover {
+    background: var(--color-hover);
+}
+
+.book-card-cover {
+    flex: 0 0 auto;
+    width: 48px;
+    height: 72px;
+}
+
+.book-card-body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.book-card-title {
+    font-weight: 600;
+    color: var(--color-link);
+    line-height: 1.3;
+    word-break: break-word;
+}
+
+.book-card-author {
+    color: var(--color-muted);
+    font-size: 0.9rem;
+    margin-top: 0.15rem;
+}
+
+.book-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.4rem;
+}
+
+.book-card-badge {
+    display: inline-block;
+    background: var(--color-border);
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+    color: var(--color-text);
+}
+
+.book-card-badge-enriched {
+    background: var(--color-badge);
+    color: white;
+}
+
+@media (max-width: 768px) {
+    .book-table {
+        display: none;
+    }
+    .book-cards {
+        display: block;
+    }
+}

--- a/src/bookery/web/templates/_book_card.html
+++ b/src/bookery/web/templates/_book_card.html
@@ -1,0 +1,28 @@
+{# ABOUTME: Plan-01 step 6 mobile card partial — one stacked card per book. #}
+{# Renders inside .book-cards alongside the desktop table; CSS swaps which is visible. #}
+
+<a class="book-card{% if book.metadata_matched_at %} book-card-enriched{% endif %}"
+   href="{{ url_for('web.book_detail', book_id=book.id) }}">
+    <img class="book-cover-thumb book-card-cover"
+         src="{{ url_for('web.book_cover', book_id=book.id) }}"
+         alt=""
+         loading="lazy"
+         width="48"
+         height="72">
+    <div class="book-card-body">
+        <div class="book-card-title">{{ book.metadata.title }}</div>
+        <div class="book-card-author">{{ book.metadata.author }}</div>
+        {%- set badges = [] -%}
+        {%- if book.metadata.language -%}{%- set _ = badges.append(book.metadata.language) -%}{%- endif -%}
+        {%- if book.metadata_matched_at or badges -%}
+        <div class="book-card-meta">
+            {%- for badge in badges %}
+            <span class="book-card-badge">{{ badge }}</span>
+            {%- endfor %}
+            {%- if book.metadata_matched_at %}
+            <span class="book-card-badge book-card-badge-enriched" aria-label="Enriched">&#10003; Enriched</span>
+            {%- endif %}
+        </div>
+        {%- endif %}
+    </div>
+</a>

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -60,6 +60,15 @@
         </tbody>
     </table>
 
+    {# Mobile-only stacked card layout. Same data, different shell — CSS at
+       768px hides the table and shows this block. Whole card is one link
+       so the entire row is tappable on touch devices. #}
+    <ul class="book-cards" aria-label="Books">
+        {% for book in page.books %}
+        <li>{% include "_book_card.html" %}</li>
+        {% endfor %}
+    </ul>
+
     {% if page.total_pages > 1 %}
     <nav class="pager" aria-label="Pagination">
         {% if page.has_prev %}

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -128,8 +128,21 @@ class TestBookList:
 
         response = client.get("/books")
         html = response.data.decode()
-        # There should be exactly one checkmark for the enriched book
-        assert html.count("&#10003;") == 1
+        # Only the enriched book shows the badge — never the plain one. With
+        # the responsive layout (plan-01 step 6) the indicator appears once
+        # in the desktop table cell and once in the mobile card, both for
+        # the same book, so the total count is the number of layouts (2).
+        assert html.count("&#10003;") == 2
+        # And it's the enriched book — the plain one carries no badge class.
+        assert "book-card-enriched" in html
+        # The plain book's id (2) must not appear inside an enriched card.
+        import re
+
+        enriched_cards = re.findall(
+            r'<a class="book-card book-card-enriched"[^>]*href="[^"]*/books/(\d+)"',
+            html,
+        )
+        assert enriched_cards == ["1"]
 
     def test_books_table_columns(self, mock_catalog, client):
         book = _make_book(

--- a/tests/web/test_list_responsive.py
+++ b/tests/web/test_list_responsive.py
@@ -1,0 +1,140 @@
+# ABOUTME: Plan-01 step 6 responsive mobile card layout tests for /books.
+# ABOUTME: Asserts dual-markup (desktop table + mobile cards) and CSS-only viewport switching.
+
+import re
+
+from .conftest import make_book
+
+
+class TestMobileCardMarkup:
+    """The /books response carries both the desktop table and a mobile card list.
+
+    CSS at the 768px breakpoint chooses which one is visible — the markup is
+    always present so the same response works for any viewport without JS.
+    """
+
+    def test_response_includes_both_table_and_card_list(self, mock_catalog, client):
+        mock_catalog.browse.return_value = ([make_book(1, title="Dune")], 1)
+
+        html = client.get("/books").data.decode()
+
+        # Desktop table still present (selectors used by other tests).
+        assert 'class="book-table"' in html
+        # Mobile cards wrapper present alongside.
+        assert "book-cards" in html
+
+    def test_one_card_per_book(self, mock_catalog, client):
+        mock_catalog.browse.return_value = (
+            [
+                make_book(1, title="Dune"),
+                make_book(2, title="Foundation"),
+                make_book(3, title="Neuromancer"),
+            ],
+            3,
+        )
+
+        html = client.get("/books").data.decode()
+
+        # Count card elements — one per book.
+        card_count = html.count('class="book-card"')
+        assert card_count == 3
+
+    def test_whole_card_is_a_single_link(self, mock_catalog, client):
+        """Per plan-01 step 6: the entire card is the row link target."""
+        mock_catalog.browse.return_value = ([make_book(42, title="Hyperion")], 1)
+
+        html = client.get("/books").data.decode()
+
+        # The card itself should be wrapped in <a href="/books/42">.
+        # Match an <a ...> tag whose href points at the book detail and which
+        # carries the book-card class.
+        pattern = re.compile(
+            r'<a[^>]+class="book-card"[^>]*href="[^"]*/books/42"'
+            r'|<a[^>]+href="[^"]*/books/42"[^>]*class="book-card"'
+        )
+        assert pattern.search(html), f"book-card anchor not found in: {html[:2000]}"
+
+    def test_card_shows_cover_thumbnail_with_lazy_loading(self, mock_catalog, client):
+        mock_catalog.browse.return_value = (
+            [make_book(7, title="Snow Crash"), make_book(8, title="Cryptonomicon")],
+            2,
+        )
+
+        html = client.get("/books").data.decode()
+
+        # Cards reuse the same /books/<id>/cover endpoint as the table thumbs.
+        # We expect at least two lazy-loaded covers per book (one in the table,
+        # one in the card) — i.e., at least 4 lazy images for 2 books.
+        assert html.count('loading="lazy"') >= 4
+        assert html.count("/books/7/cover") >= 2
+        assert html.count("/books/8/cover") >= 2
+
+    def test_card_shows_title_and_author(self, mock_catalog, client):
+        mock_catalog.browse.return_value = (
+            [make_book(1, title="Dune", authors=["Frank Herbert"])],
+            1,
+        )
+
+        html = client.get("/books").data.decode()
+
+        # Title and author appear inside the card region.
+        # We use a coarse check: both strings appear at least twice (table + card).
+        assert html.count("Dune") >= 2
+        assert html.count("Frank Herbert") >= 2
+
+    def test_card_shows_enriched_indicator_when_matched(self, mock_catalog, client):
+        mock_catalog.browse.return_value = (
+            [
+                make_book(1, title="Enriched One", metadata_matched_at="2026-01-01T00:00:00"),
+                make_book(2, title="Unenriched Two"),
+            ],
+            2,
+        )
+
+        html = client.get("/books").data.decode()
+
+        # The enriched card carries an indicator class so CSS can style it.
+        # We don't pin the exact glyph — just that the marker class exists for
+        # at least the enriched book, and that the un-enriched one doesn't
+        # accidentally inherit it.
+        assert "book-card-enriched" in html
+
+    def test_card_shows_format_or_language_badge_when_present(self, mock_catalog, client):
+        mock_catalog.browse.return_value = (
+            [make_book(1, title="Dune", language="en")],
+            1,
+        )
+
+        html = client.get("/books").data.decode()
+
+        # Language metadata surfaces in the card so users on mobile can see
+        # at-a-glance which copies are which.
+        assert "book-card-meta" in html
+        # The actual language token is in the card region.
+        assert "en" in html
+
+
+class TestMobileCardCss:
+    """The stylesheet defines the breakpoint that swaps table for cards."""
+
+    def test_stylesheet_swaps_layouts_at_768px(self, client):
+        """The 768px media query must exist and toggle both layouts."""
+        # Pull the static stylesheet through the test client so we go through
+        # the same routing the browser would use.
+        response = client.get("/static/style.css")
+        assert response.status_code == 200
+        css = response.data.decode()
+
+        # Defines a card layout (additions only — covers/etc untouched).
+        assert ".book-card" in css
+        assert ".book-cards" in css
+        # 768px breakpoint must exist somewhere — the exact form is
+        # `@media (max-width: 768px)` or `(min-width: 768px)`. Either works
+        # provided it toggles `.book-table` and `.book-cards` display.
+        assert "768px" in css
+        # Default state: cards hidden on desktop (visible only via media query).
+        # We don't pin the exact selector — just that .book-cards is mentioned
+        # alongside `display:` to confirm the layout is controlled.
+        assert re.search(r"\.book-cards[^{]*\{[^}]*display\s*:", css), (
+            "expected .book-cards to have a display rule"
+        )


### PR DESCRIPTION
## Summary

Closes #129. Final step of plan-01 (#146).

Below 768px the `/books` table reflows into stacked cards — one per book — and each card is wrapped in a single `<a href="/books/<id>">` so the whole card is the tap target. Above 768px the existing table layout is unchanged. CSS-only switching, no JS: the same response works for any viewport.

- Dual-markup approach (option B from the instructions): a new `_book_card.html` partial renders alongside the table inside `_book_list.html`. The 768px media query toggles `display` on `.book-table` / `.book-cards`. Picked B because `<a>` cannot wrap `<tr>` cleanly, and the plan explicitly calls for "whole card is the row link."
- Each card shows the cover thumbnail (lazy-loaded, reusing `/books/<id>/cover`), title, author, language badge, and an "Enriched" pill when `metadata_matched_at` is set.
- Filter chips, sort headers, search, and pager are unchanged — they stack naturally on mobile.
- Verified at 390px with Playwright: `documentScrollWidth == clientWidth == 390` (no horizontal scroll), `.book-table` hidden, `.book-cards` visible, 50 cards rendered, first card `<a>` resolves to a book detail. At 1280px: table visible, cards hidden.

## Plan-01 wrap-up

This closes the last remaining child issue of plan-01 master #146. All six steps are now merged:

1. #158 pagination + result count
2. #159 sortable columns
3. #160 heading hierarchy
4. #161 filter chips
5. #162 cover thumbnails + detail hero
6. #129 responsive mobile cards (this PR)

**The plan-01 master #146 can be closed once this lands.**

## Test plan

- [x] `uv run pytest tests/web/` — 222 pass (was 214; +8 new in `test_list_responsive.py`)
- [x] `uv run pytest` full suite — 1613 pass
- [x] `uv run ruff check` clean (pre-commit also green)
- [x] Manual viewport check at 390px via Playwright — no horizontal scroll, cards visible, table hidden
- [x] Manual viewport check at 1280px via Playwright — table visible, cards hidden
- [ ] Reviewer: tap a card on a real mobile device to confirm focus ring / tap area feel right