### PR TITLE
feat(web): edit becomes a real URL (#131)

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -182,14 +182,22 @@ def book_cover(book_id):
 
 @bp.route("/books/<int:book_id>/edit", methods=["GET"])
 def edit_form(book_id):
-    """Return the edit form partial for a book."""
+    """Render the edit form for a book.
+
+    htmx GET (``HX-Request`` header set) returns the bare partial for an
+    in-place swap into ``#book-content``. A plain GET — direct nav, browser
+    refresh, shared link — returns the full styled page so the user lands
+    on a real URL rather than an unstyled fragment.
+    """
     catalog = current_app.config["CATALOG"]
     book = catalog.get_by_id(book_id)
     if book is None:
         abort(404)
 
     file_info = _file_context(book)
-    return render_template("_edit_form.html", book=book, file_info=file_info)
+    if request.headers.get("HX-Request"):
+        return render_template("_edit_form.html", book=book, file_info=file_info)
+    return render_template("edit.html", book=book, file_info=file_info)
 
 
 @bp.route("/books/<int:book_id>/edit", methods=["POST"])
@@ -248,9 +256,16 @@ def update_book(book_id):
     genres = catalog.get_genres_for_book(book_id)
     file_info = _file_context(book)
 
-    return render_template(
-        "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
+    response = make_response(
+        render_template(
+            "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
+        )
     )
+    # If the user came from the edit URL (/books/<id>/edit), push the URL
+    # back to /books/<id> so refresh/share lands on detail, not on a stale
+    # edit URL that would re-render the form.
+    response.headers["HX-Push-Url"] = url_for("web.book_detail", book_id=book_id)
+    return response
 
 
 def _prefill_for_book(book) -> tuple[str | None, str | None]:

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -257,9 +257,7 @@ def update_book(book_id):
     file_info = _file_context(book)
 
     response = make_response(
-        render_template(
-            "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
-        )
+        render_template("_detail.html", book=book, tags=tags, genres=genres, file_info=file_info)
     )
     # If the user came from the edit URL (/books/<id>/edit), push the URL
     # back to /books/<id> so refresh/share lands on detail, not on a stale

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -17,6 +17,7 @@
         <button type="button"
                 class="btn btn-secondary"
                 hx-get="{{ url_for('web.edit_form', book_id=book.id) }}"
+                hx-push-url="{{ url_for('web.edit_form', book_id=book.id) }}"
                 hx-target="#book-content"
                 hx-swap="innerHTML">Edit</button>
         <button type="button"

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -57,6 +57,7 @@
                     class="btn btn-secondary"
                     id="edit-cancel"
                     hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
+                    hx-push-url="{{ url_for('web.book_detail', book_id=book.id) }}"
                     hx-target="#book-content"
                     hx-swap="innerHTML">Cancel</button>
         </div>

--- a/src/bookery/web/templates/edit.html
+++ b/src/bookery/web/templates/edit.html
@@ -1,0 +1,17 @@
+{# ABOUTME: Full-page wrapper for the edit form — direct nav, refresh, share. #}
+{# ABOUTME: htmx requests get the bare _edit_form.html fragment instead. #}
+{% extends "base.html" %}
+
+{% block title %}Edit: {{ book.metadata.title }} - Bookery{% endblock %}
+
+{% block content %}
+<div class="book-detail">
+    <nav aria-label="Breadcrumb" class="back-link">
+        <a href="{{ url_for('web.book_detail', book_id=book.id) }}">&larr; Back to book</a>
+    </nav>
+
+    <div id="book-content" aria-live="polite">
+        {% include "_edit_form.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -294,10 +294,11 @@ class TestEditForm:
         assert response.status_code == 200
         assert "<form" in html
 
-    def test_edit_form_returns_partial_only(self, mock_catalog, client):
+    def test_edit_form_htmx_get_returns_partial_only(self, mock_catalog, client):
+        """htmx GET still swaps in the bare fragment — no base layout."""
         mock_catalog.get_by_id.return_value = _make_book(1)
 
-        response = client.get("/books/1/edit")
+        response = client.get("/books/1/edit", headers={"HX-Request": "true"})
         html = response.data.decode()
         assert "<html" not in html
         assert "<head" not in html

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -1,0 +1,79 @@
+# ABOUTME: Plan-02 navigation/URL-state matrix — edit URL, search form, return_to, subhead.
+# ABOUTME: Each test row maps to a row in plans/02-web-navigation-url-state.md.
+
+from tests.web.conftest import make_book
+
+
+class TestEditUrlIsReal:
+    """Step 1 / issue #131 — GET /books/<id>/edit is a real URL.
+
+    Plain GET returns the full styled page so refresh, deep-link, and share
+    all work. htmx GET returns the fragment for in-place swap. The detail
+    page's Edit affordance pushes the URL so the browser sees the navigation.
+    """
+
+    def test_plain_get_returns_full_styled_page(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Book One")
+        response = client.get("/books/1/edit")
+        assert response.status_code == 200
+        html = response.data.decode()
+        # Base layout markers: doctype, site header, skip link.
+        assert "<!DOCTYPE html>" in html
+        assert "Skip to main content" in html
+        assert 'class="logo"' in html
+        # Edit form is still populated.
+        assert 'name="title"' in html
+        assert "Book One" in html
+
+    def test_htmx_get_returns_fragment_only(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Book One")
+        response = client.get("/books/1/edit", headers={"HX-Request": "true"})
+        assert response.status_code == 200
+        html = response.data.decode()
+        # No base layout — fragment for in-place swap.
+        assert "<!DOCTYPE html>" not in html
+        assert "Skip to main content" not in html
+        # Edit form still present.
+        assert 'name="title"' in html
+        assert "Book One" in html
+
+    def test_refresh_on_edit_url_renders_full_page(self, mock_catalog, client):
+        """Browser refresh sends no HX-Request header — same path as direct nav."""
+        mock_catalog.get_by_id.return_value = make_book(1, title="Refreshed")
+        response = client.get("/books/1/edit")
+        html = response.data.decode()
+        assert "<!DOCTYPE html>" in html
+        assert "Refreshed" in html
+
+    def test_edit_button_pushes_url(self, mock_catalog, client):
+        """Detail's Edit affordance must push the edit URL so refresh/share work."""
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # The Edit control resolves to a real link/button that updates the URL.
+        # Accept either an anchor with href or an hx-push-url on the button.
+        assert "/books/1/edit" in html
+        assert "hx-push-url" in html or 'href="/books/1/edit"' in html
+
+    def test_edit_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        assert client.get("/books/999/edit").status_code == 404
+
+    def test_save_pushes_url_back_to_detail(self, mock_catalog, client):
+        """After save, htmx clients should land back on /books/<id>."""
+        mock_catalog.get_by_id.return_value = make_book(1, title="Saved")
+        response = client.post(
+            "/books/1/edit",
+            data={
+                "title": "Saved",
+                "authors": "Author",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 200
+        assert response.headers.get("HX-Push-Url") == "/books/1"


### PR DESCRIPTION
## Summary
- Plain `GET /books/<id>/edit` now returns a full styled page (refresh, deep-link, share all work).
- htmx GET (`HX-Request` set) still returns the bare `_edit_form.html` fragment for in-place swap.
- Edit / Cancel / Save all push the URL via `hx-push-url` and `HX-Push-Url` so the address bar matches what's on screen.

Plan-02 step 1 of 4. Closes #131.

## Test plan
- [x] `tests/web/test_navigation_state.py::TestEditUrlIsReal` — 6 new tests covering plain GET, htmx GET, refresh, Edit-button push, 404, and save-pushes-back-to-detail.
- [x] Full suite: 1619 passed.
- [x] Ruff clean.
- [x] Manual browser smoke (`/books/524`):
  - Direct nav to `/books/524/edit` → full styled page, form populated, back link.
  - Click Edit on detail → URL pushes to `/books/524/edit`, no full reload.
  - Click Cancel → URL pushes back to `/books/524`.