### PR TITLE
docs: refresh README and roadmap for 2026.5.x reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bookery takes the "metadata-first" approach that made beets great for music and 
 
 ## Status
 
-**Early development** — Bookery is functional but not yet feature-complete. EPUB metadata extraction, MOBI-to-EPUB conversion, matching against Open Library, SQLite catalog, and non-destructive write-back are working. Device sync and plugins are on the roadmap.
+**Active development** — daily-driver usable. EPUB metadata extraction, MOBI/PDF-to-EPUB conversion, multi-provider matching (Open Library + Google Books) with consensus merging, a SQLite catalog with per-field provenance, non-destructive write-back, Kobo device sync, a local web UI for browsing/editing, and Obsidian vault-export are all working. Plugin architecture is the main item still on the roadmap.
 
 See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
@@ -16,10 +16,14 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 - **MOBI-to-EPUB conversion** — converts MOBI/KF8 files to EPUB, preserving metadata, images, cover art, and chapter structure (via NCX TOC)
 - **PDF-to-EPUB conversion** — `bookery add` and `bookery import` detect text-based PDFs, extract their structure with pdfplumber + a local LLM (LM Studio), and produce a reflowable EPUB. Scanned PDFs are refused (OCR not yet supported).
 - **Kobo sync** — `bookery sync kobo` walks the catalog, converts each EPUB to `.kepub.epub` via `kepubify`, and copies the result to a mounted Kobo. The library itself stays format-canonical (EPUB only); kepub is generated on demand at sync time and cached so re-syncs are free when nothing has changed.
-- **Open Library matching** — searches by ISBN (precise) or title/author (fuzzy), with confidence scoring
+- **Multi-provider metadata matching** — Open Library and Google Books in a consensus merger that prefers values agreed on by ≥2 providers and falls back to a priority order otherwise. ISBN-10/13 lookups are normalized and provider responses are cached.
+- **Per-field provenance & locking** — every cataloged field records which provider supplied it and when. User edits are stamped as `user` and locked against `rematch`; individual fields can be locked/unlocked explicitly with `bookery info --lock` / `--unlock`.
 - **Interactive review** — presents candidates in a Rich table, lets you accept, compare details, look up by URL, or skip
 - **Smart normalization** — splits mangled filenames like `SteveBerry-TheTemplarLegacy` into clean search queries, detects embedded author names
 - **SQLite catalog** — imports books into a local database for querying, tagging, and integrity checks
+- **Web UI** — `bookery serve` launches a local browser UI for paginated/sortable browsing of the catalog, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail/edit pages, search-active-providers, and "apply candidate metadata with diff" rematch flow.
+- **Genre management** — `bookery genre` auto-maps raw provider subjects to a canonical genre vocabulary, with `assign` / `apply` / `auto` / `stats` / `unmatched` for curation.
+- **Obsidian vault-export** — `bookery vault-export` turns an Obsidian vault into a single EPUB with a hierarchical folder/note TOC, A-Z buckets within each folder, leading-article-aware filing ("The Loop" files under L), resolved `[[wiki-links]]` and `![[image]]` embeds, and an optional tag index. Can auto-catalog the export so it ships on the next Kobo sync.
 - **Non-destructive** — metadata writes always go to a copy; original file contents are never modified. `import` copies each source into your library by default (`--move` deletes the source after a successful catalog insert)
 
 ## Installation
@@ -143,12 +147,15 @@ bookery info 42
 
 | Command | Description |
 |---------|-------------|
+| `add <file>` | Add a single EPUB or PDF to the library in one step (copies into `library_root`, matches, catalogs; `--move` deletes the source) |
 | `import <dir>` | Scan for EPUBs, copy into `library_root`, and catalog them (supports `--match`, `--move`) |
 | `remove <id>...` | Delete one or more books from the catalog and disk (`-y` skips prompt; `--keep-file` keeps the file) |
+| `prune` | Remove catalog rows whose underlying files are missing |
 | `ls` | List all books in the catalog (filter with `--series` or `--tag`) |
-| `info <id>` | Show detailed metadata for a book by ID |
+| `info <id>` | Show detailed metadata for a book by ID (`--provenance`, `--set field=value`, `--lock field`, `--unlock field`) |
 | `search <query>` | Search the catalog by title, author, or description |
 | `inventory <path>` | Scan a directory tree and report ebook format coverage |
+| `folder <query>` | Open the on-disk folder for a book (`--print` to print the path instead) |
 
 ### Organization
 
@@ -157,7 +164,21 @@ bookery info 42
 | `tag add <id> <tag>` | Add a tag to a book |
 | `tag rm <id> <tag>` | Remove a tag from a book |
 | `tag ls` | List all tags with book counts |
