### PR TITLE
feat(web): thread ?return_to= through detail and edit (#122)

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -3,6 +3,7 @@
 
 import os
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from flask import (
     Blueprint,
@@ -26,6 +27,42 @@ from bookery.util.text import strip_html
 from bookery.web.browse import BrowsePage, from_request_args
 from bookery.web.covers import get_or_extract_cover
 from bookery.web.diff import metadata_diff
+
+
+def _safe_return_to(value: str | None) -> str | None:
+    """Sanitize a ``return_to`` query param to an internal path.
+
+    The list controller stamps each row anchor with the originating list
+    URL so detail / edit / diff back-links can return the user to the
+    exact view they came from (filters, page, sort all intact). Because
+    the value is user-controllable, we accept only absolute internal
+    paths — anything with a scheme (``https://``), an authority
+    (``//evil.com``), or a non-``/``-leading path falls back to ``None``
+    so the consumer renders the default ``/books`` back-link. This
+    prevents the param from being used as an open-redirect or a
+    ``javascript:`` URL smuggle.
+    """
+    if not value:
+        return None
+    parsed = urlsplit(value)
+    if parsed.scheme or parsed.netloc:
+        return None
+    if not parsed.path.startswith("/"):
+        return None
+    return value
+
+
+def _current_list_url() -> str:
+    """Return the current request's path+query, suitable for ``return_to``.
+
+    Flask's ``request.full_path`` always appends ``?`` even when the query
+    string is empty, so we trim a lone trailing ``?`` to keep the value
+    tidy for round-tripping through ``url_for``.
+    """
+    full = request.full_path
+    if full.endswith("?"):
+        return full[:-1]
+    return full
 
 
 def _file_context(book) -> dict[str, str]:
@@ -122,10 +159,14 @@ def books():
         query=query,
     )
 
+    # ``list_url`` is what row anchors stamp into ``?return_to=`` so detail /
+    # edit / diff back-links can return to this exact view (filters, page,
+    # sort all preserved). Same value on both htmx and full-page paths.
+    list_url = _current_list_url()
     if request.headers.get("HX-Request"):
-        return render_template("_book_list.html", page=page, query=query)
+        return render_template("_book_list.html", page=page, query=query, list_url=list_url)
 
-    return render_template("list.html", page=page, query=query)
+    return render_template("list.html", page=page, query=query, list_url=list_url)
 
 
 @bp.route("/books/<int:book_id>")
@@ -139,13 +180,26 @@ def book_detail(book_id):
     tags = catalog.get_tags_for_book(book_id)
     genres = catalog.get_genres_for_book(book_id)
     file_info = _file_context(book)
+    return_to = _safe_return_to(request.args.get("return_to"))
 
     if request.headers.get("HX-Request"):
         return render_template(
-            "_detail.html", book=book, tags=tags, genres=genres, file_info=file_info
+            "_detail.html",
+            book=book,
+            tags=tags,
+            genres=genres,
+            file_info=file_info,
+            return_to=return_to,
         )
 
-    return render_template("detail.html", book=book, tags=tags, genres=genres, file_info=file_info)
+    return render_template(
+        "detail.html",
+        book=book,
+        tags=tags,
+        genres=genres,
+        file_info=file_info,
+        return_to=return_to,
+    )
 
 
 @bp.route("/books/<int:book_id>/cover")
@@ -195,9 +249,12 @@ def edit_form(book_id):
         abort(404)
 
     file_info = _file_context(book)
+    return_to = _safe_return_to(request.args.get("return_to"))
     if request.headers.get("HX-Request"):
-        return render_template("_edit_form.html", book=book, file_info=file_info)
-    return render_template("edit.html", book=book, file_info=file_info)
+        return render_template(
+            "_edit_form.html", book=book, file_info=file_info, return_to=return_to
+        )
+    return render_template("edit.html", book=book, file_info=file_info, return_to=return_to)
 
 
 @bp.route("/books/<int:book_id>/edit", methods=["POST"])
@@ -256,13 +313,25 @@ def update_book(book_id):
     genres = catalog.get_genres_for_book(book_id)
     file_info = _file_context(book)
 
+    return_to = _safe_return_to(request.args.get("return_to"))
     response = make_response(
-        render_template("_detail.html", book=book, tags=tags, genres=genres, file_info=file_info)
+        render_template(
+            "_detail.html",
+            book=book,
+            tags=tags,
+            genres=genres,
+            file_info=file_info,
+            return_to=return_to,
+        )
     )
     # If the user came from the edit URL (/books/<id>/edit), push the URL
     # back to /books/<id> so refresh/share lands on detail, not on a stale
-    # edit URL that would re-render the form.
-    response.headers["HX-Push-Url"] = url_for("web.book_detail", book_id=book_id)
+    # edit URL that would re-render the form. ``return_to`` rides along so
+    # the breadcrumb on the now-pushed detail URL still resolves to the
+    # originating list view.
+    response.headers["HX-Push-Url"] = url_for(
+        "web.book_detail", book_id=book_id, return_to=return_to or None
+    )
     return response
 
 

--- a/src/bookery/web/templates/_book_card.html
+++ b/src/bookery/web/templates/_book_card.html
@@ -2,7 +2,7 @@
 {# Renders inside .book-cards alongside the desktop table; CSS swaps which is visible. #}
 
 <a class="book-card{% if book.metadata_matched_at %} book-card-enriched{% endif %}"
-   href="{{ url_for('web.book_detail', book_id=book.id) }}">
+   href="{{ url_for('web.book_detail', book_id=book.id, return_to=list_url or none) }}">
     <img class="book-cover-thumb book-card-cover"
          src="{{ url_for('web.book_cover', book_id=book.id) }}"
          alt=""

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -37,7 +37,7 @@
             {% for book in page.books %}
             <tr class="book-row">
                 <td class="book-row-cover">
-                    <a href="{{ url_for('web.book_detail', book_id=book.id) }}" tabindex="-1" aria-hidden="true">
+                    <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=list_url or none) }}" tabindex="-1" aria-hidden="true">
                         <img class="book-cover-thumb"
                              src="{{ url_for('web.book_cover', book_id=book.id) }}"
                              alt=""
