### PR TITLE
feat(web): wrap search input in a real form (#130)

### DIFF
--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -78,15 +78,30 @@ header .logo {
 /* Search */
 
 .search-bar {
+    display: flex;
+    gap: 0.5rem;
     margin-bottom: 1rem;
 }
 
 .search-bar input {
-    width: 100%;
+    flex: 1;
     padding: 0.5rem 0.75rem;
     font-size: 1rem;
     border: 1px solid var(--color-border);
     border-radius: 4px;
+}
+
+/* Visually hide content but keep it available to screen readers. */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Book table */

--- a/src/bookery/web/templates/list.html
+++ b/src/bookery/web/templates/list.html
@@ -4,8 +4,13 @@
 
 {% block content %}
 <h1 class="page-title">Library</h1>
-<div class="search-bar">
+<form class="search-bar"
+      action="{{ url_for('web.books') }}"
+      method="get"
+      role="search">
+    <label class="visually-hidden" for="search-q">Search books</label>
     <input type="search"
+           id="search-q"
            name="q"
            placeholder="Search books..."
            value="{{ query.q }}"
@@ -14,7 +19,8 @@
            hx-target="#book-list"
            hx-include="this"
            hx-push-url="true">
-</div>
+    <button type="submit" class="btn btn-secondary">Search</button>
+</form>
 
 <div id="book-list">
     {% include "_book_list.html" %}

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -1,6 +1,8 @@
 # ABOUTME: Plan-02 navigation/URL-state matrix — edit URL, search form, return_to, subhead.
 # ABOUTME: Each test row maps to a row in plans/02-web-navigation-url-state.md.
 
+import re
+
 from tests.web.conftest import make_book
 
 
@@ -77,3 +79,60 @@ class TestEditUrlIsReal:
         )
         assert response.status_code == 200
         assert response.headers.get("HX-Push-Url") == "/books/1"
+
+
+class TestSearchFormFallback:
+    """Step 2 / issue #130 — search must work without JS.
+
+    The search input lives inside a real ``<form action="/books" method="get">``
+    so submitting via Enter or the visible button posts ``?q=…`` and the
+    server returns filtered HTML. htmx keystroke search stays as progressive
+    enhancement.
+    """
+
+    def _list_html(self, mock_catalog, client):
+        mock_catalog.browse.return_value = ([], 0)
+        return client.get("/books").data.decode()
+
+    def test_search_input_wrapped_in_form(self, mock_catalog, client):
+        html = self._list_html(mock_catalog, client)
+        # A real form with action="/books" method="get" wraps the search input.
+        form_match = re.search(
+            r'<form[^>]*action="/books"[^>]*method="get"[^>]*>'
+            r"(?P<body>.*?)</form>",
+            html,
+            re.DOTALL | re.IGNORECASE,
+        )
+        assert form_match, 'expected <form action="/books" method="get">'
+        body = form_match.group("body")
+        assert 'name="q"' in body, "search input must be inside the form"
+        assert "<button" in body or 'type="submit"' in body, "form needs a submit affordance"
+
+    def test_htmx_attrs_remain_for_progressive_enhancement(self, mock_catalog, client):
+        html = self._list_html(mock_catalog, client)
+        # Keystroke search still wired so JS clients get the live update.
+        assert "hx-get" in html
+        assert "hx-trigger" in html
+
+    def test_non_htmx_get_with_query_returns_filtered_html(self, mock_catalog, client):
+        """Pressing Enter / clicking submit hits /books?q=… as a plain GET.
+
+        Already covered by the route, but pin it here so the regression
+        surface is obvious: no HX-Request header, query string honored,
+        full styled page returned.
+        """
+        mock_catalog.browse.return_value = ([make_book(1, title="The Shining")], 1)
+        response = client.get("/books?q=king")
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "<!DOCTYPE html>" in html
+        assert "The Shining" in html
+        # The catalog was queried with q="king".
+        call = mock_catalog.browse.call_args
+        assert call.kwargs.get("q") == "king"
+
+    def test_search_input_value_is_preserved_after_submit(self, mock_catalog, client):
+        """After a plain GET submit the input echoes the current query."""
+        mock_catalog.browse.return_value = ([], 0)
+        html = client.get("/books?q=tolkien").data.decode()
+        assert 'value="tolkien"' in html


### PR DESCRIPTION
## Summary
- The \`/books\` search input now lives inside \`<form action=\"/books\" method=\"get\">\` with a visible Search submit button.
- Submitting via Enter or the button posts \`?q=…\` as a plain GET; the server returns filtered HTML.
- htmx keystroke search stays wired on the input as progressive enhancement — JS users keep the live update behavior.
- Adds a \`.visually-hidden\` utility class for the search label so the form is accessible to screen readers without altering the visible layout.

Plan-02 step 2 of 4. Closes #130.

## Test plan
- [x] \`tests/web/test_navigation_state.py::TestSearchFormFallback\` — 4 new tests: form wraps input + has submit, htmx attrs survive, non-htmx GET returns filtered HTML, query echoes back into input value.
- [x] Full suite: 1623 passed.
- [x] Ruff lint + format clean.
- [x] Manual browser smoke: \`/books?q=shining\` renders full styled page with input pre-filled and \"The Shining\" in results.