+| `genre assign <id> <genre>` | Assign a canonical genre to a book |
+| `genre apply` | Batch-assign genres from subjects for cataloged books |
+| `genre auto` | Auto-map provider subjects to canonical genres across the catalog |
+| `genre ls` | List all canonical genres with book counts |
+| `genre stats` | Show the most common subjects that don't map to a canonical genre |
+| `genre unmatched` | Show books with subjects but no genre assigned |
 | `verify` | Check for missing or changed files (supports `--check-hash`) |
+
+### Web UI
+
+| Command | Description |
+|---------|-------------|
+| `serve` | Launch the local web UI (`--host`, `--port`; default `127.0.0.1:5000`) |
+
+The web UI provides paginated and sortable browsing, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail and edit pages, a "search active providers" flow that lets you apply candidate metadata with a side-by-side diff, and inline delete.
 
 ### Device sync
 
@@ -281,12 +302,15 @@ in `CONTRIBUTING.md`.
 Bookery is being built in phases:
 
 1. ~~EPUB metadata read/write + CLI skeleton~~
-2. ~~Open Library matching + interactive review~~
-3. ~~SQLite catalog, import pipeline, query commands~~
+2. ~~Multi-provider matching (Open Library + Google Books) with consensus merger and interactive review~~
+3. ~~SQLite catalog, import pipeline, per-field provenance, query commands~~
 4. ~~MOBI-to-EPUB conversion~~
-5. **Next:** Plugin architecture (format and provider plugins)
-6. Kobo device integration
-7. Polish (config, covers, progress bars, performance)
+5. ~~PDF-to-EPUB conversion (semantic, local-LLM)~~
+6. ~~Kobo device sync~~
+7. ~~Obsidian vault-export to EPUB~~
+8. ~~Web UI for browse/search/edit~~
+9. **Next:** Plugin architecture (format and provider plugins)
+10. Polish (covers cache, performance benchmarks, config polish)
 
 See [docs/roadmap.md](docs/roadmap.md) for detailed checklists.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,38 +30,75 @@
 - [x] `bookery tag` command group (add, rm, ls)
 - [x] `bookery info` shows tags, `bookery ls --tag` filter
 
-## Phase 4: Query DSL + Search + Browse
+## Phase 4: Query + Search + Browse
 - [ ] Hand-rolled recursive descent parser
 - [ ] Query types: FieldQuery, SubstringQuery, RegexpQuery, NotQuery, AndQuery, OrQuery
 - [ ] Bare text → FTS5, field:value → WHERE clause
-- [ ] `bookery ls` with query filters, sort, pagination
-- [ ] `bookery info <query>` detailed view
-- [ ] `bookery tag add/rm`
-- [ ] `bookery edit` interactive metadata editor
-- [ ] Output modes: table (Rich), --json, --quiet
-- [ ] Search < 200ms on 2000-book library
+- [x] `bookery ls` with `--series` / `--tag` filters, sort, pagination
+- [x] `bookery info <id>` detailed view
+- [x] `bookery tag add/rm/ls`
+- [ ] `bookery edit` interactive metadata editor (in-CLI; web UI ships the edit flow)
+- [x] Output modes: table (Rich), --json
+- [ ] Search < 200ms on 2000-book library (not yet benchmarked)
 
-## Phase 5: Plugin Architecture
+## Phase 5: Multi-Provider Metadata
+- [x] Google Books provider alongside Open Library
+- [x] Consensus merger across providers (≥2 agree → win, else priority order)
+- [x] Provider response cache (`metadata_cache.db`, TTL configurable)
+- [x] ISBN-10/13 normalization
+- [x] Per-field provenance table (`book_field_provenance`)
+- [x] Field-level lock/unlock via `bookery info --lock` / `--unlock`
+- [x] Hand-edit support via `bookery info --set field=value` (stamped as `user`)
+
+## Phase 6: Kobo Device Sync
+- [x] Kobo detection (auto-scan mount points)
+- [x] `bookery sync kobo` — convert EPUBs to `.kepub.epub` and copy to device
+- [x] `--target <path>` override and `--dry-run`
+- [x] Sync caching keyed on source hash + kepubify version (`kepub_cache.db`)
+- [x] Additive sync (existing device files never deleted)
+- [x] Tested against real Kobo hardware
+- [ ] `bookery device ls` — list books on device (not yet implemented)
+- [ ] `bookery device rm <query>` — remove from device (not yet implemented)
+
+## Phase 7: Web UI
+- [x] `bookery serve` — local Flask UI bound to 127.0.0.1
+- [x] Paginated `/books` with `BrowseQuery` + result count
+- [x] Sortable column headers
+- [x] Filter chips
+- [x] Responsive mobile card layout
+- [x] Cover thumbnails on list and detail
+- [x] Per-book detail and edit pages (real URLs, `?return_to` threading)
+- [x] Search active metadata providers from the UI
+- [x] Apply candidate metadata with side-by-side diff
+- [x] Delete book from detail page
+- [x] Persistent book context subhead on sub-flows
+
+## Phase 8: Vault-Export
+- [x] Obsidian vault → single EPUB pipeline (pandoc)
+- [x] Hierarchical folder/note TOC
+- [x] A-Z letter buckets within each folder
+- [x] Leading-article-aware filing (The/A/An stripped; `filing_title` frontmatter override)
+- [x] One TOC entry per note (body H1-H6 demoted)
+- [x] `[[wiki-link]]` and `![[image]]` embed resolution
+- [x] Optional tag index
+- [x] `--catalog` flag: auto-import the export into the library
+- [x] Stable UUID across re-exports for in-place Kobo updates
+- [x] `exclude_tags` to drop ephemeral notes (meetings, dailies)
+
+## Phase 9: Plugin Architecture (Next)
 - [ ] pluggy hookspecs (extract_metadata, match_metadata, detect_device, etc.)
 - [ ] Plugin manager: discovery via entry_points
 - [ ] Refactor EPUB format as built-in plugin
