### PR TITLE
fix(web): enrich routes return real URLs (#171)

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -354,7 +354,13 @@ def _prefill_for_book(book) -> tuple[str | None, str | None]:
 
 @bp.route("/books/<int:book_id>/enrich", methods=["GET"])
 def enrich_form(book_id):
-    """Render the multi-provider search form for a book."""
+    """Render the multi-provider search form for a book.
+
+    htmx GET (``HX-Request`` header set) returns the bare partial for an
+    in-place swap into ``#book-content``. A plain GET — direct nav, browser
+    refresh, shared link — returns the full styled page so the user lands
+    on a real URL rather than an unstyled fragment.
+    """
     catalog = current_app.config["CATALOG"]
     book = catalog.get_by_id(book_id)
     if book is None:
@@ -362,8 +368,9 @@ def enrich_form(book_id):
 
     prefill_isbn, prefill_query = _prefill_for_book(book)
     return_to = _safe_return_to(request.args.get("return_to"))
+    template = "_enrich_search.html" if request.headers.get("HX-Request") else "enrich.html"
     return render_template(
-        "_enrich_search.html",
+        template,
         book=book,
         prefill_isbn=prefill_isbn,
         prefill_query=prefill_query,
@@ -559,6 +566,11 @@ def enrich_candidate(book_id):
     Re-fetches the candidate from its provider using the original query so
     no per-session state is required. The diff panel includes an Apply form
     that POSTs back to ``enrich_apply`` with the same dispatch params.
+
+    htmx GET (``HX-Request`` header set) returns the bare partial for an
+    in-place swap into ``#book-content``. A plain GET — direct nav, browser
+    refresh, shared link — returns the full styled page so the user lands
+    on a real URL rather than an unstyled fragment.
     """
     catalog = current_app.config["CATALOG"]
     book = catalog.get_by_id(book_id)
@@ -581,8 +593,11 @@ def enrich_candidate(book_id):
     diffs = metadata_diff(book.metadata, candidate.metadata)
     return_to = _safe_return_to(request.args.get("return_to"))
 
+    template = (
+        "_enrich_diff.html" if request.headers.get("HX-Request") else "enrich_candidate.html"
+    )
     return render_template(
-        "_enrich_diff.html",
+        template,
         book=book,
         candidate=candidate,
         diffs=diffs,

--- a/src/bookery/web/templates/enrich.html
+++ b/src/bookery/web/templates/enrich.html
@@ -1,0 +1,17 @@
+{# ABOUTME: Full-page wrapper for the enrich search form — direct nav, refresh, share. #}
+{# ABOUTME: htmx requests get the bare _enrich_search.html fragment instead. #}
+{% extends "base.html" %}
+
+{% block title %}Enrich: {{ book.metadata.title }} - Bookery{% endblock %}
+
+{% block content %}
+<div class="book-detail">
+    <nav aria-label="Breadcrumb" class="back-link">
+        <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=return_to or none) }}">&larr; Back to book</a>
+    </nav>
+
+    <div id="book-content" aria-live="polite">
+        {% include "_enrich_search.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/src/bookery/web/templates/enrich_candidate.html
+++ b/src/bookery/web/templates/enrich_candidate.html
@@ -1,0 +1,17 @@
+{# ABOUTME: Full-page wrapper for the apply-candidate diff panel — direct nav, refresh, share. #}
+{# ABOUTME: htmx requests get the bare _enrich_diff.html fragment instead. #}
+{% extends "base.html" %}
+
+{% block title %}Apply candidate: {{ book.metadata.title }} - Bookery{% endblock %}
+
+{% block content %}
+<div class="book-detail">
+    <nav aria-label="Breadcrumb" class="back-link">
+        <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=return_to or none) }}">&larr; Back to book</a>
+    </nav>
+
+    <div id="book-content" aria-live="polite">
+        {% include "_enrich_diff.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -4,7 +4,9 @@
 import re
 from urllib.parse import parse_qs, urlsplit
 
-from tests.web.conftest import make_book
+import pytest
+
+from tests.web.conftest import FakeProvider, make_book, make_candidate
 
 
 def _extract_return_to(href: str) -> str | None:
@@ -296,3 +298,97 @@ class TestBookContextSubhead:
         mock_catalog.get_by_id.return_value = make_book(1)
         html = client.get("/books/1?return_to=%2Fbooks%3Fpage%3D2").data.decode()
         assert "/books/1/enrich?return_to=" in html
+
+
+class TestEnrichUrlIsReal:
+    """Issue #171 — GET /books/<id>/enrich and /enrich/candidate are real URLs.
+
+    Same defect plan-02 step 1 fixed for /books/<id>/edit: direct nav, refresh,
+    or shared link previously landed on a bare fragment. Plain GET now returns
+    the full styled page; htmx GET still returns the fragment for in-place swap.
+    """
+
+    @pytest.fixture
+    def providers(self, fake_provider):
+        return {"fake": fake_provider}
+
+    @pytest.fixture
+    def fake_provider(self):
+        provider = FakeProvider(name="fake")
+        provider.by_isbn = [make_candidate(source="fake", source_id="fake:1")]
+        return provider
+
+    # --- /books/<id>/enrich (search form) -------------------------------------
+
+    def test_search_plain_get_returns_full_styled_page(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Book One")
+        response = client.get("/books/1/enrich")
+        assert response.status_code == 200
+        html = response.data.decode()
+        # Base layout markers: doctype, site header, skip link.
+        assert "<!DOCTYPE html>" in html
+        assert "Skip to main content" in html
+        assert 'class="logo"' in html
+        # Search form is still rendered.
+        assert 'name="isbn"' in html
+        assert 'name="query"' in html
+
+    def test_search_htmx_get_returns_fragment_only(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Book One")
+        response = client.get("/books/1/enrich", headers={"HX-Request": "true"})
+        assert response.status_code == 200
+        html = response.data.decode()
+        # No base layout — bare fragment for in-place swap.
+        assert "<!DOCTYPE html>" not in html
+        assert "Skip to main content" not in html
+        # Form fields still present in the partial.
+        assert 'name="isbn"' in html
+        assert 'name="query"' in html
+
+    def test_search_refresh_renders_full_page(self, mock_catalog, client):
+        """Browser refresh sends no HX-Request header — same path as direct nav."""
+        mock_catalog.get_by_id.return_value = make_book(1, title="Refreshed")
+        response = client.get("/books/1/enrich")
+        html = response.data.decode()
+        assert "<!DOCTYPE html>" in html
+        assert "Refreshed" in html
+
+    def test_search_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        assert client.get("/books/999/enrich").status_code == 404
+
+    # --- /books/<id>/enrich/candidate (diff panel) ----------------------------
+
+    def _candidate_url(self) -> str:
+        return "/books/1/enrich/candidate?provider=fake&query=9780441172719&candidate_id=fake:1"
+
+    def test_candidate_plain_get_returns_full_styled_page(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Diff Book")
+        response = client.get(self._candidate_url())
+        assert response.status_code == 200
+        html = response.data.decode()
+        # Base layout markers.
+        assert "<!DOCTYPE html>" in html
+        assert "Skip to main content" in html
+        assert 'class="logo"' in html
+        # Diff table still rendered.
+        assert "enrich-diff-table" in html
+        assert "Apply" in html
+
+    def test_candidate_htmx_get_returns_fragment_only(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Diff Book")
+        response = client.get(self._candidate_url(), headers={"HX-Request": "true"})
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "<!DOCTYPE html>" not in html
+        assert "Skip to main content" not in html
+        assert "enrich-diff-table" in html
+
+    def test_candidate_missing_book_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        assert client.get(self._candidate_url()).status_code == 404
+
+    def test_candidate_missing_provider_returns_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        bad = "/books/1/enrich/candidate?provider=ghost&query=q&candidate_id=x"
+        assert client.get(bad).status_code == 404


### PR DESCRIPTION
## Summary
- `GET /books/<id>/enrich` and `/enrich/candidate` now return a full styled page on plain GET (direct nav, refresh, share) and the bare partial on htmx swap.
- Mirrors the edit-route fix from #164 / PR #131.

## Changes
- **src/bookery/web/templates/enrich.html** (new): full-page wrapper around `_enrich_search.html`.
- **src/bookery/web/templates/enrich_candidate.html** (new): full-page wrapper around `_enrich_diff.html`.
- **src/bookery/web/routes.py**: `enrich_form` and `enrich_candidate` branch template choice on `request.headers.get("HX-Request")`.
- **tests/web/test_navigation_state.py**: new `TestEnrichUrlIsReal` class — 8 tests covering search × {plain, htmx, refresh, 404} and candidate × {plain, htmx, missing-book, missing-provider}.

## Testing
- [x] `uv run pytest` — 1644 passed, 0 regressions.
- [x] `uv run ruff check` + `ruff format --check` on touched files — clean.
- [x] python-code-reviewer skill — no issues.

## Related Issues
Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)