@@ -47,7 +47,7 @@
                     </a>
                 </td>
                 <td class="book-row-title">
-                    <a href="{{ url_for('web.book_detail', book_id=book.id) }}">{{ book.metadata.title }}</a>
+                    <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=list_url or none) }}">{{ book.metadata.title }}</a>
                 </td>
                 <td>{{ book.metadata.author }}</td>
                 <td>{{ book.metadata.isbn or '' }}</td>

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -14,10 +14,11 @@
     <p class="enriched-badge" aria-label="Enriched">&#10003; Enriched</p>
     {% endif %}
     <div class="toolbar" role="toolbar" aria-label="Book actions">
+        {%- set edit_url = url_for('web.edit_form', book_id=book.id, return_to=return_to or none) -%}
         <button type="button"
                 class="btn btn-secondary"
-                hx-get="{{ url_for('web.edit_form', book_id=book.id) }}"
-                hx-push-url="{{ url_for('web.edit_form', book_id=book.id) }}"
+                hx-get="{{ edit_url }}"
+                hx-push-url="{{ edit_url }}"
                 hx-target="#book-content"
                 hx-swap="innerHTML">Edit</button>
         <button type="button"

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -3,7 +3,7 @@
 <h1 class="page-title">Edit: {{ book.metadata.title }}</h1>
 <div class="edit-layout">
     <form class="edit-form"
-          hx-post="{{ url_for('web.update_book', book_id=book.id) }}"
+          hx-post="{{ url_for('web.update_book', book_id=book.id, return_to=return_to or none) }}"
           hx-target="#book-content"
           hx-swap="innerHTML">
         {% if error %}
@@ -53,11 +53,12 @@
 
         <div class="form-actions">
             <button type="submit" class="btn btn-primary">Save</button>
+            {%- set cancel_url = url_for('web.book_detail', book_id=book.id, return_to=return_to or none) -%}
             <button type="button"
                     class="btn btn-secondary"
                     id="edit-cancel"
-                    hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
-                    hx-push-url="{{ url_for('web.book_detail', book_id=book.id) }}"
+                    hx-get="{{ cancel_url }}"
+                    hx-push-url="{{ cancel_url }}"
                     hx-target="#book-content"
                     hx-swap="innerHTML">Cancel</button>
         </div>

--- a/src/bookery/web/templates/detail.html
+++ b/src/bookery/web/templates/detail.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="book-detail">
     <nav aria-label="Breadcrumb" class="back-link">
-        <a href="{{ url_for('web.books') }}" aria-current="page">&larr; Back to library</a>
+        <a href="{{ return_to or url_for('web.books') }}" aria-current="page">&larr; Back to library</a>
     </nav>
 
     <div id="book-content" aria-live="polite">

