### PR TITLE
feat(web): persistent book context subhead on sub-flows (#127)

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -361,11 +361,13 @@ def enrich_form(book_id):
         abort(404)
 
     prefill_isbn, prefill_query = _prefill_for_book(book)
+    return_to = _safe_return_to(request.args.get("return_to"))
     return render_template(
         "_enrich_search.html",
         book=book,
         prefill_isbn=prefill_isbn,
         prefill_query=prefill_query,
+        return_to=return_to,
     )
 
 
@@ -577,6 +579,7 @@ def enrich_candidate(book_id):
         abort(404)
 
     diffs = metadata_diff(book.metadata, candidate.metadata)
+    return_to = _safe_return_to(request.args.get("return_to"))
 
     return render_template(
         "_enrich_diff.html",
@@ -586,6 +589,7 @@ def enrich_candidate(book_id):
         provider_name=provider_name,
         query=query,
         candidate_id=candidate_id,
+        return_to=return_to,
     )
 
 

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -91,6 +91,22 @@ header .logo {
     border-radius: 4px;
 }
 
+/* Persistent book-context subhead on edit / enrich / diff sub-flows. */
+.book-subhead {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+}
+
+.book-subhead a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.book-subhead a:hover,
+.book-subhead a:focus {
+    text-decoration: underline;
+}
+
 /* Visually hide content but keep it available to screen readers. */
 .visually-hidden {
     position: absolute;

--- a/src/bookery/web/templates/_book_subhead.html
+++ b/src/bookery/web/templates/_book_subhead.html
@@ -1,0 +1,7 @@
+{# ABOUTME: Persistent book context subhead — included by edit / enrich / diff sub-flows. #}
+{# ABOUTME: Renders as a back-link to the detail view so the user never loses track of which book they're editing. #}
+<nav class="book-subhead" aria-label="Book context">
+    <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=return_to or none) }}">
+        &larr; {{ book.metadata.title }}{% if book.metadata.author %} &mdash; {{ book.metadata.author }}{% endif %}
+    </a>
+</nav>

--- a/src/bookery/web/templates/_detail_header.html
+++ b/src/bookery/web/templates/_detail_header.html
@@ -21,9 +21,11 @@
                 hx-push-url="{{ edit_url }}"
                 hx-target="#book-content"
                 hx-swap="innerHTML">Edit</button>
+        {%- set enrich_url = url_for('web.enrich_form', book_id=book.id, return_to=return_to or none) -%}
         <button type="button"
                 class="btn btn-secondary"
-                hx-get="{{ url_for('web.enrich_form', book_id=book.id) }}"
+                hx-get="{{ enrich_url }}"
+                hx-push-url="{{ enrich_url }}"
                 hx-target="#book-content"
                 hx-swap="innerHTML">Enrich</button>
         <button type="button"

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -1,5 +1,6 @@
 {# ABOUTME: Inline edit form with read-only provenance panel and Esc-to-cancel. #}
 {# ABOUTME: Two-column on >=720px viewports, stacked on mobile (handled by CSS). #}
+{% include "_book_subhead.html" %}
 <h1 class="page-title">Edit: {{ book.metadata.title }}</h1>
 <div class="edit-layout">
     <form class="edit-form"

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -1,5 +1,6 @@
 {# ABOUTME: Diff panel for the apply-candidate flow — current vs proposed metadata. #}
 {# ABOUTME: Includes header, per-field rows, and Apply/Back-to-results/Cancel actions. #}
+{% include "_book_subhead.html" %}
 <section class="enrich-diff" aria-labelledby="enrich-diff-heading">
     <header class="enrich-diff-header">
         <h3 id="enrich-diff-heading">

--- a/src/bookery/web/templates/_enrich_search.html
+++ b/src/bookery/web/templates/_enrich_search.html
@@ -1,5 +1,6 @@
 {# ABOUTME: Search form partial for the multi-provider enrich flow. #}
 {# ABOUTME: Pre-fills ISBN when present; otherwise pre-fills "title author" free-text. #}
+{% include "_book_subhead.html" %}
 <section class="enrich" aria-labelledby="enrich-heading">
     <h3 id="enrich-heading">Search providers</h3>
 

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -231,3 +231,68 @@ class TestReturnToMechanism:
         push = response.headers.get("HX-Push-Url", "")
         assert push.startswith("/books/1")
         assert "return_to=" in push
+
+
+class TestBookContextSubhead:
+    """Step 4 / issue #127 — persistent book context subhead.
+
+    Edit / enrich / diff sub-flows render a subhead with the book title and
+    author and a link back to the detail view. The subhead survives htmx
+    swaps because every fragment that replaces ``#book-content`` includes it
+    at the top.
+    """
+
+    def _subhead_match(self, html: str):
+        return re.search(
+            r'<nav[^>]+class="book-subhead"[^>]*>(?P<body>.*?)</nav>',
+            html,
+            re.DOTALL,
+        )
+
+    def test_edit_form_renders_subhead(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Frank Herbert"])
+        html = client.get("/books/1/edit", headers={"HX-Request": "true"}).data.decode()
+        match = self._subhead_match(html)
+        assert match, "expected book-subhead nav in edit fragment"
+        body = match.group("body")
+        assert "Dune" in body
+        assert "Frank Herbert" in body
+        assert 'href="/books/1' in body
+
+    def test_edit_full_page_renders_subhead(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Frank Herbert"])
+        html = client.get("/books/1/edit").data.decode()
+        assert self._subhead_match(html), "expected book-subhead nav on full-page edit"
+
+    def test_enrich_form_renders_subhead(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Frank Herbert"])
+        html = client.get("/books/1/enrich").data.decode()
+        match = self._subhead_match(html)
+        assert match, "expected book-subhead nav in enrich form"
+        body = match.group("body")
+        assert "Dune" in body
+        assert "Frank Herbert" in body
+
+    def test_subhead_link_carries_return_to(self, mock_catalog, client):
+        """The subhead's back-to-detail link threads return_to forward."""
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", authors=["Frank Herbert"])
+        html = client.get("/books/1/edit?return_to=%2Fbooks%3Fq%3Ddune").data.decode()
+        match = self._subhead_match(html)
+        assert match
+        href_match = re.search(r'href="([^"]+)"', match.group("body"))
+        assert href_match
+        href = href_match.group(1)
+        assert href.startswith("/books/1")
+        assert _extract_return_to(href) == "/books?q=dune"
+
+    def test_detail_page_omits_subhead(self, mock_catalog, client):
+        """Detail's own header already shows title + author — no subhead needed."""
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+        html = client.get("/books/1").data.decode()
+        assert not self._subhead_match(html)
+
+    def test_detail_enrich_button_carries_return_to(self, mock_catalog, client):
+        """Enrich affordance preserves the return_to chain into the sub-flow."""
+        mock_catalog.get_by_id.return_value = make_book(1)
+        html = client.get("/books/1?return_to=%2Fbooks%3Fpage%3D2").data.decode()
+        assert "/books/1/enrich?return_to=" in html


### PR DESCRIPTION
## Summary
- New \`_book_subhead.html\` partial renders \`← <Title> — <Author>\` as a link back to the detail view, with \`return_to\` threaded through.
- Included at the top of \`_edit_form.html\`, \`_enrich_search.html\`, and \`_enrich_diff.html\` so every htmx swap into \`#book-content\` carries the context with it.
- Enrich routes (\`enrich_form\`, \`enrich_candidate\`) now thread \`return_to\` so the back-to-detail link preserves the originating list URL all the way down through the deeper sub-flow.
- Detail toolbar's Enrich button pushes the sub-flow URL with \`return_to\` so refresh/share lands back on the same context (mirroring the Edit button's behavior).

Plan-02 step 4 of 4. Closes #127.

## Test plan
- [x] \`tests/web/test_navigation_state.py::TestBookContextSubhead\` — 6 new tests: subhead present on htmx edit fragment, full-page edit, enrich form; subhead link carries return_to; detail omits subhead (it has its own header); Enrich button on detail carries return_to.
- [x] Full suite: 1636 passed.
- [x] Ruff lint + format clean.
- [x] Manual browser smoke: \`/books/568/edit?return_to=/books?q=stephen\` and \`/books/568/enrich?return_to=…\` both show \"← The Shining — Stephen King\" subhead with \`return_to\` intact in the link.

## Out of scope
Direct nav to \`/books/<id>/enrich\` still returns an unstyled fragment (same gap step 1 fixed for edit). Filed as a separate follow-up.