### PR TITLE
fix(vault-export): one TOC entry per Obsidian note (#173)

### DIFF
--- a/src/bookery/core/vault/assemble.py
+++ b/src/bookery/core/vault/assemble.py
@@ -81,8 +81,7 @@ def _disambiguate(notes: list[Note], display_for: dict[int, str]) -> dict[int, t
     return result
 
 
-_H1_LINE_RE = re.compile(r"^# (.+)$", re.MULTILINE)
-_H2_LINE_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+_BODY_HEADING_RE = re.compile(r"^(#{1,6}) (.+)$", re.MULTILINE)
 _FOLDER_SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -103,17 +102,24 @@ def _folder_label(folder: str) -> str:
 
 
 def _demote_body_headings(body: str) -> str:
-    """Demote body H1/H2 down so they sit beneath the note's H3 heading.
+    """Demote every body heading so none compete with the note's H3 entry.
 
     Folders are H1 chapters, letter buckets are H2 sections, and notes are H3
-    entries. Any in-body H1 or H2 would compete with those structural headings
-    in the TOC, so push body H1->H4 and body H2->H5. The H2 substitution runs
-    first so demoted H1s (now starting with ``## ``) are not re-matched as
-    H2s. pandoc ``--toc-depth=3`` only walks folder->bucket->note.
+    entries. pandoc ``--toc-depth=3`` walks folder->bucket->note and
+    ``--split-level=3`` splits the spine at H3. Any in-body H1/H2/H3 would
+    pollute both the TOC and the spine, and body H4/H5/H6 also get pushed to
+    H6 so the rendered note has a single, predictable subheading level.
+
+    Mapping: H1->H4, H2->H5, H3-H6->H6. Implemented as one pass over a
+    leading-hash regex so demoted headings cannot be re-matched.
     """
-    body = _H2_LINE_RE.sub(r"##### \1", body)
-    body = _H1_LINE_RE.sub(r"#### \1", body)
-    return body
+
+    def _shift(match: re.Match[str]) -> str:
+        level = len(match.group(1))
+        new_level = min(level + 3, 6)
+        return f"{'#' * new_level} {match.group(2)}"
+
+    return _BODY_HEADING_RE.sub(_shift, body)
 
 
 @dataclass(slots=True)

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -55,6 +55,25 @@ def test_vault_export_produces_valid_epub(tmp_path: Path):
     assert "Note B" in titles
 
 
+def test_vault_export_one_toc_entry_per_note(tmp_path: Path):
+    """Body H3+ inside a note must never reach the EPUB TOC. A literature note
+    full of `### Key Points` / `### Chapter Questions` per chapter must appear
+    as a single TOC entry (the note title), not as a fan of sibling chapters.
+    """
+    result, out = _run(tmp_path)
+    assert result.exit_code == 0, result.output
+
+    book = epub.read_epub(str(out))
+    titles = _flatten_toc_titles(book.toc)
+
+    assert "Book With Chapters" in titles
+    # Body headings must not leak through to the TOC.
+    assert "Key Points" not in titles
+    assert "Chapter Questions" not in titles
+    assert not any(t.startswith("Chapter 1") for t in titles), titles
+    assert not any(t.startswith("Chapter 2") for t in titles), titles
+
+
 def test_vault_export_stable_identifier_across_runs(tmp_path: Path):
     first, out = _run(tmp_path)
     assert first.exit_code == 0, first.output

--- a/tests/fixtures/vault/2_Literature Notes/book-with-chapters.md
+++ b/tests/fixtures/vault/2_Literature Notes/book-with-chapters.md
@@ -1,0 +1,26 @@
+---
+tags:
+  - type/book
+---
+
+# Book With Chapters
+
+A literature note shaped like a real book write-up: per-chapter H2 sections
+each holding `### Key Points` and `### Chapter Questions`. None of those body
+headings may surface as TOC entries in the rendered EPUB.
+
+## Chapter 1: Beginnings
+
+### Key Points
+- point one
+
+### Chapter Questions
+1. What is the unique nature of the brain injury suffered by the soldier?
+
+## Chapter 2: Middles
+
+### Key Points
+- point two
+
+### Chapter Questions
+1. Why do middles matter?

--- a/tests/unit/test_vault_assemble.py
+++ b/tests/unit/test_vault_assemble.py
@@ -201,6 +201,58 @@ def test_body_h2_demoted_to_h5(tmp_path: Path):
     assert "##### Subsection" in md
 
 
+def test_body_h3_demoted_below_toc(tmp_path: Path):
+    # Notes own H3. Any body H3 must cascade to H6 so it never appears as a
+    # sibling note entry in the TOC and never causes a pandoc --split-level=3
+    # spine split.
+    notes = [_note("T", "F", "### Inner Heading\n\nbody\n")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    h3_lines = [ln for ln in md.splitlines() if ln.startswith("### ")]
+    assert h3_lines == ["### T {#t}"]
+    assert "###### Inner Heading" in md
+
+
+def test_body_h4_and_h5_clamped_to_h6(tmp_path: Path):
+    # H4 and H5 already sit below the TOC depth, but demote to H6 anyway so
+    # every body heading lands at a single predictable level.
+    notes = [_note("T", "F", "#### Four\n\n##### Five\n\nbody\n")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "###### Four" in md
+    assert "###### Five" in md
+    # No H4 or H5 heading lines should survive.
+    assert not any(ln.startswith("#### ") for ln in md.splitlines())
+    assert not any(ln.startswith("##### ") for ln in md.splitlines())
+
+
+def test_body_h6_left_at_h6(tmp_path: Path):
+    notes = [_note("T", "F", "###### Already Deep\n\nbody\n")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    assert "###### Already Deep" in result.markdown
+
+
+def test_literature_note_with_many_h3_subsections_yields_one_toc_entry(tmp_path: Path):
+    # Real-world shape: a book note containing per-chapter H2 sections each
+    # holding ### Key Points and ### Chapter Questions. None of those body
+    # headings may surface at H3 or shallower in the assembled markdown.
+    body = (
+        "# Book Title\n\n"
+        "## Chapter 1\n\n"
+        "### Key Points\n- point\n\n"
+        "### Chapter Questions\n1. Q?\n\n"
+        "## Chapter 2\n\n"
+        "### Key Points\n- point\n\n"
+        "### Chapter Questions\n1. Q?\n"
+    )
+    notes = [_note("The Loop", "Lit", body)]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    h3_lines = [ln for ln in md.splitlines() if ln.startswith("### ")]
+    # Exactly one H3 entry — the note title itself.
+    assert h3_lines == ["### The Loop {#the-loop}"]
+
+
 def test_duplicate_titles_in_same_folder_use_filename_hint(tmp_path: Path):
     # Two "Reference" literature notes in the same folder — common in a real
     # vault where every book note has its own References.md. The folder alone


### PR DESCRIPTION
Closes #173. Refs epic #109.

## Summary
- Replace H1/H2-only body-heading demotion with a single pass that shifts every body heading by 3 levels (clamped at H6).
- Literature notes (e.g. `The Loop`) that pack per-chapter `### Key Points` / `### Chapter Questions` no longer leak siblings into the TOC or into the pandoc `--split-level=3` spine — one TOC entry per `.md`.
- Adds focused unit tests for H3, H4/H5 clamping, H6 no-op, and a real-world literature-note shape.

## Test plan
- [x] `uv run pytest` (1648 passed)
- [x] `uv run ruff check src/ tests/`
- [x] Regenerated `~/obsidian-vault` export and verified in Apple Books — single entry per note, no `Chapter Questions` siblings, no list-item-as-chapter artifacts