### PR TITLE
Add #180: Kobo read-status pull infrastructure (P1a)

### DIFF
--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -790,9 +790,7 @@ class LibraryCatalog:
 
     # --- Device / read-status (SCHEMA_V8) -------------------------------
 
-    def upsert_device(
-        self, *, kind: str, serial: str, label: str | None, now: str
-    ) -> int:
+    def upsert_device(self, *, kind: str, serial: str, label: str | None, now: str) -> int:
         """Insert or refresh a device row; return its id.
 
         Devices are uniquely identified by (kind, serial). On re-sync we
@@ -838,13 +836,10 @@ class LibraryCatalog:
         )
         self._conn.commit()
 
-    def resolve_book_id_for_remote_path(
-        self, *, device_id: int, remote_path: str
-    ) -> int | None:
+    def resolve_book_id_for_remote_path(self, *, device_id: int, remote_path: str) -> int | None:
         """Look up the catalog book id we wrote to `remote_path` on this device."""
         row = self._conn.execute(
-            "SELECT book_id FROM device_files "
-            "WHERE device_id = ? AND remote_path = ?",
+            "SELECT book_id FROM device_files WHERE device_id = ? AND remote_path = ?",
             (device_id, remote_path),
         ).fetchone()
         return int(row["book_id"]) if row is not None else None
@@ -890,9 +885,7 @@ class LibraryCatalog:
         )
         self._conn.commit()
 
-    def seed_book_status_if_absent(
-        self, *, book_id: int, status: int, updated_at: str
-    ) -> None:
+    def seed_book_status_if_absent(self, *, book_id: int, status: int, updated_at: str) -> None:
         """Insert book_status only if no row exists for this book.
 
         The pull seeds the catalog-side mirror from device state, but P1b lets

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -787,3 +787,125 @@ class LibraryCatalog:
             subjects = json.loads(row[2]) if row[2] else []
             results.append((row[0], row[1], subjects))
         return results
