### PR TITLE
feat(vault-export): strip leading articles for filing (#175)

### DIFF
--- a/src/bookery/core/vault/assemble.py
+++ b/src/bookery/core/vault/assemble.py
@@ -21,6 +21,28 @@ AssembleProgressFn = Callable[[int, int, str], None]
 _NON_LETTER_BUCKET = "#"
 _NON_LETTER_BUCKET_SLUG = "hash"
 
+# Leading English articles ignored for filing (bucket + within-bucket sort).
+# Multi-language support is an explicit non-goal — see issue #175.
+_LEADING_ARTICLE_RE = re.compile(r"^(?:the|a|an)\s+(.+)$", re.IGNORECASE)
+
+
+def _filing_title(display: str, frontmatter: dict | None = None) -> str:
+    """Return the title used for bucket assignment and within-bucket sort.
+
+    Order of precedence:
+    1. ``filing_title`` in the note's frontmatter, if present and non-empty.
+    2. ``display`` with a leading English article (``The`` / ``A`` / ``An``)
+       stripped.
+    3. ``display`` unchanged when stripping would leave an empty string.
+    """
+    source = display
+    if frontmatter:
+        override = frontmatter.get("filing_title")
+        if isinstance(override, str) and override.strip():
+            source = override.strip()
+    stripped = _LEADING_ARTICLE_RE.sub(r"\1", source, count=1).strip()
+    return stripped or source
+
 
 def _bucket_for(title: str) -> str:
     """Return the single-character A-Z bucket label for a display title.
@@ -140,6 +162,13 @@ def assemble_vault(
 ) -> AssembledVault:
     """Concatenate notes into a single markdown doc with resolved links and assets."""
     display_for: dict[int, str] = {id(n): display_title(n.title) for n in notes}
+    # Filing title is what we bucket and sort by; display title is what the
+    # reader sees as the H3 heading. Stripping leading English articles here
+    # lets "The Loop" file under L while still rendering "The Loop" in the
+    # TOC — see issue #175.
+    filing_for: dict[int, str] = {
+        id(n): _filing_title(display_for[id(n)], n.frontmatter) for n in notes
+    }
     disambiguated = _disambiguate(notes, display_for)
     # Wiki-link resolution: map both the original raw title and the stripped
     # display title to the (first) unique slug, so both `[[202302010942 - X]]`
@@ -170,14 +199,14 @@ def assemble_vault(
         # leader (digit/symbol) lands in the ``#`` bucket.
         bucket_to_notes: dict[str, list[Note]] = {}
         for note in folder_to_notes[folder]:
-            bucket = _bucket_for(display_for[id(note)])
+            bucket = _bucket_for(filing_for[id(note)])
             bucket_to_notes.setdefault(bucket, []).append(note)
         for bucket in sorted(bucket_to_notes, key=_bucket_sort_key):
             chunks.append(f"## {bucket} {{#bucket-{_folder_slug(folder)}-{_bucket_slug(bucket)}}}")
             chunks.append("")
             bucket_notes = sorted(
                 bucket_to_notes[bucket],
-                key=lambda n: display_for[id(n)].casefold(),
+                key=lambda n: filing_for[id(n)].casefold(),
             )
             for note in bucket_notes:
                 processed += 1

--- a/src/bookery/core/vault/epub.py
+++ b/src/bookery/core/vault/epub.py
@@ -79,6 +79,10 @@ def render_epub(
         # once any note body contains a `---` thematic break, which dropped
         # hundreds of chapters and broke every cross-note link in real-world
         # vault exports.
+        # --toc inserts the nav.xhtml into the linear reading spine so the
+        # reader sees a flip-through TOC page at the start of the book in
+        # addition to the sidebar nav. Without it, Kobo shows the sidebar
+        # TOC but offers no in-spine landing page that mirrors it.
         cmd = [
             pandoc,
             "-f",

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -55,6 +55,42 @@ def test_vault_export_produces_valid_epub(tmp_path: Path):
     assert "Note B" in titles
 
 
+def _find_parent_bucket(toc, target_title: str) -> str | None:
+    """Walk pandoc's nested TOC and return the H2 bucket title that contains
+    a note whose H3 title equals ``target_title``. ``None`` if not found.
+    """
+    for entry in toc:
+        if not isinstance(entry, tuple):
+            continue
+        _folder, buckets = entry
+        for bucket_entry in buckets:
+            if not isinstance(bucket_entry, tuple):
+                continue
+            bucket_section, notes = bucket_entry
+            for note in notes:
+                if getattr(note, "title", None) == target_title:
+                    return getattr(bucket_section, "title", None)
+    return None
+
+
+def test_vault_export_strips_leading_article_for_filing(tmp_path: Path):
+    """`The Filed Note` must land in the F bucket, not the T bucket — leading
+    English articles are ignored for filing while the display title stays
+    unchanged. See issue #175.
+    """
+    result, out = _run(tmp_path)
+    assert result.exit_code == 0, result.output
+
+    book = epub.read_epub(str(out))
+    titles = _flatten_toc_titles(book.toc)
+
+    # Display title is intact in the TOC.
+    assert "The Filed Note" in titles
+    # And it lives under the F bucket, not T.
+    bucket = _find_parent_bucket(book.toc, "The Filed Note")
+    assert bucket == "F", f"expected F bucket, got {bucket!r}"
+
+
 def test_vault_export_one_toc_entry_per_note(tmp_path: Path):
     """Body H3+ inside a note must never reach the EPUB TOC. A literature note
     full of `### Key Points` / `### Chapter Questions` per chapter must appear

--- a/tests/fixtures/vault/3_Permanent Notes/the-filed-note.md
+++ b/tests/fixtures/vault/3_Permanent Notes/the-filed-note.md
@@ -1,0 +1,10 @@
+---
+tags:
+  - shared
+---
+
+# The Filed Note
+
+A note titled "The Filed Note" — the EPUB TOC must place it under the **F**
+bucket (from "Filed"), not under T, because leading English articles are
+stripped for filing.

--- a/tests/integration/test_vault_export_pipeline.py
+++ b/tests/integration/test_vault_export_pipeline.py
@@ -12,7 +12,13 @@ FIXTURE = Path(__file__).parent.parent / "fixtures" / "vault"
 def test_full_pipeline_produces_expected_markdown():
     notes = walk_vault(FIXTURE)
     titles = sorted(n.title for n in notes)
-    assert titles == ["Lit One", "Note A", "Note B"]
+    assert titles == [
+        "Book With Chapters",
+        "Lit One",
+        "Note A",
+        "Note B",
+        "The Filed Note",
+    ]
 
     result = assemble_vault(notes, vault_path=FIXTURE, include_index=True)
     md = result.markdown
@@ -46,7 +52,7 @@ def test_full_pipeline_produces_expected_markdown():
 def test_folder_filter_excludes_other_folders():
     notes = walk_vault(FIXTURE, folders=["3_Permanent Notes"])
     titles = sorted(n.title for n in notes)
-    assert titles == ["Note A", "Note B"]
+    assert titles == ["Note A", "Note B", "The Filed Note"]
 
 
 def test_index_exclude_prefix_filters_topic():

--- a/tests/unit/test_vault_assemble.py
+++ b/tests/unit/test_vault_assemble.py
@@ -7,14 +7,20 @@ from bookery.core.vault.assemble import AssembledVault, assemble_vault
 from bookery.core.vault.note import Note
 
 
-def _note(title: str, folder: str, body: str, tags: list[str] | None = None) -> Note:
+def _note(
+    title: str,
+    folder: str,
+    body: str,
+    tags: list[str] | None = None,
+    frontmatter: dict | None = None,
+) -> Note:
     return Note(
         path=Path(f"{folder}/{title}.md"),
         relative_folder=folder,
         title=title,
         slug=title.lower().replace(" ", "-"),
         body=body,
-        frontmatter={},
+        frontmatter=frontmatter or {},
         tags=tags or [],
     )
 
@@ -302,3 +308,132 @@ def test_notes_without_tags_reported(tmp_path: Path):
     notes = [_note("Tagged", "P", "x", tags=["t"]), _note("Untagged", "P", "y")]
     result = assemble_vault(notes, vault_path=tmp_path, include_index=True)
     assert "Untagged" in result.notes_without_tags
+
+
+# --- Leading-article filing (issue #175) ----------------------------------
+
+
+def test_leading_the_files_under_second_word_bucket(tmp_path: Path):
+    notes = [_note("The Loop", "F", "x")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    # Bucket is L (from "Loop"), not T.
+    assert "## L {#bucket-f-l}" in md
+    assert "{#bucket-f-t}" not in md
+    # Display title is unchanged.
+    assert "### The Loop {#the-loop}" in md
+
+
+def test_leading_a_files_under_second_word_bucket(tmp_path: Path):
+    notes = [_note("A Tale of Two Cities", "F", "x")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "## T {#bucket-f-t}" in md
+    # No A bucket should exist (would be `## A {#bucket-f-a}`).
+    assert "{#bucket-f-a}" not in md
+    assert "### A Tale of Two Cities" in md
+
+
+def test_leading_an_files_under_second_word_bucket(tmp_path: Path):
+    # "An Owl" must file under O, not A — otherwise the test passes
+    # trivially against the legacy first-letter rule.
+    notes = [_note("An Owl", "F", "x")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "## O {#bucket-f-o}" in md
+    assert "{#bucket-f-a}" not in md
+    # Display is unchanged.
+    assert "### An Owl" in md
+
+
+def test_leading_article_case_insensitive(tmp_path: Path):
+    notes = [
+        _note("THE Big One", "F", "x"),
+        _note("the small one", "F", "y"),
+    ]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    # Both file under B and S respectively, not T.
+    assert "## B {#bucket-f-b}" in md
+    assert "## S {#bucket-f-s}" in md
+    assert "{#bucket-f-t}" not in md
+
+
+def test_word_starting_with_article_letters_not_stripped(tmp_path: Path):
+    # "Theatre" must file under T — the article must be followed by a space.
+    notes = [_note("Theatre", "F", "x"), _note("A.I. Risks", "F", "y")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "## T {#bucket-f-t}" in md
+    assert "## A {#bucket-f-a}" in md
+
+
+def test_article_only_title_falls_back_to_original(tmp_path: Path):
+    # Literal title "The" with no body word — must not produce an empty bucket
+    # key. Fall back to the original display title so it files under T.
+    notes = [_note("The", "F", "x")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "## T {#bucket-f-t}" in md
+
+
+def test_frontmatter_filing_title_overrides_heuristic(tmp_path: Path):
+    # Author wants "The The" (a band) to actually file under T. Frontmatter
+    # filing_title wins over the strip-article heuristic.
+    notes = [
+        _note(
+            "The The",
+            "F",
+            "x",
+            frontmatter={"filing_title": "The The"},
+        ),
+    ]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    # filing_title "The The" still has the strip rule applied -> "The" ->
+    # which is article-only, so fallback uses the filing_title as-is.
+    # Net effect: files under T.
+    assert "## T {#bucket-f-t}" in md
+
+
+def test_frontmatter_filing_title_can_relocate_note(tmp_path: Path):
+    # Author can also force a note into a different bucket via filing_title.
+    notes = [
+        _note(
+            "The Loop",
+            "F",
+            "x",
+            frontmatter={"filing_title": "Zebra"},
+        ),
+    ]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "## Z {#bucket-f-z}" in md
+    # Display title still reads "The Loop".
+    assert "### The Loop" in md
+
+
+def test_non_letter_bucket_unaffected_by_article_stripping(tmp_path: Path):
+    notes = [_note("123 numbers", "F", "x")]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    assert "## # {#bucket-f-hash}" in md
+
+
+def test_within_bucket_sort_uses_filing_title(tmp_path: Path):
+    # In the L bucket, "The Loop" should sort by "Loop", landing before
+    # "Loops, Open" but after "Loop Theory".
+    notes = [
+        _note("Loops, Open", "F", "x"),
+        _note("The Loop", "F", "y"),
+        _note("Loop Theory", "F", "z"),
+    ]
+    result = assemble_vault(notes, vault_path=tmp_path)
+    md = result.markdown
+    # Order by filing title: "Loop Theory" < "Loops, Open" < "The Loop" (filed as "Loop")
+    # Actually filing keys: "loop theory", "loops, open", "loop".
+    # Sorted casefold: "loop" < "loop theory" < "loops, open".
+    pos_the_loop = md.index("### The Loop")
+    pos_loop_theory = md.index("### Loop Theory")
+    pos_loops_open = md.index("### Loops, Open")
+    assert pos_the_loop < pos_loop_theory < pos_loops_open


### PR DESCRIPTION
Closes #175.

## Summary
- Notes titled "The Loop" / "A Tale..." / "An Owl" now file under L / T / O in the EPUB TOC instead of T / A / A. Display titles in the TOC and H3 headings stay intact.
- Within-bucket sort uses the same filing title, so "The Loop" sorts as "Loop".
- `filing_title` frontmatter override lets authors force a specific bucket (e.g. the band "The The" → T).
- Article-only titles ("The") fall back to the original display title to keep the bucket key non-empty.
- Added evergreen doc comment explaining why pandoc's `--toc` flag is required for Kobo's in-spine TOC landing page (from this morning's investigation).

## Implementation notes
- New `_filing_title(display, frontmatter)` helper in `assemble.py` with a case-insensitive `^(the|a|an)\s+` regex.
- "Theatre" / "A.I. Risks" are unaffected — the article must be followed by whitespace.
- Multi-language article stripping is an explicit non-goal (see issue #175).

## Test plan
- [x] Unit tests: 10 new cases covering The/A/An stripping, case-insensitivity, word-boundary safety, article-only fallback, `filing_title` override (both bucket-preserving and relocating), non-letter buckets, and within-bucket sort order.
- [x] Integration test: updated `walk_vault` / `assemble_vault` expectations for the new fixture note.
- [x] E2E test: new `test_vault_export_strips_leading_article_for_filing` walks the generated EPUB's nested TOC and asserts "The Filed Note" lands under the F bucket.
- [x] `uv run pytest tests/unit/test_vault_assemble.py tests/integration/test_vault_export_pipeline.py tests/e2e/test_vault_export_cli.py` — 45 passed.
- [x] `uv run ruff check` clean.
- [x] Pre-commit hooks (ruff + pyright) clean.