-- [ ] Refactor Open Library as built-in plugin
+- [ ] Refactor Open Library + Google Books as built-in plugins
 - [ ] `bookery plugins` command
 - [ ] `prepare_for_device` hook (kepub conversion path)
 
-## Phase 6: Kobo Device Integration
-- [ ] Kobo detection (scan /Volumes, verify .kobo/ directory)
-- [ ] `bookery send <query>` — copy books to device
-- [ ] `bookery device ls` — list books on device
-- [ ] `bookery device rm <query>` — remove from device
-- [ ] Device sync tracking (device_syncs table)
-- [ ] Free space reporting, --dry-run
-- [ ] Test against real Kobo hardware
-
-## Phase 7: Polish
-- [ ] Cover extraction + cache (~/.config/bookery/covers/)
-- [ ] Progress bars (Rich) for import and send
-- [ ] Pydantic config model (YAML, env var, CLI flag layering)
-- [ ] `bookery verify` — scan for missing/moved/changed files
+## Phase 10: Polish
+- [x] Progress bars (Rich) for import and sync
+- [x] `bookery verify` — scan for missing/moved/changed files
+- [x] `bookery prune` — remove catalog rows with missing files
+- [x] Test guardrail: tests can no longer touch real `~/.bookery`
+- [ ] Cover extraction + cache (`~/.config/bookery/covers/`)
+- [ ] Pydantic config model (TOML + env var + CLI flag layering)
 - [ ] Performance benchmarks (search, import rate)
 - [ ] E2e test suite covering full user flows


### PR DESCRIPTION
## Summary

Bring the README and roadmap into line with what actually shipped in 2026.4.x / 2026.5.x. The Features list, Commands tables, Status line, and roadmap were significantly out of date.

## README changes

- **Status line** no longer claims device sync is "on the roadmap" — Kobo sync has shipped. Plugin architecture is now the only major item still pending.
- **Features list** adds:
  - Web UI (\`bookery serve\`) — entire 2026.5.x web buildout
  - Multi-provider metadata matching (Open Library + Google Books consensus)
  - Per-field provenance & locking
  - Genre management (\`bookery genre\`)
  - Obsidian vault-export
- **Commands tables** add: \`add\`, \`prune\`, \`folder\`, the entire \`genre\` subcommand group, and \`serve\` (with a dedicated Web UI section).
- **Bottom Roadmap** re-ordered so completed phases (PDF conversion, Kobo, vault-export, web UI) are struck through and Plugin Architecture is the next item.

## docs/roadmap.md changes

- Phase 4 (Query + Browse) — checked off the items that actually shipped (FTS5, \`ls\` filters, \`info\`, \`tag\` CRUD, Rich output) and left the query DSL parser and CLI \`edit\` as pending.
- New phases 5-8 reflect 2026.4-2026.5 work: Multi-Provider Metadata, Kobo Device Sync, Web UI, Vault-Export.
- Phase 9 (Plugins) is now the active "Next".
- Phase 10 (Polish) checks off Rich progress bars, \`verify\`, \`prune\`, and the test isolation guardrail.

## Test plan

- [x] \`uv run bookery --help\` — verified every CLI command listed in README's tables actually exists
- [x] Spot-checked subcommand help text for \`serve\`, \`add\`, \`prune\`, \`folder\`, \`genre\` against README descriptions
- [x] Markdown still renders cleanly (no broken links or table rows)