+
+    # --- Device / read-status (SCHEMA_V8) -------------------------------
+
+    def upsert_device(
+        self, *, kind: str, serial: str, label: str | None, now: str
+    ) -> int:
+        """Insert or refresh a device row; return its id.
+
+        Devices are uniquely identified by (kind, serial). On re-sync we
+        update `label` and `last_seen_at` but preserve the id so foreign keys
+        in device_read_state and device_files stay stable.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO devices (kind, serial, label, last_seen_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(kind, serial) DO UPDATE SET
+                label = excluded.label,
+                last_seen_at = excluded.last_seen_at
+            """,
+            (kind, serial, label, now),
+        )
+        self._conn.commit()
+        row = self._conn.execute(
+            "SELECT id FROM devices WHERE kind = ? AND serial = ?",
+            (kind, serial),
+        ).fetchone()
+        assert row is not None
+        return int(row["id"])
+
+    def upsert_device_file(
+        self, *, device_id: int, book_id: int, remote_path: str, now: str
+    ) -> None:
+        """Record the on-device path for a book copied during sync.
+
+        Replaces `remote_path` on conflict so the resolver always points at
+        the current file — if a book's destination changes (e.g. title edit
+        propagates a new directory), the next sync overwrites cleanly.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO device_files (device_id, book_id, remote_path, written_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(device_id, book_id) DO UPDATE SET
+                remote_path = excluded.remote_path,
+                written_at = excluded.written_at
+            """,
+            (device_id, book_id, remote_path, now),
+        )
+        self._conn.commit()
+
+    def resolve_book_id_for_remote_path(
+        self, *, device_id: int, remote_path: str
+    ) -> int | None:
+        """Look up the catalog book id we wrote to `remote_path` on this device."""
+        row = self._conn.execute(
+            "SELECT book_id FROM device_files "
+            "WHERE device_id = ? AND remote_path = ?",
+            (device_id, remote_path),
+        ).fetchone()
+        return int(row["book_id"]) if row is not None else None
+
+    def upsert_device_read_state(
+        self,
+        *,
+        device_id: int,
+        book_id: int,
+        read_status: int,
+        percent_read: float | None,
+        last_read_at: str | None,
+        last_chapter_id: str | None,
+        status_updated_at: str,
+        pulled_at: str,
+    ) -> None:
+        """Persist the device-side read state pulled from KoboReader.sqlite."""
+        self._conn.execute(
+            """
+            INSERT INTO device_read_state (
+                device_id, book_id, read_status, percent_read,
+                last_read_at, last_chapter_id, status_updated_at, pulled_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(device_id, book_id) DO UPDATE SET
+                read_status = excluded.read_status,
+                percent_read = excluded.percent_read,
+                last_read_at = excluded.last_read_at,
+                last_chapter_id = excluded.last_chapter_id,
+                status_updated_at = excluded.status_updated_at,
+                pulled_at = excluded.pulled_at
+            """,
+            (
+                device_id,
+                book_id,
+                read_status,
+                percent_read,
+                last_read_at,
+                last_chapter_id,
+                status_updated_at,
+                pulled_at,
+            ),
+        )
+        self._conn.commit()
+
+    def seed_book_status_if_absent(
+        self, *, book_id: int, status: int, updated_at: str
+    ) -> None:
+        """Insert book_status only if no row exists for this book.
+
+        The pull seeds the catalog-side mirror from device state, but P1b lets
+        users set status directly via `bookery read/unread/reading`. Once the
+        user has set a value, the pull must never clobber it — hence ON CONFLICT
+        DO NOTHING. Later phases overwrite via a different method.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO book_status (book_id, status, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(book_id) DO NOTHING
+            """,
+            (book_id, status, updated_at),
+        )
+        self._conn.commit()

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -184,6 +184,52 @@ WHERE id IN (
 INSERT INTO schema_version (version) VALUES (7);
 """
 
+# Bidirectional Kobo read-status layout. All four tables land together so
+# P1b (catalog-side status writes) and P2 (device push, merge) are additive.
+# `device_read_state` mirrors what we last pulled from the device; `book_status`
+# is the catalog-side truth that user commands set; `device_files` records the
+# on-device path of each kepub we copy, so the ContentID resolver becomes a
+# direct primary-key lookup instead of recomputing sanitization rules.
+SCHEMA_V8 = """
+CREATE TABLE devices (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind         TEXT NOT NULL,
+    serial       TEXT NOT NULL,
+    label        TEXT,
+    last_seen_at TEXT,
+    UNIQUE (kind, serial)
+);
+
+CREATE TABLE device_read_state (
+    device_id          INTEGER NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    book_id            INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    read_status        INTEGER NOT NULL,
+    percent_read       REAL,
+    last_read_at       TEXT,
+    last_chapter_id    TEXT,
+    status_updated_at  TEXT NOT NULL,
+    pulled_at          TEXT NOT NULL,
+    PRIMARY KEY (device_id, book_id)
+);
+
+CREATE TABLE book_status (
+    book_id     INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,
+    status      INTEGER NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE TABLE device_files (
+    device_id   INTEGER NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    book_id     INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    remote_path TEXT NOT NULL,
+    written_at  TEXT NOT NULL,
+    PRIMARY KEY (device_id, book_id)
+);
+CREATE INDEX idx_device_files_path ON device_files(device_id, remote_path);
+
+INSERT INTO schema_version (version) VALUES (8);
+"""
+
 MIGRATIONS = [
     (2, SCHEMA_V2),
     (3, SCHEMA_V3),
@@ -191,4 +237,5 @@ MIGRATIONS = [
     (5, SCHEMA_V5),
     (6, SCHEMA_V6),
     (7, SCHEMA_V7),
+    (8, SCHEMA_V8),
 ]

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -2,7 +2,9 @@
 # ABOUTME: The library stays canonical EPUB; kepubify runs only inside this module.
 
 import contextlib
+import datetime as _dt
 import getpass
+import logging
 import platform
 import shutil
 from collections.abc import Callable, Iterable
@@ -13,8 +15,15 @@ from typing import Protocol
 from bookery.core.pathformat import sanitize_component
 from bookery.db.hashing import compute_file_hash
 from bookery.db.mapping import BookRecord
+from bookery.device.kobo_reader import pull_read_state, read_kobo_serial
 
 KOBO_MARKER = ".kobo"
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now().replace(microsecond=0).isoformat()
 
 
 def _default_mount_roots() -> list[Path]:
@@ -67,10 +76,41 @@ class SyncReport:
     copied: list[Path] = field(default_factory=list)
     skipped: list[tuple[Path, str]] = field(default_factory=list)
     failed: list[tuple[Path, str]] = field(default_factory=list)
+    read_states_pulled: int = 0
+    read_states_skipped: int = 0
 
 
 class _CatalogProto(Protocol):
     def list_all(self) -> list[BookRecord]: ...
+
+    def upsert_device(
+        self, *, kind: str, serial: str, label: str | None, now: str
+    ) -> int: ...
+
+    def upsert_device_file(
+        self, *, device_id: int, book_id: int, remote_path: str, now: str
+    ) -> None: ...
+
+    def resolve_book_id_for_remote_path(
+        self, *, device_id: int, remote_path: str
+    ) -> int | None: ...
+
+    def upsert_device_read_state(
+        self,
+        *,
+        device_id: int,
+        book_id: int,
+        read_status: int,
+        percent_read: float | None,
+        last_read_at: str | None,
+        last_chapter_id: str | None,
+        status_updated_at: str,
+        pulled_at: str,
+    ) -> None: ...
+
+    def seed_book_status_if_absent(
+        self, *, book_id: int, status: int, updated_at: str
+    ) -> None: ...
 
 
 class _CacheProto(Protocol):
@@ -109,6 +149,9 @@ def _sync_record(
     run_kepubify: Callable[..., Path],
     workspace: Path,
     report: SyncReport,
+    catalog: _CatalogProto,
+    device_id: int | None,
+    now: str,
     on_stage: StageCallback | None = None,
 ) -> None:
     def stage(name: str) -> None:
@@ -169,6 +212,10 @@ def _sync_record(
     cache.put(source_hash, version, kepub_sha, dest)
     stage("done")
     report.copied.append(dest)
+    if device_id is not None:
+        catalog.upsert_device_file(
+            device_id=device_id, book_id=record.id, remote_path=str(dest), now=now
+        )
 
 
 def sync_library_to_kobo(
@@ -220,6 +267,32 @@ def sync_library_to_kobo(
 
     version = kepubify_version()
     workspace_dir.mkdir(parents=True, exist_ok=True)
+    now = _now_iso()
+
+    # Device identity + read-state pull happen before the kepub loop so the
+    # device DB is read in a clean (pre-write) window. Both steps are
+    # best-effort — a missing `.kobo/version` or unreadable KoboReader.sqlite
+    # logs a warning but never aborts the kepub copy half of the sync.
+    device_id: int | None = None
+    try:
+        serial = read_kobo_serial(target)
+    except FileNotFoundError:
+        logger.warning(
+            "%s/.kobo/version not found; skipping device-state pull",
+            target,
+        )
+    else:
+        device_id = catalog.upsert_device(
+            kind="kobo", serial=serial, label=None, now=now
+        )
+        try:
+            pulled, skipped = pull_read_state(
+                catalog, device_id=device_id, mount_path=target, now=now
+            )
+            report.read_states_pulled = pulled
+            report.read_states_skipped = skipped
+        except Exception as exc:
+            logger.warning("Read-state pull failed; continuing with copy: %s", exc)
 
     try:
         for idx, record in enumerate(records, 1):
@@ -234,6 +307,9 @@ def sync_library_to_kobo(
                 run_kepubify=run_kepubify,
                 workspace=workspace_dir,
                 report=report,
+                catalog=catalog,
+                device_id=device_id,
+                now=now,
                 on_stage=on_stage,
             )
     finally:

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -23,7 +23,23 @@ logger = logging.getLogger(__name__)
 
 
 def _now_iso() -> str:
-    return _dt.datetime.now().replace(microsecond=0).isoformat()
+    # UTC to match SQLite's `strftime('%Y-%m-%dT%H:%M:%S', 'now')` used
+    # elsewhere in the catalog — keeps merge timestamps comparable.
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0, tzinfo=None).isoformat()
+
+
+# The Kobo mounts its internal storage at `/mnt/onboard` from its own
+# perspective; the host sees the same root as the user-chosen `target` mount.
+# ContentID in KoboReader.sqlite is always written from the device's view, so
+# device_files must record paths in that same coordinate system — otherwise
+# the resolver's PK lookup misses every real-world row.
+KOBO_DEVICE_ROOT = "/mnt/onboard"
+
+
+def _to_device_path(host_path: Path, target: Path) -> str:
+    """Translate a host-side absolute path into the Kobo's `/mnt/onboard/...` form."""
+    relative = host_path.relative_to(target)
+    return f"{KOBO_DEVICE_ROOT}/{relative.as_posix()}"
 
 
 def _default_mount_roots() -> list[Path]:
@@ -53,9 +69,7 @@ def _scan_roots(roots: Iterable[Path]) -> list[Path]:
     return candidates
 
 
-def detect_mounted_kobo(
-    *, candidates: Iterable[Path] | None = None
-) -> Path | None:
+def detect_mounted_kobo(*, candidates: Iterable[Path] | None = None) -> Path | None:
     """Return the first mount path that contains a `.kobo/` marker, else None.
 
     When `candidates` is None, scans platform-default mount roots (e.g.
@@ -83,9 +97,7 @@ class SyncReport:
 class _CatalogProto(Protocol):
     def list_all(self) -> list[BookRecord]: ...
 
-    def upsert_device(
-        self, *, kind: str, serial: str, label: str | None, now: str
-    ) -> int: ...
+    def upsert_device(self, *, kind: str, serial: str, label: str | None, now: str) -> int: ...
 
     def upsert_device_file(
         self, *, device_id: int, book_id: int, remote_path: str, now: str
@@ -130,9 +142,7 @@ StageCallback = Callable[[str], None]
 
 
 def _book_dest_dir(target: Path, books_subdir: str, record: BookRecord) -> Path:
-    author_raw = (
-        record.metadata.authors[0] if record.metadata.authors else "Unknown Author"
-    )
+    author_raw = record.metadata.authors[0] if record.metadata.authors else "Unknown Author"
     title_raw = record.metadata.title or "Untitled"
     author = sanitize_component(author_raw, fallback="Unknown Author")
     title = sanitize_component(title_raw, fallback="Untitled")
@@ -160,9 +170,7 @@ def _sync_record(
 
     source = record.output_path
     if source is None:
-        report.skipped.append(
-            (record.source_path, "no canonical EPUB in library")
-        )
+        report.skipped.append((record.source_path, "no canonical EPUB in library"))
         return
     if source.suffix.lower() != ".epub":
         report.skipped.append((source, "output is not an EPUB"))
@@ -214,7 +222,10 @@ def _sync_record(
     report.copied.append(dest)
     if device_id is not None:
         catalog.upsert_device_file(
-            device_id=device_id, book_id=record.id, remote_path=str(dest), now=now
+            device_id=device_id,
+            book_id=record.id,
+            remote_path=_to_device_path(dest, target),
+            now=now,
         )
 
 
@@ -253,9 +264,7 @@ def sync_library_to_kobo(
                 on_progress(idx, total, record)
             source = record.output_path
             if source is None:
-                report.skipped.append(
-                    (record.source_path, "no canonical EPUB in library")
-                )
+                report.skipped.append((record.source_path, "no canonical EPUB in library"))
                 continue
             if source.suffix.lower() != ".epub":
                 report.skipped.append((source, "output is not an EPUB"))
@@ -282,9 +291,7 @@ def sync_library_to_kobo(
             target,
         )
     else:
-        device_id = catalog.upsert_device(
-            kind="kobo", serial=serial, label=None, now=now
-        )
+        device_id = catalog.upsert_device(kind="kobo", serial=serial, label=None, now=now)
         try:
             pulled, skipped = pull_read_state(
                 catalog, device_id=device_id, mount_path=target, now=now

--- a/src/bookery/device/kobo_reader.py
+++ b/src/bookery/device/kobo_reader.py
@@ -1,0 +1,195 @@
+# ABOUTME: Read-only access to a mounted Kobo's KoboReader.sqlite — pulls read
+# ABOUTME: status into the bookery catalog. No device writes happen here.
+#
+# Verification reference: Kobo Libra Colour family (device prefix N428440071799),
+# firmware 4.45.23684, 2026-05-26. Schema fields and connection URI flags below
+# were validated against a real device with 1146 sideloaded books.
+
+import logging
+import sqlite3
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KoboContentRow:
+    """One row from the device `content` table — a top-level book record."""
+
+    content_id: str
+    read_status: int  # 0 unread, 1 reading, 2 finished
+    percent_read: float | None
+    date_last_read: str | None
+    chapter_id_bookmarked: str | None
+    mime_type: str
+
+
+def open_kobo_db(kobo_sqlite_path: Path) -> sqlite3.Connection:
+    """Open KoboReader.sqlite read-only with `immutable=1`.
+
+    Plain ``?mode=ro`` fails on a USB-mounted Kobo with "unable to open
+    database file" because SQLite still tries to open a rollback journal for
+    crash recovery — which needs write access the mount won't grant.
+    ``immutable=1`` declares the file unchanging during the read window, so
+    SQLite skips the journal entirely. This is the single most important
+    detail in the whole reader module.
+    """
+    uri = f"file:{kobo_sqlite_path}?mode=ro&immutable=1"
+    return sqlite3.connect(uri, uri=True)
+
+
+def read_content_rows(conn: sqlite3.Connection) -> list[KoboContentRow]:
+    """Return top-level book rows (chapter rows excluded) with EPUB/kepub mime.
+
+    ``BookID IS NULL`` filters out the chapter rows that Kobo nests under each
+    book; ``MimeType LIKE 'application/%epub%'`` catches both the common kepub
+    (``application/x-kobo-epub+zip``) and raw EPUB (``application/epub+zip``)
+    sideloads, while excluding PDFs and store-only content.
+    """
+    cursor = conn.execute(
+        """
+        SELECT ContentID,
+               ReadStatus,
+               ___PercentRead,
+               DateLastRead,
+               ChapterIDBookmarked,
+               MimeType
+        FROM content
+        WHERE BookID IS NULL
+          AND MimeType LIKE 'application/%epub%'
+        """
+    )
+    return [
+        KoboContentRow(
+            content_id=row[0],
+            read_status=int(row[1] or 0),
+            percent_read=float(row[2]) if row[2] is not None else None,
+            date_last_read=row[3],
+            chapter_id_bookmarked=row[4],
+            mime_type=row[5],
+        )
+        for row in cursor.fetchall()
+    ]
+
+
+def _normalize_content_id(content_id: str) -> str:
+    """Strip a ``file://`` scheme and URL-decode percent escapes.
+
+    Kobo Libra Colour firmware 4.45.23684 stores ContentID *un*encoded, but
+    older firmwares may URL-encode spaces and punctuation. ``unquote`` is a
+    safe no-op when there's nothing to decode, so we always run it. Non-file
+    schemes (newsstand, store) pass through untouched — callers decide whether
+    to filter them.
+    """
+    if content_id.startswith("file://"):
+        path = content_id[len("file://") :]
+        return urllib.parse.unquote(path)
+    return content_id
+
+
+def read_kobo_serial(mount_path: Path) -> str:
+    """Read the device serial from ``<mount>/.kobo/version``.
+
+    The version file is a comma-separated list whose first field is the
+    serial-like device identifier (e.g. ``N428440071799``). If the file
+    contains no comma, return the whole stripped content — useful for older
+    devices or alternate firmwares where the format differs.
+    """
+    version_file = mount_path / ".kobo" / "version"
+    text = version_file.read_text().strip()
+    first, sep, _ = text.partition(",")
+    return first if sep else text
+
+
+class _ReaderCatalogProto(Protocol):
+    def resolve_book_id_for_remote_path(
+        self, *, device_id: int, remote_path: str
+    ) -> int | None: ...
+
+    def upsert_device_read_state(
+        self,
+        *,
+        device_id: int,
+        book_id: int,
+        read_status: int,
+        percent_read: float | None,
+        last_read_at: str | None,
+        last_chapter_id: str | None,
+        status_updated_at: str,
+        pulled_at: str,
+    ) -> None: ...
+
+    def seed_book_status_if_absent(
+        self, *, book_id: int, status: int, updated_at: str
+    ) -> None: ...
+
+
+def pull_read_state(
+    catalog: _ReaderCatalogProto,
+    *,
+    device_id: int,
+    mount_path: Path,
+    now: str,
+) -> tuple[int, int]:
+    """Pull read-state rows from the device and merge into the catalog.
+
+    Returns ``(pulled, skipped)`` — the number of rows whose ContentID
+    resolved to a known book in our catalog, and the number that didn't
+    (and were therefore ignored).
+
+    Best-effort: a missing or unreadable KoboReader.sqlite logs a warning and
+    returns ``(0, 0)`` rather than raising — a Kobo with no read history yet
+    or a transient mount issue must not fail the kepub-copy half of a sync.
+    """
+    db_path = mount_path / ".kobo" / "KoboReader.sqlite"
+    if not db_path.exists():
+        logger.warning("KoboReader.sqlite not found at %s; skipping read-state pull", db_path)
+        return (0, 0)
+
+    try:
+        conn = open_kobo_db(db_path)
+    except sqlite3.Error as exc:
+        logger.warning("Could not open KoboReader.sqlite at %s: %s", db_path, exc)
+        return (0, 0)
+
+    try:
+        rows = read_content_rows(conn)
+    except sqlite3.Error as exc:
+        logger.warning("Could not read content rows from %s: %s", db_path, exc)
+        return (0, 0)
+    finally:
+        conn.close()
+
+    pulled = 0
+    skipped = 0
+    for row in rows:
+        remote_path = _normalize_content_id(row.content_id)
+        book_id = catalog.resolve_book_id_for_remote_path(
+            device_id=device_id, remote_path=remote_path
+        )
+        if book_id is None:
+            skipped += 1
+            continue
+        # status_updated_at falls back to `now` when the device has never
+        # recorded a DateLastRead (an unread book that's been on-device since
+        # before tracking started). The merge logic in P2 keys on this field,
+        # so it must always be a real ISO timestamp.
+        status_updated_at = row.date_last_read or now
+        catalog.upsert_device_read_state(
+            device_id=device_id,
+            book_id=book_id,
+            read_status=row.read_status,
+            percent_read=row.percent_read,
+            last_read_at=row.date_last_read,
+            last_chapter_id=row.chapter_id_bookmarked,
+            status_updated_at=status_updated_at,
+            pulled_at=now,
+        )
+        catalog.seed_book_status_if_absent(
+            book_id=book_id, status=row.read_status, updated_at=status_updated_at
+        )
+        pulled += 1
+    return (pulled, skipped)

--- a/tests/integration/test_catalog_path_truth.py
+++ b/tests/integration/test_catalog_path_truth.py
@@ -170,7 +170,7 @@ class TestMatchedSignal:
         db_path = tmp_path / "fresh.db"
         conn = open_library(db_path)
         try:
-            assert _get_schema_version(conn) == 7
+            assert _get_schema_version(conn) == 8
             cursor = conn.execute("PRAGMA table_info(books)")
             cols = {row["name"] for row in cursor.fetchall()}
             assert "metadata_matched_at" in cols
@@ -284,7 +284,7 @@ class TestMatchedSignal:
         # Reopen to trigger V7 migration
         conn = open_library(db_path)
         try:
-            assert _get_schema_version(conn) == 7
+            assert _get_schema_version(conn) == 8
             rows = conn.execute(
                 "SELECT title, metadata_matched_at FROM books ORDER BY title"
             ).fetchall()

--- a/tests/integration/test_migration_lifecycle.py
+++ b/tests/integration/test_migration_lifecycle.py
@@ -30,7 +30,7 @@ class TestMigrationLifecycle:
 
         # Step 2: Open with bookery to trigger migration
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 7
+        assert _get_schema_version(conn) == 8
 
         # Step 3: Verify the book survived and tags work
         catalog = LibraryCatalog(conn)
@@ -51,7 +51,7 @@ class TestMigrationLifecycle:
         # Open 3 times
         for _ in range(3):
             conn = open_library(db_path)
-            assert _get_schema_version(conn) == 7
+            assert _get_schema_version(conn) == 8
             conn.close()
 
         # Final open — add a book and tag it

--- a/tests/integration/test_sync_kobo_read_status.py
+++ b/tests/integration/test_sync_kobo_read_status.py
@@ -96,16 +96,19 @@ def test_round_trip_sync_populates_read_state_and_book_status(tmp_path: Path) ->
     # --- Mount + seeded device DB ---
     mount = _build_fake_kobo_mount(tmp_path)
     kobo_db = mount / ".kobo" / "KoboReader.sqlite"
-    # First seed: the ContentIDs are what the device "expects" to find — we
-    # know what paths the sync will create because they follow the
-    # sanitize_component rules for "Asimov"/"Foundation" etc.
+    # The device records ContentID from its own filesystem view, rooted at
+    # /mnt/onboard. The host writes to the mount path. The resolver translates
+    # between the two — these test ContentIDs are written in the device form
+    # to prove the round-trip works against realistic device data.
     expected_a = mount / "Books" / "Asimov" / "Foundation" / "Foundation.kepub.epub"
     expected_b = mount / "Books" / "Le Guin" / "Earthsea" / "Earthsea.kepub.epub"
+    content_id_a = "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub"
+    content_id_b = "file:///mnt/onboard/Books/Le Guin/Earthsea/Earthsea.kepub.epub"
     _seed_kobo_db(
         kobo_db,
         [
             (
-                f"file://{expected_a}",
+                content_id_a,
                 None,
                 2,
                 1.0,
@@ -114,7 +117,7 @@ def test_round_trip_sync_populates_read_state_and_book_status(tmp_path: Path) ->
                 "application/x-kobo-epub+zip",
             ),
             (
-                f"file://{expected_b}",
+                content_id_b,
                 None,
                 1,
                 0.42,
@@ -148,12 +151,16 @@ def test_round_trip_sync_populates_read_state_and_book_status(tmp_path: Path) ->
     assert report.read_states_pulled == 0
     assert report.read_states_skipped == 2
 
-    # device_files written for both books.
+    # device_files written for both books, in the device-side coordinate
+    # system that matches Kobo's ContentID format.
     rows = conn.execute(
         "SELECT book_id, remote_path FROM device_files ORDER BY book_id"
     ).fetchall()
     paths_by_book = {row["book_id"]: row["remote_path"] for row in rows}
-    assert paths_by_book == {book_a: str(expected_a), book_b: str(expected_b)}
+    assert paths_by_book == {
+        book_a: "/mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+        book_b: "/mnt/onboard/Books/Le Guin/Earthsea/Earthsea.kepub.epub",
+    }
 
     # Devices row was upserted with the seeded serial.
     dev = conn.execute("SELECT kind, serial FROM devices").fetchone()
@@ -233,9 +240,10 @@ def test_regression_sync_still_works_when_kobo_db_missing(tmp_path: Path) -> Non
     assert report.copied == [expected]
     assert report.read_states_pulled == 0
     assert report.read_states_skipped == 0
-    # device_files still written so a future pull can resolve this book.
+    # device_files records the device-side path, not the host mount path.
     row = conn.execute(
-        "SELECT book_id FROM device_files WHERE remote_path = ?", (str(expected),)
+        "SELECT book_id FROM device_files WHERE remote_path = ?",
+        ("/mnt/onboard/Books/A/T/T.kepub.epub",),
     ).fetchone()
     assert row["book_id"] == book_id
     conn.close()

--- a/tests/integration/test_sync_kobo_read_status.py
+++ b/tests/integration/test_sync_kobo_read_status.py
@@ -1,0 +1,241 @@
+# ABOUTME: Integration test for the P1a Kobo read-status pull — runs a real sync
+# ABOUTME: against a fixture KoboReader.sqlite and the real LibraryCatalog.
+
+import sqlite3
+from pathlib import Path
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kobo import sync_library_to_kobo
+from bookery.metadata.types import BookMetadata
+
+
+class _StubKepubify:
+    """Cheap kepubify replacement — writes a fake byte payload, no subprocess."""
+
+    def __init__(self) -> None:
+        self.version = "v4.4.0"
+
+    def run(self, epub: Path, *, out_dir: Path) -> Path:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = out_dir / f"{epub.stem}.kepub.epub"
+        result.write_bytes(b"FAKE-KEPUB")
+        return result
+
+    def get_version(self) -> str:
+        return self.version
+
+
+def _build_fake_kobo_mount(root: Path) -> Path:
+    mount = root / "kobo"
+    kobo_dir = mount / ".kobo"
+    kobo_dir.mkdir(parents=True)
+    (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
+    return mount
+
+
+def _seed_kobo_db(path: Path, rows: list[tuple]) -> None:
+    """Build a KoboReader.sqlite with the minimal `content` schema P1a queries.
+
+    Each row is (ContentID, BookID, ReadStatus, ___PercentRead, DateLastRead,
+    ChapterIDBookmarked, MimeType).
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE content (
+            ContentID            TEXT PRIMARY KEY,
+            BookID               TEXT,
+            ReadStatus           INTEGER,
+            ___PercentRead       REAL,
+            DateLastRead         TEXT,
+            ChapterIDBookmarked  TEXT,
+            MimeType             TEXT
+        )
+        """
+    )
+    conn.executemany("INSERT INTO content VALUES (?, ?, ?, ?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.close()
+
+
+def test_round_trip_sync_populates_read_state_and_book_status(tmp_path: Path) -> None:
+    """End-to-end: a sync writes device_files, then a re-sync reads back state.
+
+    Strategy B (record what we wrote) means the resolver isn't usable until the
+    *first* sync writes device_files rows. So this test runs the sync twice:
+    1. First sync: copies kepubs, writes device_files. read_states_skipped == N
+       because the seeded KoboReader.sqlite predates the device_files rows.
+    2. Re-seed KoboReader.sqlite so its ContentIDs now point at the paths
+       written in step 1, then re-sync. Now resolver finds every row.
+    """
+    # --- Catalog with two real books in the library ---
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub_a = library / "Asimov" / "Foundation" / "Foundation.epub"
+    epub_b = library / "Le Guin" / "Earthsea" / "Earthsea.epub"
+    for path in (epub_a, epub_b):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"EPUB")
+
+    book_a = catalog.add_book(
+        BookMetadata(title="Foundation", authors=["Asimov"], source_path=epub_a),
+        file_hash="hash-a",
+        output_path=epub_a,
+    )
+    book_b = catalog.add_book(
+        BookMetadata(title="Earthsea", authors=["Le Guin"], source_path=epub_b),
+        file_hash="hash-b",
+        output_path=epub_b,
+    )
+
+    # --- Mount + seeded device DB ---
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    # First seed: the ContentIDs are what the device "expects" to find — we
+    # know what paths the sync will create because they follow the
+    # sanitize_component rules for "Asimov"/"Foundation" etc.
+    expected_a = mount / "Books" / "Asimov" / "Foundation" / "Foundation.kepub.epub"
+    expected_b = mount / "Books" / "Le Guin" / "Earthsea" / "Earthsea.kepub.epub"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                f"file://{expected_a}",
+                None,
+                2,
+                1.0,
+                "2026-05-20T10:00:00",
+                None,
+                "application/x-kobo-epub+zip",
+            ),
+            (
+                f"file://{expected_b}",
+                None,
+                1,
+                0.42,
+                "2026-05-21T11:00:00",
+                "OEBPS/ch3.xhtml",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+
+    # --- Sync ---
+    cache = KepubCache(tmp_path / "kepub.db")
+    kepubify = _StubKepubify()
+
+    # We need a list_all on the catalog — LibraryCatalog already has it.
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=cache,
+        run_kepubify=kepubify.run,
+        kepubify_version=kepubify.get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+    )
+
+    # --- Assertions ---
+    assert set(report.copied) == {expected_a, expected_b}
+    # On the FIRST sync the pull runs BEFORE the copy, so device_files is
+    # still empty when the resolver looks up these ContentIDs — both rows
+    # count as skipped. This is the documented behaviour (Strategy B).
+    assert report.read_states_pulled == 0
+    assert report.read_states_skipped == 2
+
+    # device_files written for both books.
+    rows = conn.execute(
+        "SELECT book_id, remote_path FROM device_files ORDER BY book_id"
+    ).fetchall()
+    paths_by_book = {row["book_id"]: row["remote_path"] for row in rows}
+    assert paths_by_book == {book_a: str(expected_a), book_b: str(expected_b)}
+
+    # Devices row was upserted with the seeded serial.
+    dev = conn.execute("SELECT kind, serial FROM devices").fetchone()
+    assert dev["kind"] == "kobo"
+    assert dev["serial"] == "N428440071799"
+
+    # --- Second sync: now the resolver knows the paths. ---
+    report2 = sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=cache,
+        run_kepubify=kepubify.run,
+        kepubify_version=kepubify.get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+    )
+    assert report2.read_states_pulled == 2
+    assert report2.read_states_skipped == 0
+
+    # device_read_state has both rows with the device-side values intact.
+    states = {
+        row["book_id"]: row
+        for row in conn.execute(
+            "SELECT book_id, read_status, percent_read, last_read_at, last_chapter_id "
+            "FROM device_read_state"
+        ).fetchall()
+    }
+    assert states[book_a]["read_status"] == 2
+    assert states[book_a]["percent_read"] == 1.0
+    assert states[book_a]["last_read_at"] == "2026-05-20T10:00:00"
+    assert states[book_b]["read_status"] == 1
+    assert states[book_b]["percent_read"] == 0.42
+    assert states[book_b]["last_chapter_id"] == "OEBPS/ch3.xhtml"
+
+    # book_status mirror seeded.
+    statuses = {
+        row["book_id"]: row["status"]
+        for row in conn.execute("SELECT book_id, status FROM book_status").fetchall()
+    }
+    assert statuses == {book_a: 2, book_b: 1}
+
+    conn.close()
+
+
+def test_regression_sync_still_works_when_kobo_db_missing(tmp_path: Path) -> None:
+    """Existing kepub-copy path must keep working when KoboReader.sqlite is absent."""
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub = library / "A" / "T" / "T.epub"
+    epub.parent.mkdir(parents=True, exist_ok=True)
+    epub.write_bytes(b"EPUB")
+    book_id = catalog.add_book(
+        BookMetadata(title="T", authors=["A"], source_path=epub),
+        file_hash="hash-t",
+        output_path=epub,
+    )
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    # NOTE: .kobo/version exists but KoboReader.sqlite does NOT.
+
+    cache = KepubCache(tmp_path / "kepub.db")
+    kepubify = _StubKepubify()
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=cache,
+        run_kepubify=kepubify.run,
+        kepubify_version=kepubify.get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+    )
+
+    expected = mount / "Books" / "A" / "T" / "T.kepub.epub"
+    assert report.copied == [expected]
+    assert report.read_states_pulled == 0
+    assert report.read_states_skipped == 0
+    # device_files still written so a future pull can resolve this book.
+    row = conn.execute(
+        "SELECT book_id FROM device_files WHERE remote_path = ?", (str(expected),)
+    ).fetchone()
+    assert row["book_id"] == book_id
+    conn.close()

--- a/tests/unit/test_catalog_devices.py
+++ b/tests/unit/test_catalog_devices.py
@@ -1,0 +1,235 @@
+# ABOUTME: Unit tests for the device/read-status catalog methods added in SCHEMA_V8.
+# ABOUTME: Covers upsert_device, upsert_device_file, resolve_book_id_for_remote_path,
+# ABOUTME: upsert_device_read_state, seed_book_status_if_absent.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> LibraryCatalog:
+    conn = open_library(tmp_path / "test.db")
+    return LibraryCatalog(conn)
+
+
+def _add_book(catalog: LibraryCatalog, title: str = "T", author: str = "A") -> int:
+    md = BookMetadata(
+        title=title,
+        authors=[author],
+        source_path=Path(f"/tmp/{title}-{author}.epub"),
+    )
+    return catalog.add_book(md, file_hash=f"hash-{title}-{author}")
+
+
+class TestUpsertDevice:
+    def test_insert_returns_new_id(self, catalog: LibraryCatalog) -> None:
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        assert isinstance(device_id, int)
+        assert device_id > 0
+
+    def test_second_insert_same_serial_returns_same_id(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        first = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        second = catalog.upsert_device(
+            kind="kobo", serial="N1", label="Bedside Kobo", now="2026-05-26T09:00:00"
+        )
+        assert first == second
+
+    def test_second_insert_updates_last_seen_at_and_label(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        catalog.upsert_device(
+            kind="kobo", serial="N1", label="Bedside Kobo", now="2026-05-26T09:00:00"
+        )
+        row = catalog._conn.execute(
+            "SELECT label, last_seen_at FROM devices WHERE kind = ? AND serial = ?",
+            ("kobo", "N1"),
+        ).fetchone()
+        assert row["label"] == "Bedside Kobo"
+        assert row["last_seen_at"] == "2026-05-26T09:00:00"
+
+    def test_different_serial_gets_different_id(self, catalog: LibraryCatalog) -> None:
+        first = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        second = catalog.upsert_device(
+            kind="kobo", serial="N2", label=None, now="2026-05-26T08:00:00"
+        )
+        assert first != second
+
+
+class TestUpsertDeviceFile:
+    def test_insert_then_resolve_round_trip(self, catalog: LibraryCatalog) -> None:
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        book_id = _add_book(catalog)
+        path = "/Volumes/KOBOeReader/Bookery/A/T/T.kepub.epub"
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path=path,
+            now="2026-05-26T08:00:00",
+        )
+        assert (
+            catalog.resolve_book_id_for_remote_path(
+                device_id=device_id, remote_path=path
+            )
+            == book_id
+        )
+
+    def test_resolver_returns_none_when_missing(self, catalog: LibraryCatalog) -> None:
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        assert (
+            catalog.resolve_book_id_for_remote_path(
+                device_id=device_id, remote_path="/nowhere"
+            )
+            is None
+        )
+
+    def test_reinsert_is_idempotent_and_updates_written_at(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        book_id = _add_book(catalog)
+        path = "/Volumes/KOBOeReader/Bookery/A/T/T.kepub.epub"
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path=path,
+            now="2026-05-26T08:00:00",
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path=path,
+            now="2026-05-26T09:00:00",
+        )
+        rows = catalog._conn.execute(
+            "SELECT written_at FROM device_files WHERE device_id = ? AND book_id = ?",
+            (device_id, book_id),
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["written_at"] == "2026-05-26T09:00:00"
+
+    def test_reinsert_with_new_path_updates_path(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        # If a book moves on the device (e.g. retitled in catalog), the new path
+        # must overwrite the old — otherwise the resolver would silently miss the
+        # current file.
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        book_id = _add_book(catalog)
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/old/path.kepub.epub",
+            now="2026-05-26T08:00:00",
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/new/path.kepub.epub",
+            now="2026-05-26T09:00:00",
+        )
+        assert (
+            catalog.resolve_book_id_for_remote_path(
+                device_id=device_id, remote_path="/new/path.kepub.epub"
+            )
+            == book_id
+        )
+        assert (
+            catalog.resolve_book_id_for_remote_path(
+                device_id=device_id, remote_path="/old/path.kepub.epub"
+            )
+            is None
+        )
+
+
+class TestUpsertDeviceReadState:
+    def test_insert_then_update_all_fields(self, catalog: LibraryCatalog) -> None:
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        book_id = _add_book(catalog)
+        catalog.upsert_device_read_state(
+            device_id=device_id,
+            book_id=book_id,
+            read_status=1,
+            percent_read=0.25,
+            last_read_at="2026-05-20T10:00:00",
+            last_chapter_id="OEBPS/ch3.xhtml",
+            status_updated_at="2026-05-20T10:00:00",
+            pulled_at="2026-05-26T08:00:00",
+        )
+        catalog.upsert_device_read_state(
+            device_id=device_id,
+            book_id=book_id,
+            read_status=2,
+            percent_read=1.0,
+            last_read_at="2026-05-25T22:00:00",
+            last_chapter_id=None,
+            status_updated_at="2026-05-25T22:00:00",
+            pulled_at="2026-05-26T09:00:00",
+        )
+        row = catalog._conn.execute(
+            "SELECT * FROM device_read_state WHERE device_id = ? AND book_id = ?",
+            (device_id, book_id),
+        ).fetchone()
+        assert row["read_status"] == 2
+        assert row["percent_read"] == 1.0
+        assert row["last_read_at"] == "2026-05-25T22:00:00"
+        assert row["last_chapter_id"] is None
+        assert row["status_updated_at"] == "2026-05-25T22:00:00"
+        assert row["pulled_at"] == "2026-05-26T09:00:00"
+
+
+class TestSeedBookStatusIfAbsent:
+    def test_first_call_inserts(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog)
+        catalog.seed_book_status_if_absent(
+            book_id=book_id, status=1, updated_at="2026-05-26T08:00:00"
+        )
+        row = catalog._conn.execute(
+            "SELECT status, updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        assert row["status"] == 1
+        assert row["updated_at"] == "2026-05-26T08:00:00"
+
+    def test_second_call_does_not_overwrite(self, catalog: LibraryCatalog) -> None:
+        # P1b: `bookery read` sets status via a different path. The pull must
+        # never clobber a user's intentional status change — it only seeds when
+        # the row is absent. ON CONFLICT (book_id) DO NOTHING.
+        book_id = _add_book(catalog)
+        catalog.seed_book_status_if_absent(
+            book_id=book_id, status=2, updated_at="2026-05-26T08:00:00"
+        )
+        catalog.seed_book_status_if_absent(
+            book_id=book_id, status=0, updated_at="2026-05-26T09:00:00"
+        )
+        row = catalog._conn.execute(
+            "SELECT status, updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        assert row["status"] == 2
+        assert row["updated_at"] == "2026-05-26T08:00:00"

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -85,7 +85,7 @@ class TestOpenLibrary:
         row = cursor.fetchone()
         conn.close()
         assert row is not None
-        assert row[0] == 7
+        assert row[0] == 8
 
     def test_creates_indexes(self, db_path: Path) -> None:
         """Expected indexes exist on the books table."""
@@ -135,3 +135,67 @@ class TestOpenLibrary:
         conn = open_library(db_path)
         assert conn.row_factory == sqlite3.Row
         conn.close()
+
+
+class TestSchemaV8DeviceTables:
+    """SCHEMA_V8 lands the bidirectional Kobo read-status layout.
+
+    Pull-side wiring uses devices, device_read_state, device_files; the
+    book_status table is the catalog-side mirror that P1b/P2 will write to.
+    All four tables land at the same time so later phases are additive.
+    """
+
+    def test_creates_devices_table(self, db_path: Path) -> None:
+        conn = open_library(db_path)
+        cursor = conn.execute("PRAGMA table_info(devices)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert columns == {"id", "kind", "serial", "label", "last_seen_at"}
+
+    def test_devices_unique_kind_serial(self, db_path: Path) -> None:
+        conn = open_library(db_path)
+        insert = "INSERT INTO devices (kind, serial, last_seen_at) VALUES (?, ?, ?)"
+        conn.execute(insert, ("kobo", "N1", "2026-01-01"))
+        conn.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(insert, ("kobo", "N1", "2026-01-02"))
+        conn.close()
+
+    def test_creates_device_read_state_table(self, db_path: Path) -> None:
+        conn = open_library(db_path)
+        cursor = conn.execute("PRAGMA table_info(device_read_state)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert columns == {
+            "device_id",
+            "book_id",
+            "read_status",
+            "percent_read",
+            "last_read_at",
+            "last_chapter_id",
+            "status_updated_at",
+            "pulled_at",
+        }
+
+    def test_creates_book_status_table(self, db_path: Path) -> None:
+        conn = open_library(db_path)
+        cursor = conn.execute("PRAGMA table_info(book_status)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert columns == {"book_id", "status", "updated_at"}
+
+    def test_creates_device_files_table(self, db_path: Path) -> None:
+        conn = open_library(db_path)
+        cursor = conn.execute("PRAGMA table_info(device_files)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert columns == {"device_id", "book_id", "remote_path", "written_at"}
+
+    def test_creates_device_files_path_index(self, db_path: Path) -> None:
+        conn = open_library(db_path)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='device_files'"
+        )
+        names = {row[0] for row in cursor.fetchall()}
+        conn.close()
+        assert "idx_device_files_path" in names

--- a/tests/unit/test_device_kobo_reader.py
+++ b/tests/unit/test_device_kobo_reader.py
@@ -1,0 +1,317 @@
+# ABOUTME: Unit tests for the kobo_reader module — opens KoboReader.sqlite read-only,
+# ABOUTME: parses content rows, normalizes ContentID, and reads the device serial.
+
+import logging
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.device.kobo_reader import (
+    KoboContentRow,
+    _normalize_content_id,
+    open_kobo_db,
+    pull_read_state,
+    read_content_rows,
+    read_kobo_serial,
+)
+from bookery.metadata.types import BookMetadata
+
+
+class TestNormalizeContentId:
+    def test_strips_file_scheme(self) -> None:
+        assert (
+            _normalize_content_id("file:///mnt/onboard/Books/Foo.epub")
+            == "/mnt/onboard/Books/Foo.epub"
+        )
+
+    def test_url_decodes_when_encoded(self) -> None:
+        assert (
+            _normalize_content_id("file:///mnt/onboard/Books/My%20Book.epub")
+            == "/mnt/onboard/Books/My Book.epub"
+        )
+
+    def test_noop_when_unencoded(self) -> None:
+        # Kobo Libra Colour firmware 4.45.23684 stores ContentID *un*encoded;
+        # decoding must be a safe no-op when there's nothing to decode.
+        assert (
+            _normalize_content_id(
+                "file:///mnt/onboard/Bookery/Asimov, Isaac/Foundation/Foundation.kepub.epub"
+            )
+            == "/mnt/onboard/Bookery/Asimov, Isaac/Foundation/Foundation.kepub.epub"
+        )
+
+    def test_leaves_non_file_scheme_unchanged(self) -> None:
+        # Some Kobo rows reference non-file content (newsstand, store). Leave
+        # untouched so callers can filter them out themselves.
+        assert _normalize_content_id("http://kobobooks.com/foo") == "http://kobobooks.com/foo"
+
+
+class TestReadKoboSerial:
+    def test_parses_first_comma_separated_field(self, tmp_path: Path) -> None:
+        kobo = tmp_path / ".kobo"
+        kobo.mkdir()
+        (kobo / "version").write_text("N428440071799,4.45.23684,...\n")
+        assert read_kobo_serial(tmp_path) == "N428440071799"
+
+    def test_falls_back_to_full_stripped_content_when_no_comma(
+        self, tmp_path: Path
+    ) -> None:
+        kobo = tmp_path / ".kobo"
+        kobo.mkdir()
+        (kobo / "version").write_text("OPAQUE-SERIAL\n")
+        assert read_kobo_serial(tmp_path) == "OPAQUE-SERIAL"
+
+    def test_raises_when_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            read_kobo_serial(tmp_path)
+
+
+def _create_kobo_db(path: Path) -> None:
+    """Build a minimal KoboReader.sqlite with `content` rows that mirror real fields."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE content (
+            ContentID            TEXT PRIMARY KEY,
+            BookID               TEXT,
+            ReadStatus           INTEGER,
+            ___PercentRead       REAL,
+            DateLastRead         TEXT,
+            ChapterIDBookmarked  TEXT,
+            MimeType             TEXT
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO content VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            # Top-level kepub — should appear.
+            (
+                "file:///mnt/onboard/Bookery/A/T/T.kepub.epub",
+                None,
+                2,
+                1.0,
+                "2026-05-20T10:00:00",
+                None,
+                "application/x-kobo-epub+zip",
+            ),
+            # Top-level raw EPUB — should appear (LIKE 'application/%epub%' catches both).
+            (
+                "file:///mnt/onboard/Bookery/A/T2/T2.epub",
+                None,
+                1,
+                0.42,
+                "2026-05-21T11:00:00",
+                "OEBPS/ch3.xhtml",
+                "application/epub+zip",
+            ),
+            # Chapter row (BookID is set) — should be excluded.
+            (
+                "/mnt/onboard/.../chapter.xhtml",
+                "file:///mnt/onboard/Bookery/A/T/T.kepub.epub",
+                0,
+                None,
+                None,
+                None,
+                "application/xhtml+xml",
+            ),
+            # Non-EPUB MimeType (e.g. PDF sideload) — excluded by WHERE clause.
+            (
+                "file:///mnt/onboard/Bookery/A/T3/T3.pdf",
+                None,
+                0,
+                None,
+                None,
+                None,
+                "application/pdf",
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestOpenAndReadKoboDb:
+    def test_opens_read_only_with_immutable_flag(self, tmp_path: Path) -> None:
+        # The immutable=1 flag is what makes USB-mounted Kobo DBs work — verify
+        # it's actually applied by asserting writes are rejected.
+        db = tmp_path / "KoboReader.sqlite"
+        _create_kobo_db(db)
+        conn = open_kobo_db(db)
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO content (ContentID) VALUES ('x')")
+        conn.close()
+
+    def test_returns_only_top_level_epub_rows(self, tmp_path: Path) -> None:
+        db = tmp_path / "KoboReader.sqlite"
+        _create_kobo_db(db)
+        conn = open_kobo_db(db)
+        try:
+            rows = read_content_rows(conn)
+        finally:
+            conn.close()
+        content_ids = {r.content_id for r in rows}
+        assert content_ids == {
+            "file:///mnt/onboard/Bookery/A/T/T.kepub.epub",
+            "file:///mnt/onboard/Bookery/A/T2/T2.epub",
+        }
+
+    def test_row_fields_round_trip(self, tmp_path: Path) -> None:
+        db = tmp_path / "KoboReader.sqlite"
+        _create_kobo_db(db)
+        conn = open_kobo_db(db)
+        try:
+            rows = read_content_rows(conn)
+        finally:
+            conn.close()
+        by_id = {r.content_id: r for r in rows}
+        finished = by_id["file:///mnt/onboard/Bookery/A/T/T.kepub.epub"]
+        reading = by_id["file:///mnt/onboard/Bookery/A/T2/T2.epub"]
+
+        assert isinstance(finished, KoboContentRow)
+        assert finished.read_status == 2
+        assert finished.percent_read == 1.0
+        assert finished.date_last_read == "2026-05-20T10:00:00"
+        assert finished.chapter_id_bookmarked is None
+        assert finished.mime_type == "application/x-kobo-epub+zip"
+
+        assert reading.read_status == 1
+        assert reading.percent_read == 0.42
+        assert reading.chapter_id_bookmarked == "OEBPS/ch3.xhtml"
+        assert reading.mime_type == "application/epub+zip"
+
+
+def _add_book_with_remote_path(
+    catalog: LibraryCatalog,
+    *,
+    title: str,
+    author: str,
+    device_id: int,
+    remote_path: str,
+    now: str,
+) -> int:
+    md = BookMetadata(
+        title=title,
+        authors=[author],
+        source_path=Path(f"/tmp/{title}.epub"),
+    )
+    book_id = catalog.add_book(md, file_hash=f"hash-{title}")
+    catalog.upsert_device_file(
+        device_id=device_id, book_id=book_id, remote_path=remote_path, now=now
+    )
+    return book_id
+
+
+class TestPullReadState:
+    def _build_mount(self, tmp_path: Path) -> tuple[Path, Path]:
+        mount = tmp_path / "kobo"
+        kobo_dir = mount / ".kobo"
+        kobo_dir.mkdir(parents=True)
+        (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
+        return mount, kobo_dir
+
+    def test_pulls_resolved_rows_and_skips_unknown(self, tmp_path: Path) -> None:
+        mount, kobo_dir = self._build_mount(tmp_path)
+        _create_kobo_db(kobo_dir / "KoboReader.sqlite")
+
+        conn = open_library(tmp_path / "library.db")
+        catalog = LibraryCatalog(conn)
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N428440071799", label=None, now="2026-05-26T08:00:00"
+        )
+        # Resolve one of the two top-level EPUBs in the fixture; leave the other
+        # to confirm it counts as "skipped" (not present in our catalog).
+        book_id = _add_book_with_remote_path(
+            catalog,
+            title="T",
+            author="A",
+            device_id=device_id,
+            remote_path="/mnt/onboard/Bookery/A/T/T.kepub.epub",
+            now="2026-05-26T08:00:00",
+        )
+
+        pulled, skipped = pull_read_state(
+            catalog,
+            device_id=device_id,
+            mount_path=mount,
+            now="2026-05-26T08:00:00",
+        )
+        assert (pulled, skipped) == (1, 1)
+        row = conn.execute(
+            "SELECT * FROM device_read_state WHERE device_id = ? AND book_id = ?",
+            (device_id, book_id),
+        ).fetchone()
+        assert row["read_status"] == 2
+        assert row["percent_read"] == 1.0
+        assert row["last_read_at"] == "2026-05-20T10:00:00"
+        # book_status mirror is seeded on pull.
+        bs = conn.execute(
+            "SELECT status, updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        assert bs["status"] == 2
+        assert bs["updated_at"] == "2026-05-20T10:00:00"
+
+    def test_second_call_is_idempotent_and_preserves_book_status(
+        self, tmp_path: Path
+    ) -> None:
+        mount, kobo_dir = self._build_mount(tmp_path)
+        _create_kobo_db(kobo_dir / "KoboReader.sqlite")
+        conn = open_library(tmp_path / "library.db")
+        catalog = LibraryCatalog(conn)
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        book_id = _add_book_with_remote_path(
+            catalog,
+            title="T",
+            author="A",
+            device_id=device_id,
+            remote_path="/mnt/onboard/Bookery/A/T/T.kepub.epub",
+            now="2026-05-26T08:00:00",
+        )
+        # Simulate the user setting status in the catalog (P1b path) AFTER the
+        # first pull seeded book_status. A second pull must not overwrite that.
+        pull_read_state(catalog, device_id=device_id, mount_path=mount, now="t1")
+        conn.execute(
+            "UPDATE book_status SET status = 0, updated_at = 'user-edit' WHERE book_id = ?",
+            (book_id,),
+        )
+        conn.commit()
+
+        pulled, skipped = pull_read_state(
+            catalog, device_id=device_id, mount_path=mount, now="t2"
+        )
+        assert (pulled, skipped) == (1, 1)
+        bs = conn.execute(
+            "SELECT status, updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        assert bs["status"] == 0
+        assert bs["updated_at"] == "user-edit"
+        # device_read_state was re-upserted with new pulled_at.
+        row = conn.execute(
+            "SELECT pulled_at FROM device_read_state WHERE device_id = ? AND book_id = ?",
+            (device_id, book_id),
+        ).fetchone()
+        assert row["pulled_at"] == "t2"
+
+    def test_returns_zero_when_kobo_db_missing(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mount, _ = self._build_mount(tmp_path)
+        # KoboReader.sqlite is intentionally absent.
+        conn = open_library(tmp_path / "library.db")
+        catalog = LibraryCatalog(conn)
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="t"
+        )
+        with caplog.at_level(logging.WARNING, logger="bookery.device.kobo_reader"):
+            pulled, skipped = pull_read_state(
+                catalog, device_id=device_id, mount_path=mount, now="t"
+            )
+        assert (pulled, skipped) == (0, 0)
+        assert any("KoboReader.sqlite not found" in rec.message for rec in caplog.records)

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -535,9 +535,12 @@ class TestDeviceWiring:
         assert len(catalog.upsert_device_file_calls) == 3
         book_ids = {c["book_id"] for c in catalog.upsert_device_file_calls}
         assert book_ids == {1, 2, 3}
-        # Every recorded path actually exists on the target.
+        # Recorded remote_paths are in the device coordinate system
+        # (/mnt/onboard/...), not the host mount path — so they line up with
+        # Kobo's ContentID format on real hardware.
         for call in catalog.upsert_device_file_calls:
-            assert Path(call["remote_path"]).exists()
+            assert call["remote_path"].startswith("/mnt/onboard/Books/")
+            assert call["remote_path"].endswith(".kepub.epub")
             assert call["device_id"] == catalog.device_id
 
     def test_no_device_file_upsert_when_copy_skipped(self, tmp_path: Path) -> None:

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -1,7 +1,7 @@
 # ABOUTME: Unit tests for sync_library_to_kobo — orchestrates kepubify + cache + copy.
 # ABOUTME: Stubs the kepubify wrapper and uses a real KepubCache + tmp filesystem.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -35,9 +35,45 @@ class StubKepubify:
 @dataclass
 class StubCatalog:
     records: list[BookRecord]
+    device_id: int = 42
+    device_files: dict[tuple[int, str], int] = field(default_factory=dict)
+    upsert_device_calls: list[dict] = field(default_factory=list)
+    upsert_device_file_calls: list[dict] = field(default_factory=list)
+    read_state_upserts: list[dict] = field(default_factory=list)
+    book_status_seeds: list[dict] = field(default_factory=list)
 
     def list_all(self) -> list[BookRecord]:
         return list(self.records)
+
+    def upsert_device(self, *, kind: str, serial: str, label, now: str) -> int:
+        self.upsert_device_calls.append(
+            {"kind": kind, "serial": serial, "label": label, "now": now}
+        )
+        return self.device_id
+
+    def upsert_device_file(
+        self, *, device_id: int, book_id: int, remote_path: str, now: str
+    ) -> None:
+        self.upsert_device_file_calls.append(
+            {
+                "device_id": device_id,
+                "book_id": book_id,
+                "remote_path": remote_path,
+                "now": now,
+            }
+        )
+        self.device_files[(device_id, remote_path)] = book_id
+
+    def resolve_book_id_for_remote_path(
+        self, *, device_id: int, remote_path: str
+    ) -> int | None:
+        return self.device_files.get((device_id, remote_path))
+
+    def upsert_device_read_state(self, **kwargs) -> None:
+        self.read_state_upserts.append(kwargs)
+
+    def seed_book_status_if_absent(self, **kwargs) -> None:
+        self.book_status_seeds.append(kwargs)
 
 
 def _make_record(
@@ -65,9 +101,13 @@ def _write_epub(path: Path, body: bytes = b"EPUB-CONTENT") -> None:
     path.write_bytes(body)
 
 
-def _setup(tmp_path: Path) -> dict[str, Any]:
+def _setup(tmp_path: Path, *, write_version: bool = True) -> dict[str, Any]:
     library = tmp_path / "library"
     target = tmp_path / "kobo"
+    if write_version:
+        kobo_dir = target / ".kobo"
+        kobo_dir.mkdir(parents=True)
+        (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
     cache = KepubCache(tmp_path / "kepub.db")
     kepubify = StubKepubify()
     workspace = tmp_path / "workspace"
@@ -441,3 +481,151 @@ def test_kepubify_failure_is_recorded_not_raised(tmp_path: Path) -> None:
 
     assert len(report.failed) == 1
     assert "kepubify crashed" in report.failed[0][1]
+
+
+class TestDeviceWiring:
+    """The sync wiring added in P1a (issue #180).
+
+    Read state pull runs before the kepub copy loop, device_files rows are
+    written per successful copy, and a missing `.kobo/version` degrades
+    gracefully (kepub copy still runs).
+    """
+
+    def test_device_upserted_before_loop(self, tmp_path: Path) -> None:
+        env = _setup(tmp_path)
+        epub = env["library"] / "A" / "T" / "T.epub"
+        _write_epub(epub)
+        record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+        catalog = StubCatalog(records=[record])
+
+        sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+        )
+        assert len(catalog.upsert_device_calls) == 1
+        call = catalog.upsert_device_calls[0]
+        assert call["kind"] == "kobo"
+        assert call["serial"] == "N428440071799"
+
+    def test_device_files_upserted_per_copy(self, tmp_path: Path) -> None:
+        env = _setup(tmp_path)
+        records = []
+        for i in range(3):
+            epub = env["library"] / f"A{i}" / f"T{i}" / f"T{i}.epub"
+            _write_epub(epub)
+            records.append(
+                _make_record(rec_id=i + 1, title=f"T{i}", author=f"A{i}", epub_path=epub)
+            )
+        catalog = StubCatalog(records=records)
+
+        sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+        )
+        assert len(catalog.upsert_device_file_calls) == 3
+        book_ids = {c["book_id"] for c in catalog.upsert_device_file_calls}
+        assert book_ids == {1, 2, 3}
+        # Every recorded path actually exists on the target.
+        for call in catalog.upsert_device_file_calls:
+            assert Path(call["remote_path"]).exists()
+            assert call["device_id"] == catalog.device_id
+
+    def test_no_device_file_upsert_when_copy_skipped(self, tmp_path: Path) -> None:
+        env = _setup(tmp_path)
+        epub = env["library"] / "A" / "T" / "T.epub"
+        _write_epub(epub)
+        record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+        catalog = StubCatalog(records=[record])
+
+        # First sync — copies and records the device_file.
+        sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+        )
+        baseline = len(catalog.upsert_device_file_calls)
+
+        # Second sync — kepub cache hits, file skipped; no new device_file row.
+        sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+        )
+        assert len(catalog.upsert_device_file_calls) == baseline
+
+    def test_dry_run_does_not_touch_device_tables(self, tmp_path: Path) -> None:
+        env = _setup(tmp_path)
+        epub = env["library"] / "A" / "T" / "T.epub"
+        _write_epub(epub)
+        record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+        catalog = StubCatalog(records=[record])
+
+        sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+            dry_run=True,
+        )
+        assert catalog.upsert_device_calls == []
+        assert catalog.upsert_device_file_calls == []
+
+    def test_sync_continues_when_kobo_version_missing(self, tmp_path: Path) -> None:
+        env = _setup(tmp_path, write_version=False)
+        epub = env["library"] / "A" / "T" / "T.epub"
+        _write_epub(epub)
+        record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+        catalog = StubCatalog(records=[record])
+
+        report = sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+        )
+        # The kepub copy still happens — sync is best-effort.
+        assert len(report.copied) == 1
+        # But no device-side bookkeeping was done (no serial → no device id).
+        assert catalog.upsert_device_calls == []
+        assert catalog.upsert_device_file_calls == []
+        assert report.read_states_pulled == 0
+        assert report.read_states_skipped == 0
+
+    def test_report_has_read_state_counter_defaults(self, tmp_path: Path) -> None:
+        env = _setup(tmp_path)
+        catalog = StubCatalog(records=[])
+        report = sync_library_to_kobo(
+            catalog=catalog,
+            target=env["target"],
+            cache=env["cache"],
+            run_kepubify=env["kepubify"].run,
+            kepubify_version=env["kepubify"].get_version,
+            workspace_dir=env["workspace"],
+            books_subdir="Books",
+        )
+        assert report.read_states_pulled == 0
+        assert report.read_states_skipped == 0

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 7
+        assert version == 8
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -126,7 +126,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 7
+        assert version == 8
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")


### PR DESCRIPTION
## Summary

Lands the foundation for bidirectional Kobo read-status sync — pull-only in this PR. After merge, `bookery sync kobo` reads `.kobo/KoboReader.sqlite` and populates `device_read_state` + `book_status` in the catalog. No UI, no CLI commands, no device writes yet — those land in P1b (#181), P2 (#182), P3 (#183).

The schema migration lands the **full bidirectional layout** in one shot so later phases are purely additive.

## Changes

- **`db/schema.py`** — SCHEMA_V8: `devices`, `device_read_state`, `book_status`, `device_files`
- **`db/catalog.py`** — `upsert_device`, `upsert_device_file`, `resolve_book_id_for_remote_path`, `upsert_device_read_state`, `seed_book_status_if_absent` (uses `ON CONFLICT DO NOTHING` so future user edits via `bookery read` aren't clobbered)
- **`device/kobo_reader.py`** (new) — Read-only opener (`file:...?mode=ro&immutable=1` — required for USB-mounted DBs), parser, ContentID normalizer, serial reader, and `pull_read_state()` orchestrator
- **`device/kobo.py`** — Extended `_CatalogProto` and `SyncReport`; reads `.kobo/version` for serial; upserts device + calls pull before kepub copy loop; records each successful copy in `device_files`; `_to_device_path()` translates host-side mount paths into the device's `/mnt/onboard/...` coordinate system (Kobo's `ContentID` is always device-side)

## Design notes

- **Strategy B (record what we wrote):** Resolver does a direct PK lookup against `device_files` instead of recomputing sanitization rules — correct by construction.
- **Best-effort pull:** Missing `.kobo/version` or `KoboReader.sqlite` logs a warning, returns `(0, 0)`, and the kepub copy still runs. Verified by a regression test.
- **Verified against real hardware:** Kobo Libra Colour (firmware 4.45.23684, 1146 books) — confirmed schema fields, `MimeType LIKE 'application/%epub%'` catches kepubs + raw EPUBs, and the `immutable=1` URI flag is required.

## Testing
- [x] 26 new tests added (unit + integration)
- [x] Full suite passes (1698 tests)
- [x] Round-trip integration test seeds `KoboReader.sqlite` with device-form ContentIDs and verifies the resolver round-trips on the second sync
- [x] ruff + pyright clean

## Related

Parent epic: #178
Closes #180
Followups: #181 (CLI surfaces + bookery read/unread/reading), #182 (device push + merge), #183 (web UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)