--- a/src/bookery/web/templates/edit.html
+++ b/src/bookery/web/templates/edit.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="book-detail">
     <nav aria-label="Breadcrumb" class="back-link">
-        <a href="{{ url_for('web.book_detail', book_id=book.id) }}">&larr; Back to book</a>
+        <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=return_to or none) }}">&larr; Back to book</a>
     </nav>
 
     <div id="book-content" aria-live="polite">

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -138,8 +138,9 @@ class TestBookList:
         # The plain book's id (2) must not appear inside an enriched card.
         import re
 
+        # href may carry a trailing ?return_to=… (plan-02 step 3).
         enriched_cards = re.findall(
-            r'<a class="book-card book-card-enriched"[^>]*href="[^"]*/books/(\d+)"',
+            r'<a class="book-card book-card-enriched"[^>]*href="[^"]*/books/(\d+)(?:\?[^"]*)?"',
             html,
         )
         assert enriched_cards == ["1"]

--- a/tests/web/test_accessibility.py
+++ b/tests/web/test_accessibility.py
@@ -57,7 +57,8 @@ class TestBookListRowAnchors:
             1,
         )
         html = client.get("/books").data.decode()
-        assert 'href="/books/42"' in html
+        # Detail link target; may carry a ?return_to=… for back navigation.
+        assert re.search(r'href="/books/42(\?[^"]*)?"', html)
 
     def test_row_has_no_onclick_attribute(self, mock_catalog, client):
         mock_catalog.browse.return_value = (
@@ -75,4 +76,4 @@ class TestBookListRowAnchors:
         html = client.get("/books").data.decode()
         # Anchor must contain the title text so keyboard users land on a
         # focusable element whose accessible name is the book title.
-        assert re.search(r'<a[^>]+href="/books/42"[^>]*>\s*The Test Book\s*</a>', html)
+        assert re.search(r'<a[^>]+href="/books/42(\?[^"]*)?"[^>]*>\s*The Test Book\s*</a>', html)

--- a/tests/web/test_list_responsive.py
+++ b/tests/web/test_list_responsive.py
@@ -48,9 +48,10 @@ class TestMobileCardMarkup:
         # The card itself should be wrapped in <a href="/books/42">.
         # Match an <a ...> tag whose href points at the book detail and which
         # carries the book-card class.
+        # Allow a trailing ``?return_to=…`` (plan-02 step 3) inside the href.
         pattern = re.compile(
-            r'<a[^>]+class="book-card"[^>]*href="[^"]*/books/42"'
-            r'|<a[^>]+href="[^"]*/books/42"[^>]*class="book-card"'
+            r'<a[^>]+class="book-card[^"]*"[^>]*href="[^"]*/books/42(\?[^"]*)?"'
+            r'|<a[^>]+href="[^"]*/books/42(\?[^"]*)?"[^>]*class="book-card[^"]*"'
         )
         assert pattern.search(html), f"book-card anchor not found in: {html[:2000]}"
 

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -2,8 +2,16 @@
 # ABOUTME: Each test row maps to a row in plans/02-web-navigation-url-state.md.
 
 import re
+from urllib.parse import parse_qs, urlsplit
 
 from tests.web.conftest import make_book
+
+
+def _extract_return_to(href: str) -> str | None:
+    """Pull the ``return_to`` value out of an href, decoded."""
+    qs = parse_qs(urlsplit(href).query)
+    values = qs.get("return_to") or []
+    return values[0] if values else None
 
 
 class TestEditUrlIsReal:
@@ -136,3 +144,90 @@ class TestSearchFormFallback:
         mock_catalog.browse.return_value = ([], 0)
         html = client.get("/books?q=tolkien").data.decode()
         assert 'value="tolkien"' in html
+
+
+class TestReturnToMechanism:
+    """Step 3 / issue #122 — back navigation honors the originating list URL.
+
+    The list page stamps each row anchor with ``?return_to=<list URL>``. Detail,
+    edit, and enrich/diff routes thread the param through and use it as the
+    back-link target, falling back to ``/books`` on deep-link entry. ``return_to``
+    is sanitized to internal paths only — anything with a scheme or host is
+    dropped to prevent open-redirect.
+    """
+
+    def test_list_row_anchors_carry_return_to(self, mock_catalog, client):
+        """Each row's detail link encodes the current list URL as return_to."""
+        mock_catalog.browse.return_value = ([make_book(1, title="A")], 1)
+        html = client.get("/books?q=king").data.decode()
+        # Find a row anchor and decode its return_to value back to the list URL.
+        match = re.search(r'href="(/books/1\?[^"]*return_to=[^"]+)"', html)
+        assert match, "expected a row anchor with return_to"
+        decoded = _extract_return_to(match.group(1))
+        assert decoded == "/books?q=king"
+
+    def test_detail_back_link_honors_return_to(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1?return_to=%2Fbooks%3Fq%3Dking").data.decode()
+        # The breadcrumb anchor targets the originating list URL, not /books.
+        assert 'href="/books?q=king"' in html
+
+    def test_detail_back_link_falls_back_to_books_on_deep_link(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1").data.decode()
+        # No return_to → breadcrumb points at the unfiltered list.
+        assert 'href="/books"' in html
+
+    def test_detail_back_link_rejects_external_return_to(self, mock_catalog, client):
+        """Open-redirect defense: scheme or host means we ignore return_to."""
+        mock_catalog.get_by_id.return_value = make_book(1)
+        for evil in ("https://evil.com", "//evil.com", "javascript:alert(1)"):
+            html = client.get(f"/books/1?return_to={evil}").data.decode()
+            assert "evil.com" not in html
+            assert "javascript:" not in html
+
+    def test_edit_button_carries_return_to(self, mock_catalog, client):
+        """Clicking Edit on detail keeps the return_to chain intact."""
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1?return_to=%2Fbooks%3Fpage%3D3").data.decode()
+        # Edit affordance points at /books/1/edit?return_to=…
+        assert "/books/1/edit?return_to=" in html
+
+    def test_edit_full_page_back_link_honors_return_to(self, mock_catalog, client):
+        """Edit's breadcrumb back-to-book preserves the return_to chain.
+
+        Two-step: from edit, "back to book" → detail with same return_to so
+        from detail another "back" lands on the originating list.
+        """
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1/edit?return_to=%2Fbooks%3Fpage%3D3").data.decode()
+        # Back-to-book breadcrumb threads return_to so popping pages
+        # eventually lands on the originating list URL.
+        match = re.search(r'class="back-link"[^>]*>\s*<a href="([^"]+)"', html)
+        assert match, "expected back-link anchor"
+        href = match.group(1)
+        assert href.startswith("/books/1")
+        assert _extract_return_to(href) == "/books?page=3"
+
+    def test_edit_save_pushes_url_with_return_to(self, mock_catalog, client):
+        """After save, HX-Push-Url lands on detail with return_to preserved."""
+        mock_catalog.get_by_id.return_value = make_book(1, title="Saved")
+        response = client.post(
+            "/books/1/edit?return_to=%2Fbooks%3Fq%3Dking",
+            data={
+                "title": "Saved",
+                "authors": "Author",
+                "isbn": "",
+                "language": "",
+                "publisher": "",
+                "description": "",
+                "series": "",
+                "series_index": "",
+            },
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 200
+        # HX-Push-Url should include return_to so the detail URL preserves the chain.
+        push = response.headers.get("HX-Push-Url", "")
+        assert push.startswith("/books/1")
+        assert "return_to=" in push


### PR DESCRIPTION
## Summary
- \`/books\` stamps each row anchor with \`?return_to=<current list URL>\` so back-navigation can return the user to the exact filtered/paged view.
- Detail and edit (both GET render paths and the POST save's \`HX-Push-Url\`) thread \`return_to\` through.
- Deep-links without \`return_to\` fall back to \`/books\`.
- \`return_to\` is sanitized to internal absolute paths only — scheme (\`https://\`), netloc (\`//evil.com\`), and non-\`/\` paths are dropped to prevent open-redirect / \`javascript:\` smuggling.

Plan-02 step 3 of 4. Closes #122.

## Test plan
- [x] \`tests/web/test_navigation_state.py::TestReturnToMechanism\` — 7 new tests: list row carries return_to, detail back link honors it, fallback to /books on deep-link, external URL rejection (https/protocol-relative/javascript), Edit button + edit full-page back link + save HX-Push-Url all thread the value.
- [x] Updated 4 pre-existing tests whose href regexes assumed no query string suffix.
- [x] Full suite: 1630 passed.
- [x] Ruff lint + format clean.
- [x] Manual browser walk: \`/books?q=stephen\` → click row → detail back link → \`/books?q=stephen\` ✓; Edit button → \`/books/568/edit?return_to=/books?q=stephen\` ✓; Cancel push URL preserves chain ✓.