### PR TITLE
Add #181: Surface Kobo read-status in CLI and web (P1b)

### DIFF
--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -22,6 +22,7 @@ from bookery.cli.commands import (
     remove_cmd,
     search_cmd,
     serve_cmd,
+    status_cmd,
     sync_cmd,
     tag_cmd,
     vault_export_cmd,
@@ -72,6 +73,9 @@ cli.add_command(rematch_cmd.rematch)
 cli.add_command(remove_cmd.remove)
 cli.add_command(search_cmd.search)
 cli.add_command(serve_cmd.serve)
+cli.add_command(status_cmd.read_cmd)
+cli.add_command(status_cmd.reading_cmd)
+cli.add_command(status_cmd.unread_cmd)
 cli.add_command(sync_cmd.sync)
 cli.add_command(tag_cmd.tag)
 cli.add_command(vault_export_cmd.vault_export)

--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -10,6 +10,7 @@ from rich.table import Table
 from bookery.cli.options import db_option, resolve_db_path
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
+from bookery.db.status import status_name
 
 console = Console()  # TODO: move Console() inside command for testability
 
@@ -199,4 +200,32 @@ def info(
     table.add_row("Modified", record.date_modified)
 
     console.print(table)
+
+    book_status = catalog.get_book_status(book_id)
+    device_state = catalog.get_device_read_state_for_book(book_id)
+    if book_status is not None or device_state is not None:
+        reading = Table(show_header=False, box=None, pad_edge=False)
+        reading.add_column("Field", style="bold", width=14)
+        reading.add_column("Value")
+        if book_status is not None:
+            reading.add_row("Status", status_name(book_status.status))
+        elif device_state is not None:
+            # No user mark yet — surface the device's view rather than render
+            # an empty section just because device_read_state exists.
+            reading.add_row("Status", status_name(device_state.read_status))
+        if device_state is not None and device_state.percent_read is not None:
+            reading.add_row("Progress", f"{device_state.percent_read:.0%}")
+        if device_state is not None and device_state.last_read_at:
+            reading.add_row("Last opened", device_state.last_read_at)
+        if device_state is not None:
+            label = (
+                f"{device_state.device_kind.title()} ({device_state.device_label})"
+                if device_state.device_label
+                else device_state.device_kind.title()
+            )
+            reading.add_row("Device", label)
+        console.print()
+        console.print("[bold]Reading[/bold]")
+        console.print(reading)
+
     conn.close()

--- a/src/bookery/cli/commands/info_cmd.py
+++ b/src/bookery/cli/commands/info_cmd.py
@@ -16,9 +16,21 @@ console = Console()  # TODO: move Console() inside command for testability
 
 
 _SETTABLE_FIELDS = {
-    "title", "subtitle", "authors", "author_sort", "language", "publisher", "isbn",
-    "description", "series", "series_index", "subjects", "published_date",
-    "original_publication_date", "page_count", "cover_url",
+    "title",
+    "subtitle",
+    "authors",
+    "author_sort",
+    "language",
+    "publisher",
+    "isbn",
+    "description",
+    "series",
+    "series_index",
+    "subjects",
+    "published_date",
+    "original_publication_date",
+    "page_count",
+    "cover_url",
 }
 
 
@@ -27,15 +39,12 @@ def _parse_set_pairs(pairs: tuple[str, ...]) -> dict[str, object]:
     out: dict[str, object] = {}
     for pair in pairs:
         if "=" not in pair:
-            raise click.BadParameter(
-                f"--set expects field=value, got {pair!r}"
-            )
+            raise click.BadParameter(f"--set expects field=value, got {pair!r}")
         key, _, value = pair.partition("=")
         key = key.strip()
         if key not in _SETTABLE_FIELDS:
             raise click.BadParameter(
-                f"Unknown field {key!r}. Settable fields: "
-                f"{', '.join(sorted(_SETTABLE_FIELDS))}"
+                f"Unknown field {key!r}. Settable fields: {', '.join(sorted(_SETTABLE_FIELDS))}"
             )
         if key in ("authors", "subjects"):
             out[key] = [a.strip() for a in value.split(",") if a.strip()]
@@ -117,9 +126,7 @@ def info(
     if lock_fields:
         console.print(f"[green]Locked:[/green] {', '.join(sorted(set(lock_fields)))}")
     if unlock_fields:
-        console.print(
-            f"[green]Unlocked:[/green] {', '.join(sorted(set(unlock_fields)))}"
-        )
+        console.print(f"[green]Unlocked:[/green] {', '.join(sorted(set(unlock_fields)))}")
 
     if show_provenance:
         prov = catalog.get_provenance(book_id)

--- a/src/bookery/cli/commands/ls_cmd.py
+++ b/src/bookery/cli/commands/ls_cmd.py
@@ -10,6 +10,7 @@ from rich.table import Table
 from bookery.cli.options import db_option, resolve_db_path
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
+from bookery.db.status import STATUS_FINISHED, STATUS_READING
 
 console = Console()  # TODO: move Console() inside command for testability
 
@@ -34,13 +35,47 @@ console = Console()  # TODO: move Console() inside command for testability
     default=None,
     help="Filter by genre name.",
 )
+@click.option(
+    "--reading",
+    "reading_filter",
+    is_flag=True,
+    default=False,
+    help="Show only books currently being read.",
+)
+@click.option(
+    "--finished",
+    "finished_filter",
+    is_flag=True,
+    default=False,
+    help="Show only books marked finished.",
+)
+@click.option(
+    "--unread",
+    "unread_filter",
+    is_flag=True,
+    default=False,
+    help="Show only books that are unread (no status row, or status = 0).",
+)
 def ls(
     db_path: Path | None,
     series_filter: str | None,
     tag_filter: str | None,
     genre_filter: str | None,
+    reading_filter: bool,
+    finished_filter: bool,
+    unread_filter: bool,
 ) -> None:
     """List all books in the library catalog."""
+    # Status filters are mutually exclusive with each other; combining two
+    # (e.g. --reading --finished) is incoherent so we fail at the front door
+    # rather than silently picking one.
+    status_filters_set = sum([reading_filter, finished_filter, unread_filter])
+    if status_filters_set > 1:
+        console.print(
+            "[red]--reading, --finished, and --unread are mutually exclusive.[/red]"
+        )
+        raise SystemExit(2)
+
     # TODO: wrap conn in try-finally or context manager to prevent leak on exception
     conn = open_library(resolve_db_path(db_path))
     catalog = LibraryCatalog(conn)
@@ -61,6 +96,12 @@ def ls(
             raise SystemExit(1) from exc
     elif series_filter:
         records = catalog.list_by_series(series_filter)
+    elif reading_filter:
+        records = catalog.list_books_by_status(STATUS_READING)
+    elif finished_filter:
+        records = catalog.list_books_by_status(STATUS_FINISHED)
+    elif unread_filter:
+        records = catalog.list_books_unread()
     else:
         records = catalog.list_all()
 

--- a/src/bookery/cli/commands/ls_cmd.py
+++ b/src/bookery/cli/commands/ls_cmd.py
@@ -71,9 +71,7 @@ def ls(
     # rather than silently picking one.
     status_filters_set = sum([reading_filter, finished_filter, unread_filter])
     if status_filters_set > 1:
-        console.print(
-            "[red]--reading, --finished, and --unread are mutually exclusive.[/red]"
-        )
+        console.print("[red]--reading, --finished, and --unread are mutually exclusive.[/red]")
         raise SystemExit(2)
 
     # TODO: wrap conn in try-finally or context manager to prevent leak on exception

--- a/src/bookery/cli/commands/status_cmd.py
+++ b/src/bookery/cli/commands/status_cmd.py
@@ -37,13 +37,9 @@ def parse_bulk_ids(text: str) -> list[int]:
         try:
             value = int(stripped)
         except ValueError as exc:
-            raise ValueError(
-                f"Line {lineno}: not an integer: {stripped!r}"
-            ) from exc
+            raise ValueError(f"Line {lineno}: not an integer: {stripped!r}") from exc
         if value <= 0:
-            raise ValueError(
-                f"Line {lineno}: book ID must be positive, got {value}"
-            )
+            raise ValueError(f"Line {lineno}: book ID must be positive, got {value}")
         ids.append(value)
     return ids
 
@@ -53,9 +49,7 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat(timespec="seconds")
 
 
-def _resolve_book_ids(
-    *, book_id: int | None, bulk_from: Path | None
-) -> list[int]:
+def _resolve_book_ids(*, book_id: int | None, bulk_from: Path | None) -> list[int]:
     """Return the list of book IDs to operate on, validating mutual exclusion.
 
     Exactly one of (positional ``book_id``, ``--bulk-from FILE``) must be
@@ -64,13 +58,9 @@ def _resolve_book_ids(
     bare traceback.
     """
     if book_id is None and bulk_from is None:
-        raise click.UsageError(
-            "Provide a BOOK_ID argument or --bulk-from FILE."
-        )
+        raise click.UsageError("Provide a BOOK_ID argument or --bulk-from FILE.")
     if book_id is not None and bulk_from is not None:
-        raise click.UsageError(
-            "BOOK_ID and --bulk-from are mutually exclusive."
-        )
+        raise click.UsageError("BOOK_ID and --bulk-from are mutually exclusive.")
     if bulk_from is not None:
         text = Path(bulk_from).read_text()
         try:
@@ -141,36 +131,24 @@ _bulk_from_option = click.option(
 @click.argument("book_id", type=int, required=False)
 @_bulk_from_option
 @db_option
-def read_cmd(
-    book_id: int | None, bulk_from: Path | None, db_path: Path | None
-) -> None:
+def read_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
     """Mark a book as finished (status = 2)."""
-    _apply_status(
-        db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_FINISHED
-    )
+    _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_FINISHED)
 
 
 @click.command("unread")
 @click.argument("book_id", type=int, required=False)
 @_bulk_from_option
 @db_option
-def unread_cmd(
-    book_id: int | None, bulk_from: Path | None, db_path: Path | None
-) -> None:
+def unread_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
     """Mark a book as unread (status = 0)."""
-    _apply_status(
-        db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_UNREAD
-    )
+    _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_UNREAD)
 
 
 @click.command("reading")
 @click.argument("book_id", type=int, required=False)
 @_bulk_from_option
 @db_option
-def reading_cmd(
-    book_id: int | None, bulk_from: Path | None, db_path: Path | None
-) -> None:
+def reading_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
     """Mark a book as in-progress (status = 1)."""
-    _apply_status(
-        db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_READING
-    )
+    _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_READING)

--- a/src/bookery/cli/commands/status_cmd.py
+++ b/src/bookery/cli/commands/status_cmd.py
@@ -1,0 +1,176 @@
+# ABOUTME: The `bookery read`, `bookery unread`, `bookery reading` commands.
+# ABOUTME: Set catalog-side book_status; --bulk-from FILE applies to many books at once.
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from bookery.cli.options import db_option, resolve_db_path
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.db.status import (
+    STATUS_FINISHED,
+    STATUS_READING,
+    STATUS_UNREAD,
+    status_name,
+)
+
+console = Console()
+
+
+def parse_bulk_ids(text: str) -> list[int]:
+    """Parse a `--bulk-from` file body into a list of positive integers.
+
+    Format: one ID per line. Blank lines are skipped. Lines whose first
+    non-whitespace character is `#` are treated as comments and skipped.
+    Each surviving line must parse as a positive (>= 1) integer; anything
+    else raises ValueError naming the line number and content so the user
+    can fix the file rather than guess.
+    """
+    ids: list[int] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            value = int(stripped)
+        except ValueError as exc:
+            raise ValueError(
+                f"Line {lineno}: not an integer: {stripped!r}"
+            ) from exc
+        if value <= 0:
+            raise ValueError(
+                f"Line {lineno}: book ID must be positive, got {value}"
+            )
+        ids.append(value)
+    return ids
+
+
+def _now_iso() -> str:
+    """UTC ISO timestamp with seconds precision — matches the P1a pull path."""
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _resolve_book_ids(
+    *, book_id: int | None, bulk_from: Path | None
+) -> list[int]:
+    """Return the list of book IDs to operate on, validating mutual exclusion.
+
+    Exactly one of (positional ``book_id``, ``--bulk-from FILE``) must be
+    supplied. Both-or-neither is a usage error surfaced as a Click
+    BadParameter so Click formats the help-style message instead of a
+    bare traceback.
+    """
+    if book_id is None and bulk_from is None:
+        raise click.UsageError(
+            "Provide a BOOK_ID argument or --bulk-from FILE."
+        )
+    if book_id is not None and bulk_from is not None:
+        raise click.UsageError(
+            "BOOK_ID and --bulk-from are mutually exclusive."
+        )
+    if bulk_from is not None:
+        text = Path(bulk_from).read_text()
+        try:
+            ids = parse_bulk_ids(text)
+        except ValueError as exc:
+            raise click.BadParameter(str(exc), param_hint="--bulk-from") from exc
+        if not ids:
+            raise click.UsageError(f"No book IDs found in {bulk_from}.")
+        return ids
+    assert book_id is not None
+    return [book_id]
+
+
+def _apply_status(
+    *,
+    db_path: Path | None,
+    book_id: int | None,
+    bulk_from: Path | None,
+    status: int,
+) -> None:
+    """Shared implementation for the read/unread/reading commands.
+
+    Single-ID mode exits non-zero if the book doesn't exist (so a typo at the
+    CLI fails loudly). Bulk mode is forgiving: it warns and skips unknown IDs,
+    then reports a count at the end — the common bulk case is "I just imported
+    my Calibre library and pasted in 200 IDs", and one stale row shouldn't
+    abort the whole operation.
+    """
+    ids = _resolve_book_ids(book_id=book_id, bulk_from=bulk_from)
+    is_bulk = bulk_from is not None
+    name = status_name(status).lower()
+
+    conn = open_library(resolve_db_path(db_path))
+    try:
+        catalog = LibraryCatalog(conn)
+        now = _now_iso()
+        applied = 0
+        for bid in ids:
+            try:
+                catalog.set_book_status(book_id=bid, status=status, updated_at=now)
+            except ValueError as exc:
+                if is_bulk:
+                    console.print(f"[yellow]Skipped {bid}: {exc}[/yellow]")
+                    continue
+                console.print(f"[red]{exc}[/red]")
+                raise SystemExit(1) from exc
+            applied += 1
+            if not is_bulk:
+                record = catalog.get_by_id(bid)
+                title = record.metadata.title if record else f"book {bid}"
+                console.print(f"[green]Marked[/green] [bold]{title}[/bold] as {name}.")
+        if is_bulk:
+            console.print(f"[green]Marked {applied} book(s) as {name}.[/green]")
+    finally:
+        conn.close()
+
+
+_bulk_from_option = click.option(
+    "--bulk-from",
+    "bulk_from",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="Read one book ID per line from FILE. Blank lines and #-comments are skipped.",
+)
+
+
+@click.command("read")
+@click.argument("book_id", type=int, required=False)
+@_bulk_from_option
+@db_option
+def read_cmd(
+    book_id: int | None, bulk_from: Path | None, db_path: Path | None
+) -> None:
+    """Mark a book as finished (status = 2)."""
+    _apply_status(
+        db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_FINISHED
+    )
+
+
+@click.command("unread")
+@click.argument("book_id", type=int, required=False)
+@_bulk_from_option
+@db_option
+def unread_cmd(
+    book_id: int | None, bulk_from: Path | None, db_path: Path | None
+) -> None:
+    """Mark a book as unread (status = 0)."""
+    _apply_status(
+        db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_UNREAD
+    )
+
+
+@click.command("reading")
+@click.argument("book_id", type=int, required=False)
+@_bulk_from_option
+@db_option
+def reading_cmd(
+    book_id: int | None, bulk_from: Path | None, db_path: Path | None
+) -> None:
+    """Mark a book as in-progress (status = 1)."""
+    _apply_status(
+        db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_READING
+    )

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -17,6 +17,7 @@ from bookery.db.mapping import (
     metadata_to_row,
     row_to_record,
 )
+from bookery.db.status import BookStatus, DeviceReadState
 from bookery.metadata.genres import is_canonical_genre
 from bookery.metadata.types import BookMetadata
 
@@ -902,3 +903,140 @@ class LibraryCatalog:
             (book_id, status, updated_at),
         )
         self._conn.commit()
+
+    def set_book_status(self, *, book_id: int, status: int, updated_at: str) -> None:
+        """Upsert book_status for the user-write path.
+
+        Differs from `seed_book_status_if_absent` in that this overwrites on
+        conflict — the user's `bookery read/unread/reading` command is the
+        authoritative signal for catalog-side state. Raises ValueError if
+        `book_id` is not in the books table so a bad CLI argument fails
+        loudly instead of silently writing an orphan row that an FK
+        constraint would later complain about anyway.
+        """
+        existing = self._conn.execute(
+            "SELECT 1 FROM books WHERE id = ?", (book_id,)
+        ).fetchone()
+        if existing is None:
+            raise ValueError(f"Book {book_id} not found.")
+        self._conn.execute(
+            """
+            INSERT INTO book_status (book_id, status, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(book_id) DO UPDATE SET
+                status = excluded.status,
+                updated_at = excluded.updated_at
+            """,
+            (book_id, status, updated_at),
+        )
+        self._conn.commit()
+
+    def get_book_status(self, book_id: int) -> BookStatus | None:
+        """Return the catalog-side read status for a book, or None if absent."""
+        row = self._conn.execute(
+            "SELECT book_id, status, updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return BookStatus(
+            book_id=int(row["book_id"]),
+            status=int(row["status"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    def get_book_statuses(self, book_ids: list[int]) -> dict[int, BookStatus]:
+        """Bulk lookup for the web list view: id → BookStatus.
+
+        Books without a `book_status` row are silently omitted from the result;
+        the template treats absence as "no chip". An empty ``book_ids`` short-
+        circuits without hitting the DB so a paginated page with zero books
+        skips the query entirely.
+        """
+        if not book_ids:
+            return {}
+        placeholders = ",".join("?" * len(book_ids))
+        cursor = self._conn.execute(
+            "SELECT book_id, status, updated_at FROM book_status "
+            f"WHERE book_id IN ({placeholders})",
+            book_ids,
+        )
+        return {
+            int(row["book_id"]): BookStatus(
+                book_id=int(row["book_id"]),
+                status=int(row["status"]),
+                updated_at=str(row["updated_at"]),
+            )
+            for row in cursor.fetchall()
+        }
+
+    def list_books_by_status(self, status: int) -> list[BookRecord]:
+        """Return books with `book_status.status = ?`, ordered by title."""
+        cursor = self._conn.execute(
+            """
+            SELECT books.* FROM books
+            JOIN book_status ON books.id = book_status.book_id
+            WHERE book_status.status = ?
+            ORDER BY books.title
+            """,
+            (status,),
+        )
+        return [row_to_record(row) for row in cursor.fetchall()]
+
+    def list_books_unread(self) -> list[BookRecord]:
+        """Return books that are either unread or have no status row, by title.
+
+        "Unread" in the bookery model is the union of two cases: a book that
+        has never been touched (no `book_status` row), and a book the user has
+        explicitly marked unread (`status = 0`). The CLI's `ls --unread`
+        flattens both.
+        """
+        cursor = self._conn.execute(
+            """
+            SELECT books.* FROM books
+            LEFT JOIN book_status ON books.id = book_status.book_id
+            WHERE book_status.book_id IS NULL OR book_status.status = 0
+            ORDER BY books.title
+            """,
+        )
+        return [row_to_record(row) for row in cursor.fetchall()]
+
+    def get_device_read_state_for_book(self, book_id: int) -> DeviceReadState | None:
+        """Return the most-recent device read state for a book, joined with devices.
+
+        When two devices both have a row for the same book (e.g. user paired
+        and read on two Kobos), the row with the latest `status_updated_at`
+        wins — that's what the user is actively touching. Returns None when no
+        device has ever pulled a state for this book.
+        """
+        row = self._conn.execute(
+            """
+            SELECT
+                drs.device_id,
+                drs.book_id,
+                drs.read_status,
+                drs.percent_read,
+                drs.last_read_at,
+                drs.status_updated_at,
+                devices.kind AS device_kind,
+                devices.label AS device_label
+            FROM device_read_state AS drs
+            JOIN devices ON devices.id = drs.device_id
+            WHERE drs.book_id = ?
+            ORDER BY drs.status_updated_at DESC
+            LIMIT 1
+            """,
+            (book_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return DeviceReadState(
+            device_id=int(row["device_id"]),
+            device_kind=str(row["device_kind"]),
+            device_label=row["device_label"],
+            book_id=int(row["book_id"]),
+            read_status=int(row["read_status"]),
+            percent_read=float(row["percent_read"]) if row["percent_read"] is not None else None,
+            last_read_at=row["last_read_at"],
+            status_updated_at=str(row["status_updated_at"]),
+        )

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -914,9 +914,7 @@ class LibraryCatalog:
         loudly instead of silently writing an orphan row that an FK
         constraint would later complain about anyway.
         """
-        existing = self._conn.execute(
-            "SELECT 1 FROM books WHERE id = ?", (book_id,)
-        ).fetchone()
+        existing = self._conn.execute("SELECT 1 FROM books WHERE id = ?", (book_id,)).fetchone()
         if existing is None:
             raise ValueError(f"Book {book_id} not found.")
         self._conn.execute(

--- a/src/bookery/db/status.py
+++ b/src/bookery/db/status.py
@@ -1,0 +1,56 @@
+# ABOUTME: Read-status constants and dataclasses shared across CLI, catalog, and web.
+# ABOUTME: Integer mapping mirrors KoboContentRow.read_status so no remap happens between layers.
+
+from dataclasses import dataclass
+
+STATUS_UNREAD = 0
+STATUS_READING = 1
+STATUS_FINISHED = 2
+
+_STATUS_NAMES = {
+    STATUS_UNREAD: "Unread",
+    STATUS_READING: "Reading",
+    STATUS_FINISHED: "Finished",
+}
+
+
+def status_name(status: int) -> str:
+    """Return the human-readable label for a status integer.
+
+    Falls back to ``"Unknown"`` on values outside the canonical set so a
+    future schema addition never crashes a render path. Callers that want
+    strict checking should compare against the ``STATUS_*`` constants.
+    """
+    return _STATUS_NAMES.get(status, "Unknown")
+
+
+@dataclass(frozen=True, slots=True)
+class BookStatus:
+    """A row from the ``book_status`` table — catalog-side read state.
+
+    This is the truth that the user manipulates via ``bookery read/unread/reading``
+    and that the web detail page surfaces. The device-side mirror lives in
+    ``DeviceReadState`` and is populated by the P1a pull.
+    """
+
+    book_id: int
+    status: int
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceReadState:
+    """A row from ``device_read_state`` joined with ``devices``.
+
+    Carries the device label/kind so CLI and web can render
+    "Kobo (Mr. C's Libra)" without a second lookup.
+    """
+
+    device_id: int
+    device_kind: str
+    device_label: str | None
+    book_id: int
+    read_status: int
+    percent_read: float | None
+    last_read_at: str | None
+    status_updated_at: str

--- a/src/bookery/web/__init__.py
+++ b/src/bookery/web/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from flask import Flask
 
 from bookery.db.catalog import LibraryCatalog
+from bookery.db.status import status_name
 from bookery.metadata.provider import MetadataProvider
 from bookery.util.text import description_paragraphs
 from bookery.web.routes import bp
@@ -37,5 +38,9 @@ def create_app(
     # already plain text (HTML is stripped on write), so this filter never
     # needs to sanitize — it just wraps blank-line paragraphs.
     app.jinja_env.filters["description_paragraphs"] = description_paragraphs
+    # Expose status_name so the detail Reading partial can render the
+    # human-readable label for a `book_status.status` integer without the
+    # template having to know the mapping.
+    app.jinja_env.globals["status_name"] = status_name
     app.register_blueprint(bp)
     return app

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -163,9 +163,7 @@ def books():
     # from this dict so the template stays cheap. Empty pages skip the call
     # entirely; the catalog method also short-circuits but the route is
     # considerate so the DB never sees the question.
-    book_statuses = (
-        catalog.get_book_statuses([b.id for b in books_page]) if books_page else {}
-    )
+    book_statuses = catalog.get_book_statuses([b.id for b in books_page]) if books_page else {}
 
     # ``list_url`` is what row anchors stamp into ``?return_to=`` so detail /
     # edit / diff back-links can return to this exact view (filters, page,

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -201,6 +201,8 @@ def book_detail(book_id):
     genres = catalog.get_genres_for_book(book_id)
     file_info = _file_context(book)
     return_to = _safe_return_to(request.args.get("return_to"))
+    book_status = catalog.get_book_status(book_id)
+    device_read_state = catalog.get_device_read_state_for_book(book_id)
 
     if request.headers.get("HX-Request"):
         return render_template(
@@ -210,6 +212,8 @@ def book_detail(book_id):
             genres=genres,
             file_info=file_info,
             return_to=return_to,
+            book_status=book_status,
+            device_read_state=device_read_state,
         )
 
     return render_template(
@@ -219,6 +223,8 @@ def book_detail(book_id):
         genres=genres,
         file_info=file_info,
         return_to=return_to,
+        book_status=book_status,
+        device_read_state=device_read_state,
     )
 
 

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -159,14 +159,34 @@ def books():
         query=query,
     )
 
+    # One bulk status lookup for the visible page — every row's chip pulls
+    # from this dict so the template stays cheap. Empty pages skip the call
+    # entirely; the catalog method also short-circuits but the route is
+    # considerate so the DB never sees the question.
+    book_statuses = (
+        catalog.get_book_statuses([b.id for b in books_page]) if books_page else {}
+    )
+
     # ``list_url`` is what row anchors stamp into ``?return_to=`` so detail /
     # edit / diff back-links can return to this exact view (filters, page,
     # sort all preserved). Same value on both htmx and full-page paths.
     list_url = _current_list_url()
     if request.headers.get("HX-Request"):
-        return render_template("_book_list.html", page=page, query=query, list_url=list_url)
+        return render_template(
+            "_book_list.html",
+            page=page,
+            query=query,
+            list_url=list_url,
+            book_statuses=book_statuses,
+        )
 
-    return render_template("list.html", page=page, query=query, list_url=list_url)
+    return render_template(
+        "list.html",
+        page=page,
+        query=query,
+        list_url=list_url,
+        book_statuses=book_statuses,
+    )
 
 
 @bp.route("/books/<int:book_id>")

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -722,6 +722,22 @@ header .logo {
     color: white;
 }
 
+/* Read-status chip — small leading glyph next to the title on list and card
+   views. The chip itself is a span so it stays inline with the title link
+   without pulling tap behavior off the anchor; the tooltip lives in the
+   title attribute so it works without JS. */
+.book-status-chip {
+    display: inline-block;
+    margin-right: 0.35rem;
+    font-size: 0.9em;
+    vertical-align: baseline;
+    color: var(--color-muted);
+}
+
+.book-status-chip.status-finished {
+    color: var(--color-badge);
+}
+
 @media (max-width: 768px) {
     .book-table {
         display: none;

--- a/src/bookery/web/templates/_book_card.html
+++ b/src/bookery/web/templates/_book_card.html
@@ -10,7 +10,15 @@
          width="48"
          height="72">
     <div class="book-card-body">
-        <div class="book-card-title">{{ book.metadata.title }}</div>
+        <div class="book-card-title">
+            {%- set status = book_statuses.get(book.id) -%}
+            {%- if status and status.status == 1 -%}
+            <span class="book-status-chip status-reading" title="Reading" aria-label="Reading">&#128214;</span>
+            {%- elif status and status.status == 2 -%}
+            <span class="book-status-chip status-finished" title="Finished" aria-label="Finished">&#10003;</span>
+            {%- endif %}
+            {{ book.metadata.title }}
+        </div>
         <div class="book-card-author">{{ book.metadata.author }}</div>
         {%- set badges = [] -%}
         {%- if book.metadata.language -%}{%- set _ = badges.append(book.metadata.language) -%}{%- endif -%}

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -47,6 +47,12 @@
                     </a>
                 </td>
                 <td class="book-row-title">
+                    {%- set status = book_statuses.get(book.id) -%}
+                    {%- if status and status.status == 1 -%}
+                    <span class="book-status-chip status-reading" title="Reading" aria-label="Reading">&#128214;</span>
+                    {%- elif status and status.status == 2 -%}
+                    <span class="book-status-chip status-finished" title="Finished" aria-label="Finished">&#10003;</span>
+                    {%- endif %}
                     <a href="{{ url_for('web.book_detail', book_id=book.id, return_to=list_url or none) }}">{{ book.metadata.title }}</a>
                 </td>
                 <td>{{ book.metadata.author }}</td>

--- a/src/bookery/web/templates/_detail.html
+++ b/src/bookery/web/templates/_detail.html
@@ -3,6 +3,7 @@
 {% include "_detail_header.html" %}
 <div id="enrich-panel"></div>
 {% include "_detail_identity.html" %}
+{% include "_detail_reading.html" %}
 {% include "_detail_publication.html" %}
 {% include "_detail_classification.html" %}
 {% include "_detail_file.html" %}

--- a/src/bookery/web/templates/_detail_reading.html
+++ b/src/bookery/web/templates/_detail_reading.html
@@ -1,0 +1,28 @@
+{# ABOUTME: Detail Reading partial — status, progress, last opened, device. #}
+{# ABOUTME: Renders only when book_status or device_read_state has a row. #}
+{% if book_status or device_read_state %}
+<section class="section" aria-labelledby="detail-reading">
+    <h2 id="detail-reading">Reading</h2>
+    <dl class="metadata-grid">
+        {% if book_status %}
+        <dt>Status</dt>
+        <dd>{{ status_name(book_status.status) }}</dd>
+        {% elif device_read_state %}
+        <dt>Status</dt>
+        <dd>{{ status_name(device_read_state.read_status) }}</dd>
+        {% endif %}
+        {% if device_read_state and device_read_state.percent_read is not none %}
+        <dt>Progress</dt>
+        <dd>{{ "%.0f"|format(device_read_state.percent_read * 100) }}%</dd>
+        {% endif %}
+        {% if device_read_state and device_read_state.last_read_at %}
+        <dt>Last opened</dt>
+        <dd>{{ device_read_state.last_read_at }}</dd>
+        {% endif %}
+        {% if device_read_state %}
+        <dt>Device</dt>
+        <dd>{{ device_read_state.device_kind|title }}{% if device_read_state.device_label %} ({{ device_read_state.device_label }}){% endif %}</dd>
+        {% endif %}
+    </dl>
+</section>
+{% endif %}

--- a/tests/e2e/test_status_cli.py
+++ b/tests/e2e/test_status_cli.py
@@ -1,0 +1,210 @@
+# ABOUTME: End-to-end tests for `bookery read`, `unread`, `reading`, and the
+# ABOUTME: `ls --reading/--finished/--unread` filters plus info Reading section.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+
+
+def _import_one(runner: CliRunner, db_path: Path, sample_epub: Path) -> None:
+    """Import the standard sample EPUB into ``db_path`` and assert success."""
+    result = runner.invoke(
+        cli, ["import", str(sample_epub.parent), "--db", str(db_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "1 added" in result.output
+
+
+class TestStatusAuthoring:
+    def test_mark_read_then_unread_then_reading(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        """Round-trip the three status verbs on a single book."""
+        db_path = tmp_path / "status.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        # Mark finished — title should appear in confirmation.
+        result = runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Marked" in result.output
+        assert "finished" in result.output
+        assert "Name of the Rose" in result.output
+
+        # Mark unread.
+        result = runner.invoke(cli, ["unread", "1", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "unread" in result.output
+
+        # Mark in-progress.
+        result = runner.invoke(cli, ["reading", "1", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "reading" in result.output
+
+    def test_unknown_book_id_errors(self, sample_epub: Path, tmp_path: Path) -> None:
+        db_path = tmp_path / "status.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        result = runner.invoke(cli, ["read", "999", "--db", str(db_path)])
+        assert result.exit_code == 1
+        assert "999" in result.output
+
+    def test_missing_argument_errors_cleanly(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "status.db"
+        runner = CliRunner()
+        # Empty DB but the command should still fail at usage validation.
+        result = runner.invoke(cli, ["read", "--db", str(db_path)])
+        assert result.exit_code != 0
+        assert "BOOK_ID" in result.output or "bulk-from" in result.output
+
+    def test_book_id_and_bulk_from_are_mutually_exclusive(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "status.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+        bulk = tmp_path / "ids.txt"
+        bulk.write_text("1\n")
+
+        result = runner.invoke(
+            cli, ["read", "1", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+
+class TestBulkFrom:
+    def test_bulk_from_marks_multiple(self, sample_epub: Path, tmp_path: Path) -> None:
+        db_path = tmp_path / "bulk.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        bulk = tmp_path / "ids.txt"
+        bulk.write_text("# bulk wave 1\n1\n\n# trailing comment\n")
+
+        result = runner.invoke(
+            cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
+        assert result.exit_code == 0
+        assert "1 book(s) as finished" in result.output
+
+    def test_bulk_from_warns_on_unknown_id_and_continues(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "bulk-bad.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        bulk = tmp_path / "ids.txt"
+        bulk.write_text("1\n999\n")
+        result = runner.invoke(
+            cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
+        assert result.exit_code == 0
+        assert "Skipped 999" in result.output
+        assert "1 book(s) as finished" in result.output
+
+    def test_bulk_from_bad_id_format_errors(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "bulk-format.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        bulk = tmp_path / "ids.txt"
+        bulk.write_text("1\nnot-a-number\n")
+        result = runner.invoke(
+            cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
+        assert result.exit_code != 0
+        assert "not-a-number" in result.output
+
+
+class TestInfoReadingSection:
+    def test_info_shows_reading_section_after_mark(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "info.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+        runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+
+        result = runner.invoke(cli, ["info", "1", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Reading" in result.output  # the section header
+        assert "Finished" in result.output  # the status name
+
+    def test_info_no_reading_section_when_no_data(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "info-clean.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        result = runner.invoke(cli, ["info", "1", "--db", str(db_path)])
+        assert result.exit_code == 0
+        # No section header; the Rich table title for the metadata table has
+        # no "Reading" string, so plain absence is the right assertion.
+        assert "Reading\n" not in result.output
+
+
+class TestLsStatusFilters:
+    def test_ls_finished_includes_finished_excludes_others(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "lsfilters.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+        runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+
+        result = runner.invoke(cli, ["ls", "--finished", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Name of the Rose" in result.output
+
+        result = runner.invoke(cli, ["ls", "--reading", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Name of the Rose" not in result.output
+
+        result = runner.invoke(cli, ["ls", "--unread", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Name of the Rose" not in result.output
+
+    def test_ls_unread_includes_books_with_no_status_row(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "lsunread.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        result = runner.invoke(cli, ["ls", "--unread", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Name of the Rose" in result.output
+
+    def test_ls_unread_includes_books_marked_unread(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "lsunread2.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+        runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+        runner.invoke(cli, ["unread", "1", "--db", str(db_path)])
+
+        result = runner.invoke(cli, ["ls", "--unread", "--db", str(db_path)])
+        assert result.exit_code == 0
+        assert "Name of the Rose" in result.output
+
+    def test_status_filters_are_mutually_exclusive(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "lsmutex.db"
+        runner = CliRunner()
+        _import_one(runner, db_path, sample_epub)
+
+        result = runner.invoke(
+            cli, ["ls", "--finished", "--reading", "--db", str(db_path)]
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower() or "only one" in result.output.lower()

--- a/tests/e2e/test_status_cli.py
+++ b/tests/e2e/test_status_cli.py
@@ -10,17 +10,13 @@ from bookery.cli import cli
 
 def _import_one(runner: CliRunner, db_path: Path, sample_epub: Path) -> None:
     """Import the standard sample EPUB into ``db_path`` and assert success."""
-    result = runner.invoke(
-        cli, ["import", str(sample_epub.parent), "--db", str(db_path)]
-    )
+    result = runner.invoke(cli, ["import", str(sample_epub.parent), "--db", str(db_path)])
     assert result.exit_code == 0, result.output
     assert "1 added" in result.output
 
 
 class TestStatusAuthoring:
-    def test_mark_read_then_unread_then_reading(
-        self, sample_epub: Path, tmp_path: Path
-    ) -> None:
+    def test_mark_read_then_unread_then_reading(self, sample_epub: Path, tmp_path: Path) -> None:
         """Round-trip the three status verbs on a single book."""
         db_path = tmp_path / "status.db"
         runner = CliRunner()
@@ -69,9 +65,7 @@ class TestStatusAuthoring:
         bulk = tmp_path / "ids.txt"
         bulk.write_text("1\n")
 
-        result = runner.invoke(
-            cli, ["read", "1", "--bulk-from", str(bulk), "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["read", "1", "--bulk-from", str(bulk), "--db", str(db_path)])
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output
 
@@ -85,9 +79,7 @@ class TestBulkFrom:
         bulk = tmp_path / "ids.txt"
         bulk.write_text("# bulk wave 1\n1\n\n# trailing comment\n")
 
-        result = runner.invoke(
-            cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)])
         assert result.exit_code == 0
         assert "1 book(s) as finished" in result.output
 
@@ -100,25 +92,19 @@ class TestBulkFrom:
 
         bulk = tmp_path / "ids.txt"
         bulk.write_text("1\n999\n")
-        result = runner.invoke(
-            cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)])
         assert result.exit_code == 0
         assert "Skipped 999" in result.output
         assert "1 book(s) as finished" in result.output
 
-    def test_bulk_from_bad_id_format_errors(
-        self, sample_epub: Path, tmp_path: Path
-    ) -> None:
+    def test_bulk_from_bad_id_format_errors(self, sample_epub: Path, tmp_path: Path) -> None:
         db_path = tmp_path / "bulk-format.db"
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
 
         bulk = tmp_path / "ids.txt"
         bulk.write_text("1\nnot-a-number\n")
-        result = runner.invoke(
-            cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)])
         assert result.exit_code != 0
         assert "not-a-number" in result.output
 
@@ -137,9 +123,7 @@ class TestInfoReadingSection:
         assert "Reading" in result.output  # the section header
         assert "Finished" in result.output  # the status name
 
-    def test_info_no_reading_section_when_no_data(
-        self, sample_epub: Path, tmp_path: Path
-    ) -> None:
+    def test_info_no_reading_section_when_no_data(self, sample_epub: Path, tmp_path: Path) -> None:
         db_path = tmp_path / "info-clean.db"
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
@@ -203,8 +187,6 @@ class TestLsStatusFilters:
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
 
-        result = runner.invoke(
-            cli, ["ls", "--finished", "--reading", "--db", str(db_path)]
-        )
+        result = runner.invoke(cli, ["ls", "--finished", "--reading", "--db", str(db_path)])
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output.lower() or "only one" in result.output.lower()

--- a/tests/unit/test_catalog_book_status.py
+++ b/tests/unit/test_catalog_book_status.py
@@ -1,0 +1,232 @@
+# ABOUTME: Unit tests for LibraryCatalog read-status methods added in P1b.
+# ABOUTME: Covers set/get/list APIs plus the device-state JOIN that powers info/detail.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.db.status import (
+    STATUS_FINISHED,
+    STATUS_READING,
+    STATUS_UNREAD,
+    BookStatus,
+    DeviceReadState,
+)
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> LibraryCatalog:
+    """Provide a LibraryCatalog backed by a temporary database."""
+    conn = open_library(tmp_path / "test.db")
+    return LibraryCatalog(conn)
+
+
+def _add_book(catalog: LibraryCatalog, title: str, file_hash: str) -> int:
+    """Add a minimally-populated book and return its ID."""
+    return catalog.add_book(
+        BookMetadata(
+            title=title,
+            authors=["Test Author"],
+            author_sort="Author, Test",
+            source_path=Path(f"/books/{file_hash}.epub"),
+        ),
+        file_hash=file_hash,
+    )
+
+
+class TestSetBookStatus:
+    def test_inserts_new_row(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.set_book_status(
+            book_id=book_id, status=STATUS_READING, updated_at="2026-05-26T10:00:00+00:00"
+        )
+        status = catalog.get_book_status(book_id)
+        assert status == BookStatus(
+            book_id=book_id, status=STATUS_READING, updated_at="2026-05-26T10:00:00+00:00"
+        )
+
+    def test_overwrites_existing_row(self, catalog: LibraryCatalog) -> None:
+        # Differs from seed_book_status_if_absent — the user path must overwrite.
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.set_book_status(
+            book_id=book_id, status=STATUS_READING, updated_at="2026-05-26T10:00:00+00:00"
+        )
+        catalog.set_book_status(
+            book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T11:00:00+00:00"
+        )
+        status = catalog.get_book_status(book_id)
+        assert status is not None
+        assert status.status == STATUS_FINISHED
+        assert status.updated_at == "2026-05-26T11:00:00+00:00"
+
+    def test_idempotent_when_called_twice_same_values(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.set_book_status(
+            book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T10:00:00+00:00"
+        )
+        catalog.set_book_status(
+            book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T10:00:00+00:00"
+        )
+        status = catalog.get_book_status(book_id)
+        assert status is not None
+        assert status.status == STATUS_FINISHED
+
+    def test_raises_on_unknown_book(self, catalog: LibraryCatalog) -> None:
+        with pytest.raises(ValueError, match="999"):
+            catalog.set_book_status(
+                book_id=999, status=STATUS_READING, updated_at="2026-05-26T10:00:00+00:00"
+            )
+
+
+class TestGetBookStatus:
+    def test_returns_none_when_no_row(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        assert catalog.get_book_status(book_id) is None
+
+    def test_returns_none_for_unknown_book(self, catalog: LibraryCatalog) -> None:
+        # No row in books table — get_book_status just queries book_status so
+        # the result is the same as a known-book-with-no-status: None.
+        assert catalog.get_book_status(999) is None
+
+
+class TestGetBookStatuses:
+    def test_returns_empty_for_empty_input(self, catalog: LibraryCatalog) -> None:
+        assert catalog.get_book_statuses([]) == {}
+
+    def test_returns_only_books_with_status_rows(self, catalog: LibraryCatalog) -> None:
+        a = _add_book(catalog, "A", "ha")
+        b = _add_book(catalog, "B", "hb")
+        c = _add_book(catalog, "C", "hc")
+        catalog.set_book_status(book_id=a, status=STATUS_READING, updated_at="t1")
+        catalog.set_book_status(book_id=c, status=STATUS_FINISHED, updated_at="t2")
+
+        result = catalog.get_book_statuses([a, b, c])
+
+        assert set(result.keys()) == {a, c}
+        assert result[a].status == STATUS_READING
+        assert result[c].status == STATUS_FINISHED
+
+    def test_unknown_ids_silently_skipped(self, catalog: LibraryCatalog) -> None:
+        a = _add_book(catalog, "A", "ha")
+        catalog.set_book_status(book_id=a, status=STATUS_READING, updated_at="t1")
+        result = catalog.get_book_statuses([a, 999])
+        assert set(result.keys()) == {a}
+
+
+class TestListBooksByStatus:
+    def test_returns_books_matching_status(self, catalog: LibraryCatalog) -> None:
+        a = _add_book(catalog, "A finished", "ha")
+        b = _add_book(catalog, "B reading", "hb")
+        c = _add_book(catalog, "C finished", "hc")
+        catalog.set_book_status(book_id=a, status=STATUS_FINISHED, updated_at="t1")
+        catalog.set_book_status(book_id=b, status=STATUS_READING, updated_at="t2")
+        catalog.set_book_status(book_id=c, status=STATUS_FINISHED, updated_at="t3")
+
+        finished = catalog.list_books_by_status(STATUS_FINISHED)
+        finished_ids = {r.id for r in finished}
+        assert finished_ids == {a, c}
+
+        reading = catalog.list_books_by_status(STATUS_READING)
+        assert {r.id for r in reading} == {b}
+
+    def test_ordered_by_title(self, catalog: LibraryCatalog) -> None:
+        b = _add_book(catalog, "Beta", "hb")
+        a = _add_book(catalog, "Alpha", "ha")
+        catalog.set_book_status(book_id=a, status=STATUS_FINISHED, updated_at="t1")
+        catalog.set_book_status(book_id=b, status=STATUS_FINISHED, updated_at="t2")
+        result = catalog.list_books_by_status(STATUS_FINISHED)
+        assert [r.metadata.title for r in result] == ["Alpha", "Beta"]
+
+    def test_status_with_no_matches_returns_empty(self, catalog: LibraryCatalog) -> None:
+        _add_book(catalog, "A", "ha")
+        assert catalog.list_books_by_status(STATUS_FINISHED) == []
+
+
+class TestListBooksUnread:
+    def test_returns_books_with_no_status_row(self, catalog: LibraryCatalog) -> None:
+        a = _add_book(catalog, "A no-row", "ha")
+        b = _add_book(catalog, "B reading", "hb")
+        catalog.set_book_status(book_id=b, status=STATUS_READING, updated_at="t")
+        result = catalog.list_books_unread()
+        assert {r.id for r in result} == {a}
+
+    def test_includes_books_with_status_zero(self, catalog: LibraryCatalog) -> None:
+        a = _add_book(catalog, "A no-row", "ha")
+        b = _add_book(catalog, "B explicit-unread", "hb")
+        c = _add_book(catalog, "C reading", "hc")
+        catalog.set_book_status(book_id=b, status=STATUS_UNREAD, updated_at="t")
+        catalog.set_book_status(book_id=c, status=STATUS_READING, updated_at="t")
+        result = catalog.list_books_unread()
+        assert {r.id for r in result} == {a, b}
+
+    def test_ordered_by_title(self, catalog: LibraryCatalog) -> None:
+        _add_book(catalog, "Zulu", "hz")
+        _add_book(catalog, "Alpha", "ha")
+        result = catalog.list_books_unread()
+        assert [r.metadata.title for r in result] == ["Alpha", "Zulu"]
+
+
+class TestGetDeviceReadStateForBook:
+    def test_returns_none_when_no_device_row(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        assert catalog.get_device_read_state_for_book(book_id) is None
+
+    def test_joins_device_label_and_kind(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N428440071799", label="Mr. C's Libra", now="t0"
+        )
+        catalog.upsert_device_read_state(
+            device_id=device_id,
+            book_id=book_id,
+            read_status=STATUS_READING,
+            percent_read=0.47,
+            last_read_at="2026-05-21T14:02:00+00:00",
+            last_chapter_id=None,
+            status_updated_at="2026-05-21T14:02:00+00:00",
+            pulled_at="2026-05-26T10:00:00+00:00",
+        )
+
+        state = catalog.get_device_read_state_for_book(book_id)
+
+        assert state is not None
+        assert isinstance(state, DeviceReadState)
+        assert state.device_kind == "kobo"
+        assert state.device_label == "Mr. C's Libra"
+        assert state.read_status == STATUS_READING
+        assert state.percent_read == 0.47
+        assert state.last_read_at == "2026-05-21T14:02:00+00:00"
+
+    def test_returns_most_recent_when_multiple_devices(self, catalog: LibraryCatalog) -> None:
+        # If two devices each have a row for the same book, return the most
+        # recently updated one — that's what the user is actively reading.
+        book_id = _add_book(catalog, "Rose", "h1")
+        old = catalog.upsert_device(kind="kobo", serial="OLD", label="Old", now="t0")
+        new = catalog.upsert_device(kind="kobo", serial="NEW", label="New", now="t0")
+        catalog.upsert_device_read_state(
+            device_id=old,
+            book_id=book_id,
+            read_status=STATUS_READING,
+            percent_read=0.10,
+            last_read_at="2026-05-01T00:00:00+00:00",
+            last_chapter_id=None,
+            status_updated_at="2026-05-01T00:00:00+00:00",
+            pulled_at="2026-05-26T10:00:00+00:00",
+        )
+        catalog.upsert_device_read_state(
+            device_id=new,
+            book_id=book_id,
+            read_status=STATUS_FINISHED,
+            percent_read=1.0,
+            last_read_at="2026-05-20T00:00:00+00:00",
+            last_chapter_id=None,
+            status_updated_at="2026-05-20T00:00:00+00:00",
+            pulled_at="2026-05-26T10:00:00+00:00",
+        )
+        state = catalog.get_device_read_state_for_book(book_id)
+        assert state is not None
+        assert state.device_label == "New"
+        assert state.read_status == STATUS_FINISHED

--- a/tests/unit/test_status_cmd_bulk_parser.py
+++ b/tests/unit/test_status_cmd_bulk_parser.py
@@ -1,0 +1,54 @@
+# ABOUTME: Unit tests for the parse_bulk_ids helper used by `bookery read --bulk-from`.
+# ABOUTME: Covers blank-line, comment, whitespace, and bad-ID handling rules.
+
+import pytest
+
+from bookery.cli.commands.status_cmd import parse_bulk_ids
+
+
+class TestParseBulkIds:
+    def test_simple_ids_one_per_line(self) -> None:
+        assert parse_bulk_ids("1\n2\n3\n") == [1, 2, 3]
+
+    def test_skips_blank_lines(self) -> None:
+        assert parse_bulk_ids("1\n\n2\n\n\n3\n") == [1, 2, 3]
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_bulk_ids("  1  \n\t 2\n3\t\n") == [1, 2, 3]
+
+    def test_skips_full_line_comments(self) -> None:
+        text = "# import wave 1\n1\n# wave 2\n2\n3\n"
+        assert parse_bulk_ids(text) == [1, 2, 3]
+
+    def test_skips_indented_comments(self) -> None:
+        # A line that's whitespace then '#' is still a comment.
+        text = "1\n   # interlude\n2\n"
+        assert parse_bulk_ids(text) == [1, 2]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert parse_bulk_ids("") == []
+        assert parse_bulk_ids("\n\n\n") == []
+        assert parse_bulk_ids("# only comments\n# nothing else\n") == []
+
+    def test_bad_id_raises_with_line_number_and_content(self) -> None:
+        # Bad IDs surface the offending line so the user can fix the file
+        # rather than guess. Line numbers are 1-based to match editor reality.
+        text = "1\n2\nnot-an-id\n4\n"
+        with pytest.raises(ValueError) as exc:
+            parse_bulk_ids(text)
+        msg = str(exc.value)
+        assert "3" in msg  # line number
+        assert "not-an-id" in msg  # offending content
+
+    def test_negative_id_rejected(self) -> None:
+        # Book IDs are positive autoincrement; a negative value is a typo.
+        with pytest.raises(ValueError):
+            parse_bulk_ids("1\n-3\n")
+
+    def test_zero_id_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            parse_bulk_ids("1\n0\n")
+
+    def test_floating_point_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            parse_bulk_ids("1\n2.5\n")

--- a/tests/unit/test_status_module.py
+++ b/tests/unit/test_status_module.py
@@ -1,0 +1,86 @@
+# ABOUTME: Unit tests for db/status.py — read-status constants and dataclasses.
+# ABOUTME: Pins the integer mapping shared by CLI, catalog, and web.
+
+import dataclasses
+
+import pytest
+
+from bookery.db.status import (
+    STATUS_FINISHED,
+    STATUS_READING,
+    STATUS_UNREAD,
+    BookStatus,
+    DeviceReadState,
+    status_name,
+)
+
+
+class TestStatusConstants:
+    def test_status_integers_match_kobo_mapping(self) -> None:
+        # KoboContentRow.read_status uses 0=unread, 1=reading, 2=finished.
+        # We mirror that mapping verbatim so the catalog write path never
+        # has to remap integers between layers.
+        assert STATUS_UNREAD == 0
+        assert STATUS_READING == 1
+        assert STATUS_FINISHED == 2
+
+
+class TestStatusName:
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            (STATUS_UNREAD, "Unread"),
+            (STATUS_READING, "Reading"),
+            (STATUS_FINISHED, "Finished"),
+        ],
+    )
+    def test_known_statuses_have_human_names(self, status: int, expected: str) -> None:
+        assert status_name(status) == expected
+
+    def test_unknown_status_returns_neutral_label(self) -> None:
+        # A future schema bump could add new values; rendering shouldn't crash.
+        assert status_name(99) == "Unknown"
+
+
+class TestBookStatus:
+    def test_book_status_holds_fields(self) -> None:
+        s = BookStatus(book_id=42, status=STATUS_READING, updated_at="2026-05-26T10:00:00+00:00")
+        assert s.book_id == 42
+        assert s.status == STATUS_READING
+        assert s.updated_at == "2026-05-26T10:00:00+00:00"
+
+    def test_book_status_is_frozen(self) -> None:
+        s = BookStatus(book_id=1, status=STATUS_READING, updated_at="t")
+        with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+            s.status = STATUS_FINISHED  # type: ignore[misc]
+
+
+class TestDeviceReadState:
+    def test_device_read_state_holds_all_fields(self) -> None:
+        d = DeviceReadState(
+            device_id=1,
+            device_kind="kobo",
+            device_label="Mr. C's Libra",
+            book_id=42,
+            read_status=STATUS_READING,
+            percent_read=0.47,
+            last_read_at="2026-05-21T14:02:00+00:00",
+            status_updated_at="2026-05-21T14:02:00+00:00",
+        )
+        assert d.device_kind == "kobo"
+        assert d.device_label == "Mr. C's Libra"
+        assert d.percent_read == 0.47
+
+    def test_device_read_state_label_optional(self) -> None:
+        d = DeviceReadState(
+            device_id=1,
+            device_kind="kobo",
+            device_label=None,
+            book_id=42,
+            read_status=STATUS_UNREAD,
+            percent_read=None,
+            last_read_at=None,
+            status_updated_at="2026-05-26T10:00:00+00:00",
+        )
+        assert d.device_label is None
+        assert d.percent_read is None

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -59,6 +59,9 @@ def mock_catalog():
     catalog.get_by_id.return_value = None
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
+    catalog.get_book_statuses.return_value = {}
+    catalog.get_book_status.return_value = None
+    catalog.get_device_read_state_for_book.return_value = None
     return catalog
 
 

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -120,6 +120,9 @@ def mock_catalog():
     catalog.get_by_id.return_value = None
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
+    catalog.get_book_statuses.return_value = {}
+    catalog.get_book_status.return_value = None
+    catalog.get_device_read_state_for_book.return_value = None
     return catalog
 
 

--- a/tests/web/test_detail_reading.py
+++ b/tests/web/test_detail_reading.py
@@ -1,0 +1,113 @@
+# ABOUTME: Tests for the Reading section on the book detail page.
+# ABOUTME: Section renders when book_status or device_read_state exists; hidden otherwise.
+
+from bookery.db.status import (
+    STATUS_FINISHED,
+    STATUS_READING,
+    BookStatus,
+    DeviceReadState,
+)
+
+from .conftest import make_book
+
+
+class TestDetailReadingSection:
+    def test_renders_when_book_status_present(self, mock_catalog, client) -> None:
+        book = make_book(1, title="Sample")
+        mock_catalog.get_by_id.return_value = book
+        mock_catalog.get_book_status.return_value = BookStatus(
+            book_id=1, status=STATUS_FINISHED, updated_at="2026-05-26T10:00:00+00:00"
+        )
+        mock_catalog.get_device_read_state_for_book.return_value = None
+
+        response = client.get("/books/1")
+        html = response.data.decode()
+
+        assert 'id="detail-reading"' in html
+        assert "Status" in html
+        assert "Finished" in html
+
+    def test_renders_device_progress_and_last_opened(self, mock_catalog, client) -> None:
+        book = make_book(1, title="Sample")
+        mock_catalog.get_by_id.return_value = book
+        mock_catalog.get_book_status.return_value = BookStatus(
+            book_id=1, status=STATUS_READING, updated_at="t"
+        )
+        mock_catalog.get_device_read_state_for_book.return_value = DeviceReadState(
+            device_id=1,
+            device_kind="kobo",
+            device_label="Mr. C's Libra",
+            book_id=1,
+            read_status=STATUS_READING,
+            percent_read=0.47,
+            last_read_at="2026-05-21T14:02:00+00:00",
+            status_updated_at="2026-05-21T14:02:00+00:00",
+        )
+
+        response = client.get("/books/1")
+        html = response.data.decode()
+
+        assert "47%" in html
+        assert "2026-05-21T14:02:00+00:00" in html
+        assert "Kobo" in html
+        assert "Mr. C&#39;s Libra" in html or "Mr. C's Libra" in html
+
+    def test_section_absent_when_no_data(self, mock_catalog, client) -> None:
+        # Cleanly hidden — the regression criterion from the issue.
+        book = make_book(1, title="Untouched")
+        mock_catalog.get_by_id.return_value = book
+        mock_catalog.get_book_status.return_value = None
+        mock_catalog.get_device_read_state_for_book.return_value = None
+
+        response = client.get("/books/1")
+        html = response.data.decode()
+
+        assert "Untouched" in html
+        assert 'id="detail-reading"' not in html
+
+    def test_renders_device_only_when_no_book_status(
+        self, mock_catalog, client
+    ) -> None:
+        book = make_book(1, title="Just pulled")
+        mock_catalog.get_by_id.return_value = book
+        mock_catalog.get_book_status.return_value = None
+        mock_catalog.get_device_read_state_for_book.return_value = DeviceReadState(
+            device_id=1,
+            device_kind="kobo",
+            device_label=None,
+            book_id=1,
+            read_status=STATUS_READING,
+            percent_read=0.10,
+            last_read_at=None,
+            status_updated_at="t",
+        )
+
+        response = client.get("/books/1")
+        html = response.data.decode()
+
+        assert 'id="detail-reading"' in html
+        # Kind alone (no label) renders without parens.
+        assert "Kobo" in html
+        assert "(" not in html.split('id="detail-reading"')[1].split("</section>")[0]
+
+    def test_device_label_omitted_when_missing(self, mock_catalog, client) -> None:
+        book = make_book(1, title="No label")
+        mock_catalog.get_by_id.return_value = book
+        mock_catalog.get_book_status.return_value = BookStatus(
+            book_id=1, status=STATUS_READING, updated_at="t"
+        )
+        mock_catalog.get_device_read_state_for_book.return_value = DeviceReadState(
+            device_id=1,
+            device_kind="kobo",
+            device_label=None,
+            book_id=1,
+            read_status=STATUS_READING,
+            percent_read=None,
+            last_read_at=None,
+            status_updated_at="t",
+        )
+
+        response = client.get("/books/1")
+        html = response.data.decode()
+
+        assert "Kobo" in html

--- a/tests/web/test_detail_reading.py
+++ b/tests/web/test_detail_reading.py
@@ -65,9 +65,7 @@ class TestDetailReadingSection:
         assert "Untouched" in html
         assert 'id="detail-reading"' not in html
 
-    def test_renders_device_only_when_no_book_status(
-        self, mock_catalog, client
-    ) -> None:
+    def test_renders_device_only_when_no_book_status(self, mock_catalog, client) -> None:
         book = make_book(1, title="Just pulled")
         mock_catalog.get_by_id.return_value = book
         mock_catalog.get_book_status.return_value = None

--- a/tests/web/test_list_status_chip.py
+++ b/tests/web/test_list_status_chip.py
@@ -64,9 +64,7 @@ class TestListStatusChip:
         assert "Marked Unread" in html
         assert "book-status-chip" not in html
 
-    def test_route_calls_get_book_statuses_with_visible_ids(
-        self, mock_catalog, client
-    ) -> None:
+    def test_route_calls_get_book_statuses_with_visible_ids(self, mock_catalog, client) -> None:
         books = [make_book(i, title=f"B{i}") for i in (1, 2, 3)]
         _stub_browse(mock_catalog, books=books, total=3)
         mock_catalog.get_book_statuses.return_value = {}

--- a/tests/web/test_list_status_chip.py
+++ b/tests/web/test_list_status_chip.py
@@ -1,0 +1,90 @@
+# ABOUTME: Tests for the read-status chip on the book list view.
+# ABOUTME: Verifies chip renders per-book status; books without status get no chip.
+
+from bookery.db.status import STATUS_FINISHED, STATUS_READING, STATUS_UNREAD, BookStatus
+
+from .conftest import make_book
+
+
+def _stub_browse(mock_catalog, *, books, total):
+    mock_catalog.browse.return_value = (books, total)
+
+
+class TestListStatusChip:
+    def test_reading_book_renders_reading_chip(self, mock_catalog, client) -> None:
+        book = make_book(1, title="In Progress")
+        _stub_browse(mock_catalog, books=[book], total=1)
+        mock_catalog.get_book_statuses.return_value = {
+            1: BookStatus(book_id=1, status=STATUS_READING, updated_at="2026-05-26T00:00:00+00:00")
+        }
+
+        response = client.get("/books")
+        html = response.data.decode()
+
+        assert "book-status-chip" in html
+        assert "status-reading" in html
+        assert 'title="Reading"' in html
+
+    def test_finished_book_renders_finished_chip(self, mock_catalog, client) -> None:
+        book = make_book(2, title="Done Reading")
+        _stub_browse(mock_catalog, books=[book], total=1)
+        mock_catalog.get_book_statuses.return_value = {
+            2: BookStatus(book_id=2, status=STATUS_FINISHED, updated_at="t")
+        }
+
+        response = client.get("/books")
+        html = response.data.decode()
+
+        assert "status-finished" in html
+        assert 'title="Finished"' in html
+
+    def test_unread_book_renders_no_chip(self, mock_catalog, client) -> None:
+        book = make_book(3, title="Untouched")
+        _stub_browse(mock_catalog, books=[book], total=1)
+        mock_catalog.get_book_statuses.return_value = {}
+
+        response = client.get("/books")
+        html = response.data.decode()
+
+        # The book's title still renders; absent chip = no class string anywhere.
+        assert "Untouched" in html
+        assert "book-status-chip" not in html
+
+    def test_explicit_unread_status_renders_no_chip(self, mock_catalog, client) -> None:
+        # status=0 is the explicit unread state — still no chip per spec.
+        book = make_book(4, title="Marked Unread")
+        _stub_browse(mock_catalog, books=[book], total=1)
+        mock_catalog.get_book_statuses.return_value = {
+            4: BookStatus(book_id=4, status=STATUS_UNREAD, updated_at="t")
+        }
+
+        response = client.get("/books")
+        html = response.data.decode()
+
+        assert "Marked Unread" in html
+        assert "book-status-chip" not in html
+
+    def test_route_calls_get_book_statuses_with_visible_ids(
+        self, mock_catalog, client
+    ) -> None:
+        books = [make_book(i, title=f"B{i}") for i in (1, 2, 3)]
+        _stub_browse(mock_catalog, books=books, total=3)
+        mock_catalog.get_book_statuses.return_value = {}
+
+        client.get("/books")
+
+        mock_catalog.get_book_statuses.assert_called_once()
+        called_with = mock_catalog.get_book_statuses.call_args[0][0]
+        assert sorted(called_with) == [1, 2, 3]
+
+    def test_empty_page_skips_status_query(self, mock_catalog, client) -> None:
+        _stub_browse(mock_catalog, books=[], total=0)
+        mock_catalog.get_book_statuses.return_value = {}
+
+        client.get("/books")
+
+        # On an empty library we shouldn't burn a SQL query asking about
+        # statuses for zero books — the catalog method handles this too,
+        # but the route should be considerate.
+        if mock_catalog.get_book_statuses.called:
+            assert mock_catalog.get_book_statuses.call_args[0][0] == []


### PR DESCRIPTION
## Summary

P1b makes the catalog-side read-status data from P1a (#180) visible and editable from bookery itself. The data was previously sitting in `book_status` and `device_read_state` with no way for the user to see or modify it.

## Changes

### CLI

- **`bookery read|unread|reading <id>`** — three sibling top-level commands that set catalog-side `book_status` to finished/unread/reading respectively.
- **`--bulk-from FILE`** — applies the same status to a list of book IDs (one per line; blank lines and `#`-comments skipped). Bulk mode warns-and-counts on unknown IDs; single-ID mode fails loudly.
- **`bookery ls --reading|--finished|--unread`** — filter the list by status. Mutually exclusive with each other.
- **`bookery info <id>`** — adds a "Reading" section showing status, progress, last opened, and device when data exists. Hidden cleanly when there's nothing to show.

### Web

- **List view** — small status chip next to each title: book emoji for *reading*, checkmark for *finished*, nothing for *unread*. One bulk query per page; no N+1.
- **Detail page** — new "Reading" section between Identity and File. Renders only when `book_status` or `device_read_state` has a row.

### Catalog API additions

- `set_book_status` (overwrites on conflict — the user path is authoritative)
- `get_book_status`, `get_book_statuses` (bulk for the list view)
- `list_books_by_status`, `list_books_unread`
- `get_device_read_state_for_book` (JOINs `devices` for label/kind)

### Shared

- `bookery/db/status.py` — `STATUS_UNREAD/READING/FINISHED` constants matching `KoboContentRow.read_status`, plus `BookStatus` and `DeviceReadState` dataclasses and a `status_name` helper.

## Out of scope (deferred)

- Device push of catalog-side writes — that's **P2** (#182).
- Web toggles / bulk-mark in the web UI — **P3** (#183).
- Composing status filters with `--tag`/`--genre` in `ls` — current `ls` filters are mutually exclusive; adding composition requires the catalog query layer to learn filter composition first.
- The `--since` date filter shown as an aside in the issue — separate added flag.

## Testing

- [x] Unit tests for db/status module (9)
- [x] Unit tests for catalog read/write methods (18)
- [x] Unit tests for `--bulk-from` parser (10)
- [x] E2E CLI tests (13) — full lifecycle: import → read/unread/reading → info → ls filters
- [x] Web tests for list status chip (6)
- [x] Web tests for detail Reading section (5)
- [x] Full suite passes: 1759 tests
- [x] Ruff lint + format clean
- [x] Manual smoke test: CLI commands end-to-end + web chip renders + detail Reading section renders

## Related Issues

Closes #181

Builds on P1a (#180). Parent epic: #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)