### PR TITLE
Add #182: Push read-status from bookery to Kobo (P2)

### DIFF
--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -27,6 +27,40 @@ from bookery.device.kobo import detect_mounted_kobo, sync_library_to_kobo
 console = Console()
 
 
+def _print_status_summary(report) -> None:  # type: ignore[no-untyped-def]
+    """Render the device-side read-status portion of the sync report.
+
+    Each line is only printed if the corresponding counter is non-zero, so a
+    typical sync without status changes stays quiet. Backup path is shown
+    whenever a snapshot was taken (i.e. a push actually ran) regardless of
+    the push outcome — the user wants to know where the safety net is.
+    """
+    if report.read_states_pulled or report.read_states_skipped:
+        console.print(
+            f"[dim]Read-state: pulled {report.read_states_pulled}, "
+            f"skipped {report.read_states_skipped}[/dim]"
+        )
+    if report.read_statuses_pushed or report.read_status_pull_only:
+        console.print(
+            f"[green]Pushed {report.read_statuses_pushed} read-status update(s)"
+            f"[/green]"
+            + (
+                f" [dim](pull-only: {report.read_status_pull_only})[/dim]"
+                if report.read_status_pull_only
+                else ""
+            )
+        )
+    if report.backup_path is not None:
+        console.print(f"[dim]Backup: {report.backup_path}[/dim]")
+    if report.read_status_push_failed:
+        console.print(
+            f"[yellow]Read-status push failed for "
+            f"{len(report.read_status_push_failed)} book(s):[/yellow]"
+        )
+        for content_id, reason in report.read_status_push_failed:
+            console.print(f"  [yellow]- {content_id}: {reason}[/yellow]")
+
+
 @click.group("sync")
 def sync() -> None:
     """Sync the library to a connected device."""
@@ -46,6 +80,13 @@ def sync() -> None:
     help="Show what would be copied without touching the device.",
 )
 @click.option(
+    "--no-status-push",
+    "no_status_push",
+    is_flag=True,
+    default=False,
+    help="Skip writing read-status back to the device — pulls and copies still run.",
+)
+@click.option(
     "--data-dir",
     "data_dir_override",
     type=click.Path(path_type=Path),
@@ -56,6 +97,7 @@ def sync() -> None:
 def sync_kobo(
     target: Path | None,
     dry_run: bool,
+    no_status_push: bool,
     data_dir_override: Path | None,
     db_path: Path | None,
 ) -> None:
@@ -85,6 +127,7 @@ def sync_kobo(
     data_dir = data_dir_override or get_data_dir()
     cache = KepubCache(data_dir / "kepub_cache.db")
     workspace_dir = data_dir / "sync-workspace"
+    backup_root = data_dir / "backups"
 
     _stage_label = {
         "hash": "hashing",
@@ -150,6 +193,8 @@ def sync_kobo(
                     dry_run=dry_run,
                     on_progress=_on_progress,
                     on_stage=_on_stage,
+                    backup_root=backup_root,
+                    status_push_enabled=not no_status_push,
                 )
                 overall.update(overall_task, completed=overall.tasks[0].total or 0)
             except DeviceError as exc:
@@ -161,6 +206,9 @@ def sync_kobo(
     label = "Would copy" if dry_run else "Copied"
     if not report.copied and not report.skipped and not report.failed:
         console.print("[dim]No books to sync.[/dim]")
+        # Even an empty copy report should surface a successful push if one
+        # happened — the user wants to see what changed on the device.
+        _print_status_summary(report)
         return
 
     if report.copied:
@@ -171,6 +219,7 @@ def sync_kobo(
         console.print(f"[dim]Skipped {len(report.skipped)}:[/dim]")
         for path, reason in report.skipped:
             console.print(f"  [dim]- {path.name}: {reason}[/dim]")
+    _print_status_summary(report)
     if report.failed:
         # Per-book failures are reported but don't fail the command — a stale
         # catalog entry or a single un-convertible EPUB shouldn't block a sync

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -17,7 +17,7 @@ from bookery.db.mapping import (
     metadata_to_row,
     row_to_record,
 )
-from bookery.db.status import BookStatus, DeviceReadState
+from bookery.db.status import BookStatus, DeviceReadState, PushCandidate
 from bookery.metadata.genres import is_canonical_genre
 from bookery.metadata.types import BookMetadata
 
@@ -1074,3 +1074,45 @@ class LibraryCatalog:
             last_read_at=row["last_read_at"],
             status_updated_at=str(row["status_updated_at"]),
         )
+
+    def list_push_candidates(self, *, device_id: int) -> list[PushCandidate]:
+        """Return rows the sync orchestrator can consider for a device push.
+
+        A candidate has both a catalog ``book_status`` row (so we know what
+        the user wants) and a ``device_files`` row for this device (so we
+        know which ContentID to write to). ``device_read_state`` is a LEFT
+        JOIN — books the device has never reported a read for still show
+        up with ``device_status_updated_at = None`` so the orchestrator can
+        push the catalog's intent unconditionally.
+        """
+        cursor = self._conn.execute(
+            """
+            SELECT
+                df.book_id,
+                df.remote_path,
+                bs.status AS catalog_status,
+                bs.updated_at AS catalog_updated_at,
+                drs.status_updated_at AS device_status_updated_at
+            FROM device_files AS df
+            JOIN book_status AS bs ON bs.book_id = df.book_id
+            LEFT JOIN device_read_state AS drs
+                ON drs.book_id = df.book_id AND drs.device_id = df.device_id
+            WHERE df.device_id = ?
+            ORDER BY df.book_id
+            """,
+            (device_id,),
+        )
+        return [
+            PushCandidate(
+                book_id=int(row["book_id"]),
+                remote_path=str(row["remote_path"]),
+                catalog_status=int(row["catalog_status"]),
+                catalog_updated_at=str(row["catalog_updated_at"]),
+                device_status_updated_at=(
+                    str(row["device_status_updated_at"])
+                    if row["device_status_updated_at"] is not None
+                    else None
+                ),
+            )
+            for row in cursor.fetchall()
+        ]

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -904,6 +904,42 @@ class LibraryCatalog:
         )
         self._conn.commit()
 
+    def merge_book_status_from_device(
+        self,
+        *,
+        book_id: int,
+        device_status: int,
+        device_updated_at: str,
+    ) -> None:
+        """Merge a device-side status into ``book_status`` using last-writer-wins.
+
+        Overwrites the catalog row iff the device timestamp is greater than
+        or equal to the catalog's existing ``updated_at`` (or the catalog has
+        no row yet). The ``>=`` tiebreak comes from the #178 sync model: when
+        two timestamps match exactly we let the device win, which keeps the
+        two sides consistent without an extra "are these really the same"
+        check. This replaces ``seed_book_status_if_absent`` for P2 — the pull
+        now respects user intent only when the catalog timestamp is strictly
+        newer, not whenever the user happened to touch the book first.
+        """
+        existing = self._conn.execute(
+            "SELECT updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        if existing is not None and str(existing["updated_at"]) > device_updated_at:
+            return
+        self._conn.execute(
+            """
+            INSERT INTO book_status (book_id, status, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(book_id) DO UPDATE SET
+                status = excluded.status,
+                updated_at = excluded.updated_at
+            """,
+            (book_id, device_status, device_updated_at),
+        )
+        self._conn.commit()
+
     def set_book_status(self, *, book_id: int, status: int, updated_at: str) -> None:
         """Upsert book_status for the user-write path.
 

--- a/src/bookery/db/status.py
+++ b/src/bookery/db/status.py
@@ -54,3 +54,21 @@ class DeviceReadState:
     percent_read: float | None
     last_read_at: str | None
     status_updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class PushCandidate:
+    """A book that *might* need its status pushed to the device.
+
+    Produced by ``LibraryCatalog.list_push_candidates`` — one row per
+    (device, book) with both a catalog status and a known on-device file.
+    The orchestrator compares ``catalog_updated_at`` against
+    ``device_status_updated_at`` to decide whether this candidate actually
+    becomes a push, a no-op, or a pull-direction merge.
+    """
+
+    book_id: int
+    remote_path: str
+    catalog_status: int
+    catalog_updated_at: str
+    device_status_updated_at: str | None

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -15,7 +15,10 @@ from typing import Protocol
 from bookery.core.pathformat import sanitize_component
 from bookery.db.hashing import compute_file_hash
 from bookery.db.mapping import BookRecord
+from bookery.db.status import PushCandidate
+from bookery.device.kobo_backup import backup_kobo_db
 from bookery.device.kobo_reader import pull_read_state, read_kobo_serial
+from bookery.device.kobo_writer import ReadStatusUpdate, push_read_status
 
 KOBO_MARKER = ".kobo"
 
@@ -92,6 +95,15 @@ class SyncReport:
     failed: list[tuple[Path, str]] = field(default_factory=list)
     read_states_pulled: int = 0
     read_states_skipped: int = 0
+    # P2: device-side write counts. ``read_statuses_pushed`` is rows we
+    # actually mutated on the Kobo; ``read_status_pull_only`` is push
+    # candidates whose ContentID didn't match a current device row (book
+    # copied this sync but not yet indexed by firmware); ``read_status_push_failed``
+    # is (content_id, error_message) pairs from a rollback scenario.
+    read_statuses_pushed: int = 0
+    read_status_pull_only: int = 0
+    read_status_push_failed: list[tuple[str, str]] = field(default_factory=list)
+    backup_path: Path | None = None
 
 
 class _CatalogProto(Protocol):
@@ -120,9 +132,11 @@ class _CatalogProto(Protocol):
         pulled_at: str,
     ) -> None: ...
 
-    def seed_book_status_if_absent(
-        self, *, book_id: int, status: int, updated_at: str
+    def merge_book_status_from_device(
+        self, *, book_id: int, device_status: int, device_updated_at: str
     ) -> None: ...
+
+    def list_push_candidates(self, *, device_id: int) -> list[PushCandidate]: ...
 
 
 class _CacheProto(Protocol):
@@ -229,6 +243,89 @@ def _sync_record(
         )
 
 
+def _build_push_updates(candidates: list[PushCandidate]) -> list[ReadStatusUpdate]:
+    """Filter push candidates down to the ones the catalog wins for.
+
+    A candidate becomes a push when the catalog's ``updated_at`` is strictly
+    greater than the device's ``status_updated_at`` (or the device has no row
+    for the book at all). Equal-or-older candidates are dropped — the pull
+    half already converged those rows via :func:`merge_book_status_from_device`.
+    Returns ``ReadStatusUpdate`` instances keyed on the device ContentID,
+    which is ``file://`` + ``remote_path``.
+    """
+    updates: list[ReadStatusUpdate] = []
+    for cand in candidates:
+        if (
+            cand.device_status_updated_at is not None
+            and cand.catalog_updated_at <= cand.device_status_updated_at
+        ):
+            continue
+        content_id = f"file://{cand.remote_path}"
+        updates.append(
+            ReadStatusUpdate(content_id=content_id, status=cand.catalog_status)
+        )
+    return updates
+
+
+def _push_read_state(
+    *,
+    catalog: _CatalogProto,
+    device_id: int,
+    target: Path,
+    serial: str,
+    backup_root: Path | None,
+    report: SyncReport,
+) -> None:
+    """Apply catalog-side status to the device DB.
+
+    Runs after the kepub copy phase so ``device_files`` reflects the books
+    actually on the device. Builds a push list via
+    :func:`_build_push_updates`, takes a backup snapshot if there's anything
+    to write, then hands off to :func:`push_read_status`. All failures are
+    swallowed into the report rather than raised — the pull half of the
+    sync has already done useful work and we don't want to throw it away.
+    """
+    try:
+        candidates = catalog.list_push_candidates(device_id=device_id)
+    except Exception as exc:
+        logger.warning("Could not list push candidates: %s", exc)
+        return
+    updates = _build_push_updates(candidates)
+    if not updates:
+        return
+
+    db_path = target / ".kobo" / "KoboReader.sqlite"
+    if not db_path.exists():
+        logger.warning(
+            "KoboReader.sqlite not found at %s; skipping read-status push", db_path
+        )
+        return
+
+    if backup_root is not None:
+        report.backup_path = backup_kobo_db(
+            source_db=db_path,
+            backup_root=backup_root,
+            device_serial=serial,
+            now=_dt.datetime.now(_dt.UTC),
+        )
+
+    try:
+        push = push_read_status(
+            db_path=db_path,
+            updates=updates,
+            now=_now_iso,
+        )
+    except Exception as exc:
+        logger.warning("Read-status push failed: %s", exc)
+        report.read_status_push_failed = [
+            (upd.content_id, str(exc)) for upd in updates
+        ]
+        return
+    report.read_statuses_pushed = push.pushed_count
+    report.read_status_pull_only = push.pull_only_count
+    report.read_status_push_failed = list(push.failed)
+
+
 def sync_library_to_kobo(
     *,
     catalog: _CatalogProto,
@@ -241,6 +338,8 @@ def sync_library_to_kobo(
     dry_run: bool = False,
     on_progress: ProgressCallback | None = None,
     on_stage: StageCallback | None = None,
+    backup_root: Path | None = None,
+    status_push_enabled: bool = True,
 ) -> SyncReport:
     """Walk the catalog and mirror its EPUBs to a Kobo as .kepub.epub files.
 
@@ -279,10 +378,12 @@ def sync_library_to_kobo(
     now = _now_iso()
 
     # Device identity + read-state pull happen before the kepub loop so the
-    # device DB is read in a clean (pre-write) window. Both steps are
-    # best-effort — a missing `.kobo/version` or unreadable KoboReader.sqlite
-    # logs a warning but never aborts the kepub copy half of the sync.
+    # device DB is read in a clean (pre-write) window. All three phases
+    # (pull / copy / push) are best-effort — a missing `.kobo/version` or
+    # unreadable KoboReader.sqlite logs a warning but never aborts the
+    # kepub copy half of the sync.
     device_id: int | None = None
+    serial: str | None = None
     try:
         serial = read_kobo_serial(target)
     except FileNotFoundError:
@@ -290,7 +391,7 @@ def sync_library_to_kobo(
             "%s/.kobo/version not found; skipping device-state pull",
             target,
         )
-    else:
+    if serial is not None:
         device_id = catalog.upsert_device(kind="kobo", serial=serial, label=None, now=now)
         try:
             pulled, skipped = pull_read_state(
@@ -323,5 +424,15 @@ def sync_library_to_kobo(
         if workspace_dir.exists():
             with contextlib.suppress(OSError):
                 workspace_dir.rmdir()
+
+    if status_push_enabled and device_id is not None and serial is not None:
+        _push_read_state(
+            catalog=catalog,
+            device_id=device_id,
+            target=target,
+            serial=serial,
+            backup_root=backup_root,
+            report=report,
+        )
 
     return report

--- a/src/bookery/device/kobo_backup.py
+++ b/src/bookery/device/kobo_backup.py
@@ -1,0 +1,93 @@
+# ABOUTME: Snapshot KoboReader.sqlite before any mutating sync — one file per
+# ABOUTME: device per day, with rotation to the 14 most recent. Cheap and quiet.
+
+import datetime as _dt
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Keep two weeks of daily snapshots per device. Bounded but generous; a Kobo
+# DB is small enough (a few MB) that 14 files won't fill the user's disk.
+ROTATION_KEEP = 14
+
+
+def backup_kobo_db(
+    *,
+    source_db: Path,
+    backup_root: Path,
+    device_serial: str,
+    now: _dt.datetime,
+) -> Path | None:
+    """Copy KoboReader.sqlite to ``<backup_root>/<serial>/<YYYY-MM-DD>-<HHMMSS>.sqlite``.
+
+    Idempotent per device-day: if any snapshot from today already exists, the
+    function returns its path and does not re-copy — the contract is "first
+    mutating sync per device-day takes the snapshot", not "every sync takes
+    one". This keeps the backup dir uncluttered when the user syncs multiple
+    times an hour.
+
+    Rotation: after writing, prunes everything older than the 14 most recent
+    files in the device's directory. Best-effort throughout — a missing
+    source file, a corrupted backup dir, or an OS error logs a warning and
+    returns ``None`` rather than blocking the sync.
+    """
+    if not source_db.exists():
+        logger.warning("Skipping Kobo DB backup: source missing at %s", source_db)
+        return None
+
+    device_dir = backup_root / device_serial
+    try:
+        device_dir.mkdir(parents=True, exist_ok=True)
+    except (NotADirectoryError, FileExistsError, OSError) as exc:
+        logger.warning(
+            "Could not prepare backup dir at %s: %s", device_dir, exc
+        )
+        return None
+
+    # Same-day idempotency: any file whose name starts with today's date
+    # short-circuits the copy. We don't care about the time suffix — the
+    # earliest snapshot of the day is the one we want to preserve.
+    date_prefix = now.strftime("%Y-%m-%d")
+    try:
+        existing_today = sorted(
+            p for p in device_dir.iterdir() if p.name.startswith(date_prefix)
+        )
+    except OSError as exc:
+        logger.warning("Could not list backup dir %s: %s", device_dir, exc)
+        return None
+    if existing_today:
+        return existing_today[0]
+
+    stamp = now.strftime("%Y-%m-%d-%H%M%S")
+    dest = device_dir / f"{stamp}.sqlite"
+    try:
+        shutil.copyfile(source_db, dest)
+    except OSError as exc:
+        logger.warning("Could not write Kobo DB backup to %s: %s", dest, exc)
+        return None
+
+    _rotate(device_dir)
+    return dest
+
+
+def _rotate(device_dir: Path) -> None:
+    """Trim the device's backup directory to the ``ROTATION_KEEP`` most recent files.
+
+    Sorting by filename works because we stamp ``YYYY-MM-DD-HHMMSS`` which
+    is lexicographically ordered. Failures are swallowed — rotation is a
+    nice-to-have, not a blocking step.
+    """
+    try:
+        files = sorted(p for p in device_dir.iterdir() if p.is_file())
+    except OSError:
+        return
+    excess = len(files) - ROTATION_KEEP
+    if excess <= 0:
+        return
+    for old in files[:excess]:
+        try:
+            old.unlink()
+        except OSError as exc:
+            logger.warning("Could not rotate old backup %s: %s", old, exc)

--- a/src/bookery/device/kobo_reader.py
+++ b/src/bookery/device/kobo_reader.py
@@ -122,8 +122,12 @@ class _ReaderCatalogProto(Protocol):
         pulled_at: str,
     ) -> None: ...
 
-    def seed_book_status_if_absent(
-        self, *, book_id: int, status: int, updated_at: str
+    def merge_book_status_from_device(
+        self,
+        *,
+        book_id: int,
+        device_status: int,
+        device_updated_at: str,
     ) -> None: ...
 
 
@@ -139,6 +143,13 @@ def pull_read_state(
     Returns ``(pulled, skipped)`` — the number of rows whose ContentID
     resolved to a known book in our catalog, and the number that didn't
     (and were therefore ignored).
+
+    ``device_read_state`` is mirrored unconditionally — it always reflects
+    the device's most recent reality. ``book_status`` goes through the
+    timestamp-aware merge in :meth:`LibraryCatalog.merge_book_status_from_device`:
+    device-newer-or-equal overwrites catalog, catalog-newer keeps the user's
+    bookery read/unread/reading intent intact. The push half of the sync
+    (in :mod:`bookery.device.kobo`) handles the reverse direction.
 
     Best-effort: a missing or unreadable KoboReader.sqlite logs a warning and
     returns ``(0, 0)`` rather than raising — a Kobo with no read history yet
@@ -188,8 +199,10 @@ def pull_read_state(
             status_updated_at=status_updated_at,
             pulled_at=now,
         )
-        catalog.seed_book_status_if_absent(
-            book_id=book_id, status=row.read_status, updated_at=status_updated_at
+        catalog.merge_book_status_from_device(
+            book_id=book_id,
+            device_status=row.read_status,
+            device_updated_at=status_updated_at,
         )
         pulled += 1
     return (pulled, skipped)

--- a/src/bookery/device/kobo_writer.py
+++ b/src/bookery/device/kobo_writer.py
@@ -6,8 +6,51 @@
 # firmware 4.45.23684, 2026-05-26. ContentID format and writable columns below
 # were validated against a real device.
 
+import logging
 import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
+
+from bookery.db.status import STATUS_FINISHED, STATUS_READING, STATUS_UNREAD
+
+logger = logging.getLogger(__name__)
+
+
+# The writer touches only these columns on the device's ``content`` table.
+# Keeping this set tiny is a defensive boundary: if a refactor ever tries to
+# write ___SyncTime / ___UserID / Synced / etc., the build of the UPDATE
+# statement happens here and only here, so the allow-list is single-source.
+_ALLOWED_COLUMNS = frozenset({"ReadStatus", "___PercentRead", "DateLastRead"})
+
+
+@dataclass(frozen=True, slots=True)
+class ReadStatusUpdate:
+    """One row's worth of intent: push ``status`` for ``content_id``.
+
+    ``content_id`` is the exact KoboReader.sqlite ``ContentID`` value
+    (typically ``file:///mnt/onboard/Books/Author/Title.kepub.epub``).
+    ``status`` is one of ``STATUS_UNREAD``/``STATUS_READING``/``STATUS_FINISHED``.
+    """
+
+    content_id: str
+    status: int
+
+
+@dataclass
+class PushReport:
+    """Outcome of a ``push_read_status`` batch.
+
+    ``pushed_count`` is rows whose UPDATE actually changed a device row.
+    ``pull_only_count`` is rows whose ContentID had no match on the device
+    (e.g. a book bookery copied this sync that the firmware hasn't indexed
+    yet). ``failed`` is ContentID + error-message pairs from a rollback
+    scenario — present iff the transaction aborted.
+    """
+
+    pushed_count: int = 0
+    pull_only_count: int = 0
+    failed: list[tuple[str, str]] = field(default_factory=list)
 
 
 def open_kobo_db_rw(kobo_sqlite_path: Path) -> sqlite3.Connection:
@@ -22,3 +65,96 @@ def open_kobo_db_rw(kobo_sqlite_path: Path) -> sqlite3.Connection:
     """
     uri = f"file:{kobo_sqlite_path}?mode=rw"
     return sqlite3.connect(uri, uri=True)
+
+
+def _percent_for_status(status: int) -> float | None:
+    """Translate a status int into a ``___PercentRead`` value or None for skip.
+
+    Finished → 100.0; unread → 0.0; reading → None means "don't touch the
+    column at all" — the user might be mid-book and we don't want to clobber
+    the device's own percentage tracking with a guess.
+    """
+    if status == STATUS_FINISHED:
+        return 100.0
+    if status == STATUS_UNREAD:
+        return 0.0
+    if status == STATUS_READING:
+        return None
+    raise ValueError(f"Unsupported status int: {status}")
+
+
+def push_read_status(
+    *,
+    db_path: Path,
+    updates: list[ReadStatusUpdate],
+    now: Callable[[], str],
+) -> PushReport:
+    """Apply read-status updates to KoboReader.sqlite in a single transaction.
+
+    For each update we run an UPDATE keyed on ContentID, touching only the
+    columns in :data:`_ALLOWED_COLUMNS`. Every row pushed gets
+    ``DateLastRead = now()`` — this closes the "user opened the book after I
+    marked it" hole described in #178's sync model. ``___PercentRead`` follows
+    :func:`_percent_for_status`.
+
+    Single transaction: if any UPDATE raises ``sqlite3.Error`` the whole batch
+    rolls back (verified via file hash in tests), and the failure list comes
+    back to the caller so the sync report can surface which books didn't
+    make it. A row whose ContentID isn't on the device (UPDATE affects zero
+    rows) is *not* a failure — it just means the firmware hasn't indexed it
+    yet — so it lands in ``pull_only_count`` instead.
+    """
+    report = PushReport()
+    if not updates:
+        return report
+
+    timestamp = now()
+    conn = open_kobo_db_rw(db_path)
+    try:
+        # Explicit transaction so a mid-batch failure rolls back cleanly.
+        # sqlite3's default isolation already wraps DML, but BEGIN makes the
+        # intent obvious to readers and to the rollback path below.
+        conn.execute("BEGIN")
+        try:
+            for upd in updates:
+                percent = _percent_for_status(upd.status)
+                # Build the SET clause from the allow-list — never let column
+                # names from anywhere else into the SQL.
+                set_parts = ["ReadStatus = ?", "DateLastRead = ?"]
+                params: list[object] = [upd.status, timestamp]
+                if percent is not None:
+                    set_parts.append("___PercentRead = ?")
+                    params.append(percent)
+                # Sanity check the allow-list invariant — column names are
+                # literals above so this is a tripwire for future edits, not
+                # a runtime guard against user input.
+                for clause in set_parts:
+                    col = clause.split(" ", 1)[0]
+                    assert col in _ALLOWED_COLUMNS, (
+                        f"Writer tried to touch disallowed column {col!r}"
+                    )
+
+                params.append(upd.content_id)
+                cursor = conn.execute(
+                    f"UPDATE content SET {', '.join(set_parts)} WHERE ContentID = ?",
+                    params,
+                )
+                if cursor.rowcount > 0:
+                    report.pushed_count += 1
+                else:
+                    report.pull_only_count += 1
+        except sqlite3.Error as exc:
+            conn.execute("ROLLBACK")
+            logger.warning(
+                "Read-status push failed; rolling back batch of %d update(s): %s",
+                len(updates),
+                exc,
+            )
+            report.pushed_count = 0
+            report.pull_only_count = 0
+            report.failed = [(upd.content_id, str(exc)) for upd in updates]
+            return report
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+    return report

--- a/src/bookery/device/kobo_writer.py
+++ b/src/bookery/device/kobo_writer.py
@@ -1,0 +1,24 @@
+# ABOUTME: Read-write access to a mounted Kobo's KoboReader.sqlite — pushes read
+# ABOUTME: status from the bookery catalog into the device. The only module that
+# ABOUTME: mutates KoboReader.sqlite.
+#
+# Verification reference: Kobo Libra Colour family (device prefix N428440071799),
+# firmware 4.45.23684, 2026-05-26. ContentID format and writable columns below
+# were validated against a real device.
+
+import sqlite3
+from pathlib import Path
+
+
+def open_kobo_db_rw(kobo_sqlite_path: Path) -> sqlite3.Connection:
+    """Open KoboReader.sqlite in read-write mode.
+
+    ``mode=rw`` requires the file to exist — SQLite raises
+    ``OperationalError`` if it doesn't, which is the behaviour we want
+    (silently creating an empty KoboReader.sqlite on a missing device would
+    mask a real problem). The connection uses the default journal mode
+    (DELETE); we intentionally do not switch to WAL because the Kobo firmware
+    only knows about rollback journals.
+    """
+    uri = f"file:{kobo_sqlite_path}?mode=rw"
+    return sqlite3.connect(uri, uri=True)

--- a/tests/e2e/test_sync_cli_push.py
+++ b/tests/e2e/test_sync_cli_push.py
@@ -1,0 +1,178 @@
+# ABOUTME: End-to-end CLI tests for the P2 status push — `bookery sync kobo`
+# ABOUTME: with read-status writes, --no-status-push, and the Rich output.
+
+import sqlite3
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.db.status import STATUS_FINISHED
+from bookery.metadata.types import BookMetadata
+
+
+def _fake_kepubify(payload: bytes = b"FAKE-KEPUB"):
+    def runner(cmd, **_kwargs):
+        if "--version" in cmd:
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="kepubify v4.4.0\n", stderr=""
+            )
+        out = Path(cmd[cmd.index("-o") + 1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(payload)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    return runner
+
+
+def _seed_kobo_db(path: Path, content_id: str, read_status: int = 0) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE content (
+            ContentID            TEXT PRIMARY KEY,
+            BookID               TEXT,
+            ReadStatus           INTEGER,
+            ___PercentRead       REAL,
+            DateLastRead         TEXT,
+            ChapterIDBookmarked  TEXT,
+            MimeType             TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO content VALUES (?, NULL, ?, 0.0, '2026-05-20T10:00:00', NULL, ?)",
+        (content_id, read_status, "application/x-kobo-epub+zip"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_kobo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "kobo"
+    root.mkdir()
+    kobo_dir = root / ".kobo"
+    kobo_dir.mkdir()
+    (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
+    return root
+
+
+def _seed_catalog(db_path: Path, library: Path) -> int:
+    epub = library / "Some Author" / "Some Title" / "Some Title.epub"
+    epub.parent.mkdir(parents=True, exist_ok=True)
+    epub.write_bytes(b"FAKE-EPUB")
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="Some Title", authors=["Some Author"], source_path=epub
+            ),
+            file_hash="seed-hash",
+            output_path=epub,
+        )
+    finally:
+        conn.close()
+    return book_id
+
+
+def _run_cli(*args: str):
+    runner = CliRunner()
+    with (
+        patch("bookery.device.kepubify.shutil.which", return_value="/usr/bin/kepubify"),
+        patch("bookery.device.kepubify.subprocess.run", side_effect=_fake_kepubify()),
+    ):
+        return runner.invoke(cli, list(args))
+
+
+def test_push_renders_in_cli_output(tmp_path: Path) -> None:
+    db_path = tmp_path / "lib.db"
+    library = tmp_path / "library"
+    book_id = _seed_catalog(db_path, library)
+    target = _make_kobo_root(tmp_path)
+    content_id = "/mnt/onboard/Bookery/Some Author/Some Title/Some Title.kepub.epub"
+    _seed_kobo_db(target / ".kobo" / "KoboReader.sqlite", f"file://{content_id}")
+
+    # First sync populates device_files so the resolver can match next time.
+    first = _run_cli(
+        "sync", "kobo",
+        "--target", str(target),
+        "--db", str(db_path),
+        "--data-dir", str(tmp_path / "data"),
+    )
+    assert first.exit_code == 0, first.output
+
+    # User marks finished in bookery (timestamp strictly later than device).
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_FINISHED,
+            updated_at="2026-05-26T11:00:00",
+        )
+    finally:
+        conn.close()
+
+    second = _run_cli(
+        "sync", "kobo",
+        "--target", str(target),
+        "--db", str(db_path),
+        "--data-dir", str(tmp_path / "data"),
+    )
+    assert second.exit_code == 0, second.output
+    assert "Pushed 1 read-status update" in second.output
+    assert "Backup:" in second.output
+    # Device row actually changed.
+    row = sqlite3.connect(str(target / ".kobo" / "KoboReader.sqlite")).execute(
+        "SELECT ReadStatus FROM content WHERE ContentID = ?",
+        (f"file://{content_id}",),
+    ).fetchone()
+    assert row[0] == 2
+
+
+def test_no_status_push_flag_skips_writer(tmp_path: Path) -> None:
+    db_path = tmp_path / "lib.db"
+    library = tmp_path / "library"
+    book_id = _seed_catalog(db_path, library)
+    target = _make_kobo_root(tmp_path)
+    content_id = "/mnt/onboard/Bookery/Some Author/Some Title/Some Title.kepub.epub"
+    _seed_kobo_db(target / ".kobo" / "KoboReader.sqlite", f"file://{content_id}")
+
+    _run_cli(
+        "sync", "kobo",
+        "--target", str(target),
+        "--db", str(db_path),
+        "--data-dir", str(tmp_path / "data"),
+    )
+    conn = open_library(db_path)
+    try:
+        catalog = LibraryCatalog(conn)
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_FINISHED,
+            updated_at="2026-05-26T11:00:00",
+        )
+    finally:
+        conn.close()
+
+    result = _run_cli(
+        "sync", "kobo",
+        "--target", str(target),
+        "--db", str(db_path),
+        "--data-dir", str(tmp_path / "data"),
+        "--no-status-push",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Pushed" not in result.output
+    assert "Backup" not in result.output
+    # Device row is unchanged — still Unread.
+    row = sqlite3.connect(str(target / ".kobo" / "KoboReader.sqlite")).execute(
+        "SELECT ReadStatus FROM content WHERE ContentID = ?",
+        (f"file://{content_id}",),
+    ).fetchone()
+    assert row[0] == 0

--- a/tests/integration/test_sync_kobo_push.py
+++ b/tests/integration/test_sync_kobo_push.py
@@ -1,0 +1,329 @@
+# ABOUTME: Integration tests for the P2 read-status push — exercises the full
+# ABOUTME: sync round-trip with catalog -> device writes, backups, and merge.
+
+import sqlite3
+from pathlib import Path
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.db.status import STATUS_FINISHED, STATUS_READING, STATUS_UNREAD
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kobo import sync_library_to_kobo
+from bookery.metadata.types import BookMetadata
+
+
+class _StubKepubify:
+    def __init__(self) -> None:
+        self.version = "v4.4.0"
+
+    def run(self, epub: Path, *, out_dir: Path) -> Path:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = out_dir / f"{epub.stem}.kepub.epub"
+        result.write_bytes(b"FAKE-KEPUB")
+        return result
+
+    def get_version(self) -> str:
+        return self.version
+
+
+def _build_fake_kobo_mount(root: Path) -> Path:
+    mount = root / "kobo"
+    kobo_dir = mount / ".kobo"
+    kobo_dir.mkdir(parents=True)
+    (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
+    return mount
+
+
+def _seed_kobo_db(path: Path, rows: list[tuple]) -> None:
+    """Build a KoboReader.sqlite with the columns the writer touches.
+
+    Each row: (ContentID, ReadStatus, ___PercentRead, DateLastRead, MimeType).
+    BookID column is included (NULL for top-level book rows) so the P1a
+    read_content_rows filter still picks the row up.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE content (
+            ContentID            TEXT PRIMARY KEY,
+            BookID               TEXT,
+            ReadStatus           INTEGER,
+            ___PercentRead       REAL,
+            DateLastRead         TEXT,
+            ChapterIDBookmarked  TEXT,
+            MimeType             TEXT
+        )
+        """
+    )
+    expanded = [(cid, None, rs, pr, dlr, None, mime) for cid, rs, pr, dlr, mime in rows]
+    conn.executemany("INSERT INTO content VALUES (?, ?, ?, ?, ?, ?, ?)", expanded)
+    conn.commit()
+    conn.close()
+
+
+def _add_library_book(library: Path, author: str, title: str) -> Path:
+    epub = library / author / title / f"{title}.epub"
+    epub.parent.mkdir(parents=True, exist_ok=True)
+    epub.write_bytes(b"EPUB")
+    return epub
+
+
+def _add_catalog_book(catalog: LibraryCatalog, epub: Path, title: str, author: str) -> int:
+    return catalog.add_book(
+        BookMetadata(title=title, authors=[author], source_path=epub),
+        file_hash=f"hash-{title}",
+        output_path=epub,
+    )
+
+
+def _run_sync(
+    *,
+    catalog: LibraryCatalog,
+    mount: Path,
+    tmp_path: Path,
+    backup_root: Path | None = None,
+    status_push_enabled: bool = True,
+):
+    return sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=KepubCache(tmp_path / "kepub.db"),
+        run_kepubify=_StubKepubify().run,
+        kepubify_version=_StubKepubify().get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+        backup_root=backup_root,
+        status_push_enabled=status_push_enabled,
+    )
+
+
+def test_catalog_newer_pushes_finished_to_device(tmp_path: Path) -> None:
+    """User marks a book finished in bookery, sync, device row reflects it."""
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    # Device has the book but only reports it as Unread.
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+                0,
+                0.0,
+                "2026-05-20T10:00:00",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+    # First sync just populates device_files (so the second sync can resolve
+    # the ContentID + push). After it, mark the book finished with a strictly
+    # later catalog timestamp than the device's DateLastRead.
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    catalog.set_book_status(
+        book_id=book_id,
+        status=STATUS_FINISHED,
+        updated_at="2026-05-26T11:00:00",
+    )
+
+    backup_root = tmp_path / "backups"
+    report = _run_sync(
+        catalog=catalog,
+        mount=mount,
+        tmp_path=tmp_path / "sync2",
+        backup_root=backup_root,
+    )
+
+    assert report.read_statuses_pushed == 1
+    assert report.read_status_push_failed == []
+    # Device row reflects the push.
+    device_row = sqlite3.connect(str(kobo_db)).execute(
+        "SELECT ReadStatus, ___PercentRead, DateLastRead FROM content WHERE ContentID = ?",
+        ("file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",),
+    ).fetchone()
+    assert device_row[0] == 2
+    assert device_row[1] == 100.0
+    # DateLastRead was stamped (just check it's no longer the seeded value).
+    assert device_row[2] != "2026-05-20T10:00:00"
+    # Backup was created.
+    assert report.backup_path is not None
+    assert report.backup_path.exists()
+
+
+def test_idempotent_second_sync_pushes_nothing(tmp_path: Path) -> None:
+    """After a push, the catalog and device timestamps match; the tiebreak
+    sends the book device-side, so the next sync pushes nothing.
+    """
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+                0,
+                0.0,
+                "2026-05-20T10:00:00",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    catalog.set_book_status(
+        book_id=1, status=STATUS_FINISHED, updated_at="2026-05-26T11:00:00"
+    )
+    first = _run_sync(
+        catalog=catalog,
+        mount=mount,
+        tmp_path=tmp_path / "sync2",
+        backup_root=tmp_path / "backups",
+    )
+    assert first.read_statuses_pushed == 1
+    second = _run_sync(
+        catalog=catalog,
+        mount=mount,
+        tmp_path=tmp_path / "sync3",
+        backup_root=tmp_path / "backups",
+    )
+    assert second.read_statuses_pushed == 0
+
+
+def test_device_newer_overwrites_catalog(tmp_path: Path) -> None:
+    """Device reports a later read than the catalog's unread mark — the
+    merge picks the device direction and bookery now shows finished."""
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+                2,
+                100.0,
+                "2026-05-25T10:00:00",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    # User marked unread BEFORE the device's later finished-read.
+    catalog.set_book_status(
+        book_id=book_id, status=STATUS_UNREAD, updated_at="2026-05-19T10:00:00"
+    )
+    report = _run_sync(
+        catalog=catalog,
+        mount=mount,
+        tmp_path=tmp_path / "sync2",
+        backup_root=tmp_path / "backups",
+    )
+    bs = catalog.get_book_status(book_id)
+    assert bs is not None
+    assert bs.status == STATUS_FINISHED
+    # Nothing to push back — device already has the correct state.
+    assert report.read_statuses_pushed == 0
+
+
+def test_no_status_push_skips_writer_and_backup(tmp_path: Path) -> None:
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+                0,
+                0.0,
+                "2026-05-20T10:00:00",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    catalog.set_book_status(
+        book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T11:00:00"
+    )
+    backup_root = tmp_path / "backups"
+    report = _run_sync(
+        catalog=catalog,
+        mount=mount,
+        tmp_path=tmp_path / "sync2",
+        backup_root=backup_root,
+        status_push_enabled=False,
+    )
+    assert report.read_statuses_pushed == 0
+    assert report.backup_path is None
+    # Device row is untouched — still Unread.
+    device_row = sqlite3.connect(str(kobo_db)).execute(
+        "SELECT ReadStatus FROM content WHERE ContentID = ?",
+        ("file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",),
+    ).fetchone()
+    assert device_row[0] == 0
+
+
+def test_reading_status_pushes_without_clobbering_percent(tmp_path: Path) -> None:
+    """STATUS_READING preserves the device's progress percentage."""
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Le Guin", "Earthsea")
+    book_id = _add_catalog_book(catalog, epub, "Earthsea", "Le Guin")
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Le Guin/Earthsea/Earthsea.kepub.epub",
+                0,
+                42.0,
+                "2026-05-20T10:00:00",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    catalog.set_book_status(
+        book_id=book_id, status=STATUS_READING, updated_at="2026-05-26T11:00:00"
+    )
+    _run_sync(
+        catalog=catalog,
+        mount=mount,
+        tmp_path=tmp_path / "sync2",
+        backup_root=tmp_path / "backups",
+    )
+    device_row = sqlite3.connect(str(kobo_db)).execute(
+        "SELECT ReadStatus, ___PercentRead FROM content WHERE ContentID = ?",
+        ("file:///mnt/onboard/Books/Le Guin/Earthsea/Earthsea.kepub.epub",),
+    ).fetchone()
+    assert device_row[0] == 1
+    # Percent untouched because status=reading skips that column.
+    assert device_row[1] == 42.0

--- a/tests/integration/test_sync_kobo_push_resilience.py
+++ b/tests/integration/test_sync_kobo_push_resilience.py
@@ -1,0 +1,170 @@
+# ABOUTME: Resilience tests for #182 push — the sync must keep working when
+# ABOUTME: KoboReader.sqlite is read-only or the backup directory is corrupted.
+
+import logging
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.db.status import STATUS_FINISHED
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kobo import sync_library_to_kobo
+from bookery.metadata.types import BookMetadata
+
+
+class _StubKepubify:
+    def __init__(self) -> None:
+        self.version = "v4.4.0"
+
+    def run(self, epub: Path, *, out_dir: Path) -> Path:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = out_dir / f"{epub.stem}.kepub.epub"
+        result.write_bytes(b"FAKE-KEPUB")
+        return result
+
+    def get_version(self) -> str:
+        return self.version
+
+
+def _build_mount(root: Path) -> Path:
+    mount = root / "kobo"
+    kobo_dir = mount / ".kobo"
+    kobo_dir.mkdir(parents=True)
+    (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
+    return mount
+
+
+def _seed_kobo_db(path: Path, content_id: str) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE content (
+            ContentID            TEXT PRIMARY KEY,
+            BookID               TEXT,
+            ReadStatus           INTEGER,
+            ___PercentRead       REAL,
+            DateLastRead         TEXT,
+            ChapterIDBookmarked  TEXT,
+            MimeType             TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO content VALUES (?, NULL, 0, 0.0, '2026-05-20T10:00:00', NULL, ?)",
+        (content_id, "application/x-kobo-epub+zip"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_catalog(tmp_path: Path) -> tuple[LibraryCatalog, int, Path]:
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    library = tmp_path / "library"
+    epub = library / "Asimov" / "Foundation" / "Foundation.epub"
+    epub.parent.mkdir(parents=True, exist_ok=True)
+    epub.write_bytes(b"EPUB")
+    book_id = catalog.add_book(
+        BookMetadata(title="Foundation", authors=["Asimov"], source_path=epub),
+        file_hash="hash-foundation",
+        output_path=epub,
+    )
+    return catalog, book_id, library
+
+
+def _run_sync(
+    *, catalog: LibraryCatalog, mount: Path, tmp_path: Path, backup_root: Path
+):
+    return sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=KepubCache(tmp_path / "kepub.db"),
+        run_kepubify=_StubKepubify().run,
+        kepubify_version=_StubKepubify().get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+        backup_root=backup_root,
+    )
+
+
+def test_read_only_kobo_db_does_not_crash(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A read-only KoboReader.sqlite (mount quirk) must let the sync complete
+    with the pull/copy phases intact and the push reported as a failure."""
+    catalog, book_id, _ = _seed_catalog(tmp_path)
+    mount = _build_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+    )
+    # First sync populates device_files normally.
+    _run_sync(
+        catalog=catalog, mount=mount, tmp_path=tmp_path / "s1",
+        backup_root=tmp_path / "backups",
+    )
+    catalog.set_book_status(
+        book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T11:00:00"
+    )
+    # Strip write permission from the device DB and its parent.
+    kobo_db.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    parent_mode = (mount / ".kobo").stat().st_mode
+    (mount / ".kobo").chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        with caplog.at_level(logging.WARNING, logger="bookery.device.kobo"):
+            report = _run_sync(
+                catalog=catalog, mount=mount, tmp_path=tmp_path / "s2",
+                backup_root=tmp_path / "backups",
+            )
+    finally:
+        # Restore so pytest can clean up the tmp dir.
+        (mount / ".kobo").chmod(parent_mode)
+        kobo_db.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    # Pull still completed (count of 1) because pulls open the DB read-only.
+    assert report.read_states_pulled == 1
+    # Push failed cleanly — failure list populated, push count zero.
+    assert report.read_statuses_pushed == 0
+    assert any(
+        "Read-status push failed" in rec.message for rec in caplog.records
+    )
+
+
+def test_corrupted_backup_dir_does_not_block_sync(tmp_path: Path) -> None:
+    """If ~/.bookery/backups/<serial>/ exists as a regular file (not a dir),
+    the backup attempt logs and returns None — the sync still pushes (we
+    accept the unbacked-up push as a soft failure of the safety net, not a
+    sync failure)."""
+    catalog, book_id, _ = _seed_catalog(tmp_path)
+    mount = _build_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+    )
+    _run_sync(
+        catalog=catalog, mount=mount, tmp_path=tmp_path / "s1",
+        backup_root=tmp_path / "backups",
+    )
+    catalog.set_book_status(
+        book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T11:00:00"
+    )
+
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir(parents=True, exist_ok=True)
+    # Plant a regular file where the serial directory should live.
+    (backup_root / "N428440071799").write_text("not a directory")
+
+    report = _run_sync(
+        catalog=catalog, mount=mount, tmp_path=tmp_path / "s2",
+        backup_root=backup_root,
+    )
+    assert report.read_statuses_pushed == 1
+    assert report.backup_path is None
+
+

--- a/tests/unit/test_catalog_book_status.py
+++ b/tests/unit/test_catalog_book_status.py
@@ -303,3 +303,118 @@ class TestMergeBookStatusFromDevice:
         status = catalog.get_book_status(book_id)
         assert status is not None
         assert status.status == STATUS_FINISHED
+
+
+class TestListPushCandidates:
+    """Returns rows the sync orchestrator can decide to push to the device."""
+
+    def test_returns_books_with_status_and_device_file(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="A", label=None, now="2026-05-01T00:00:00"
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/mnt/onboard/Books/A/Rose.kepub.epub",
+            now="2026-05-26T10:00:00+00:00",
+        )
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_READING,
+            updated_at="2026-05-26T11:00:00+00:00",
+        )
+        candidates = catalog.list_push_candidates(device_id=device_id)
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.book_id == book_id
+        assert c.remote_path == "/mnt/onboard/Books/A/Rose.kepub.epub"
+        assert c.catalog_status == STATUS_READING
+        assert c.catalog_updated_at == "2026-05-26T11:00:00+00:00"
+        assert c.device_status_updated_at is None
+
+    def test_excludes_books_without_device_file(self, catalog: LibraryCatalog) -> None:
+        """A book with book_status but no device_files entry can't be pushed —
+        we have no ContentID to write to. Skipped silently."""
+        book_id = _add_book(catalog, "Rose", "h1")
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="A", label=None, now="2026-05-01T00:00:00"
+        )
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_READING,
+            updated_at="2026-05-26T11:00:00+00:00",
+        )
+        assert catalog.list_push_candidates(device_id=device_id) == []
+
+    def test_excludes_books_without_book_status(self, catalog: LibraryCatalog) -> None:
+        """A book on the device with no catalog status is nothing to push."""
+        book_id = _add_book(catalog, "Rose", "h1")
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="A", label=None, now="2026-05-01T00:00:00"
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/mnt/onboard/Books/A/Rose.kepub.epub",
+            now="2026-05-26T10:00:00+00:00",
+        )
+        assert catalog.list_push_candidates(device_id=device_id) == []
+
+    def test_only_returns_candidates_for_the_requested_device(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        dev_a = catalog.upsert_device(
+            kind="kobo", serial="A", label=None, now="2026-05-01T00:00:00"
+        )
+        dev_b = catalog.upsert_device(
+            kind="kobo", serial="B", label=None, now="2026-05-01T00:00:00"
+        )
+        catalog.upsert_device_file(
+            device_id=dev_a,
+            book_id=book_id,
+            remote_path="/mnt/onboard/Books/A/Rose.kepub.epub",
+            now="2026-05-26T10:00:00+00:00",
+        )
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_READING,
+            updated_at="2026-05-26T11:00:00+00:00",
+        )
+        assert len(catalog.list_push_candidates(device_id=dev_a)) == 1
+        assert catalog.list_push_candidates(device_id=dev_b) == []
+
+    def test_includes_device_state_when_present(self, catalog: LibraryCatalog) -> None:
+        """If device_read_state has a row, the device timestamp comes back so
+        the orchestrator can decide direction without a second query."""
+        book_id = _add_book(catalog, "Rose", "h1")
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="A", label=None, now="2026-05-01T00:00:00"
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/mnt/onboard/Books/A/Rose.kepub.epub",
+            now="2026-05-26T10:00:00+00:00",
+        )
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_FINISHED,
+            updated_at="2026-05-26T11:00:00+00:00",
+        )
+        catalog.upsert_device_read_state(
+            device_id=device_id,
+            book_id=book_id,
+            read_status=STATUS_READING,
+            percent_read=0.5,
+            last_read_at="2026-05-20T00:00:00+00:00",
+            last_chapter_id=None,
+            status_updated_at="2026-05-20T00:00:00+00:00",
+            pulled_at="2026-05-26T10:00:00+00:00",
+        )
+        candidates = catalog.list_push_candidates(device_id=device_id)
+        assert len(candidates) == 1
+        assert candidates[0].device_status_updated_at == "2026-05-20T00:00:00+00:00"

--- a/tests/unit/test_catalog_book_status.py
+++ b/tests/unit/test_catalog_book_status.py
@@ -230,3 +230,76 @@ class TestGetDeviceReadStateForBook:
         assert state is not None
         assert state.device_label == "New"
         assert state.read_status == STATUS_FINISHED
+
+
+class TestMergeBookStatusFromDevice:
+    """The P2 merge: device-newer-or-equal-to catalog overwrites; catalog-newer wins."""
+
+    def test_inserts_row_when_catalog_empty(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.merge_book_status_from_device(
+            book_id=book_id,
+            device_status=STATUS_FINISHED,
+            device_updated_at="2026-05-26T10:00:00+00:00",
+        )
+        status = catalog.get_book_status(book_id)
+        assert status == BookStatus(
+            book_id=book_id,
+            status=STATUS_FINISHED,
+            updated_at="2026-05-26T10:00:00+00:00",
+        )
+
+    def test_overwrites_when_device_is_newer(self, catalog: LibraryCatalog) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_READING,
+            updated_at="2026-05-20T00:00:00+00:00",
+        )
+        catalog.merge_book_status_from_device(
+            book_id=book_id,
+            device_status=STATUS_FINISHED,
+            device_updated_at="2026-05-26T10:00:00+00:00",
+        )
+        status = catalog.get_book_status(book_id)
+        assert status is not None
+        assert status.status == STATUS_FINISHED
+        assert status.updated_at == "2026-05-26T10:00:00+00:00"
+
+    def test_leaves_catalog_alone_when_catalog_is_newer(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_FINISHED,
+            updated_at="2026-05-26T10:00:00+00:00",
+        )
+        catalog.merge_book_status_from_device(
+            book_id=book_id,
+            device_status=STATUS_UNREAD,
+            device_updated_at="2026-05-20T00:00:00+00:00",
+        )
+        status = catalog.get_book_status(book_id)
+        assert status is not None
+        assert status.status == STATUS_FINISHED
+        assert status.updated_at == "2026-05-26T10:00:00+00:00"
+
+    def test_equal_timestamp_device_wins(self, catalog: LibraryCatalog) -> None:
+        """Tiebreak from the #178 spec: equal timestamps go to the device — it
+        avoids a no-op write but more importantly keeps catalog and device
+        consistent without needing a separate "are these really equal" check."""
+        book_id = _add_book(catalog, "Rose", "h1")
+        catalog.set_book_status(
+            book_id=book_id,
+            status=STATUS_READING,
+            updated_at="2026-05-26T10:00:00+00:00",
+        )
+        catalog.merge_book_status_from_device(
+            book_id=book_id,
+            device_status=STATUS_FINISHED,
+            device_updated_at="2026-05-26T10:00:00+00:00",
+        )
+        status = catalog.get_book_status(book_id)
+        assert status is not None
+        assert status.status == STATUS_FINISHED

--- a/tests/unit/test_device_kobo_backup.py
+++ b/tests/unit/test_device_kobo_backup.py
@@ -1,0 +1,156 @@
+# ABOUTME: Unit tests for device/kobo_backup — per-device-per-day KoboReader.sqlite snapshots.
+# ABOUTME: Covers create-on-first-call, idempotent same-day, rotation to 14 most recent.
+
+import datetime as _dt
+from pathlib import Path
+
+from bookery.device.kobo_backup import backup_kobo_db
+
+
+def _seed_source(tmp_path: Path, content: bytes = b"FAKE-KOBO-DB") -> Path:
+    src = tmp_path / "KoboReader.sqlite"
+    src.write_bytes(content)
+    return src
+
+
+class TestBackupKoboDb:
+    SERIAL = "N428440071799"
+
+    def test_first_call_creates_backup_file(self, tmp_path: Path) -> None:
+        src = _seed_source(tmp_path)
+        backup_root = tmp_path / "backups"
+
+        result = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 26, 10, 30, 0),
+        )
+
+        assert result is not None
+        assert result.parent == backup_root / self.SERIAL
+        assert result.exists()
+        assert result.read_bytes() == b"FAKE-KOBO-DB"
+        # Naming includes ISO date + time so multiple per-day backups still sort.
+        assert "2026-05-26" in result.name
+        assert result.suffix == ".sqlite"
+
+    def test_same_day_second_call_is_idempotent(self, tmp_path: Path) -> None:
+        """Two calls on the same calendar day return the same path without
+        re-copying — the snapshot is "first mutating sync per device-day".
+        """
+        src = _seed_source(tmp_path)
+        backup_root = tmp_path / "backups"
+
+        first = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 26, 10, 30, 0),
+        )
+        # Mutate the source between calls — second call should NOT re-copy.
+        src.write_bytes(b"NEWER-BYTES")
+        second = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 26, 18, 00, 0),
+        )
+
+        assert first == second
+        assert second is not None
+        # First call's bytes are preserved — we don't overwrite the day's snapshot.
+        assert second.read_bytes() == b"FAKE-KOBO-DB"
+
+    def test_next_day_creates_new_backup(self, tmp_path: Path) -> None:
+        src = _seed_source(tmp_path)
+        backup_root = tmp_path / "backups"
+
+        first = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 26, 10, 30, 0),
+        )
+        src.write_bytes(b"DAY-TWO")
+        second = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 27, 9, 0, 0),
+        )
+
+        assert first != second
+        assert second is not None
+        assert second.read_bytes() == b"DAY-TWO"
+        siblings = sorted((backup_root / self.SERIAL).iterdir())
+        assert len(siblings) == 2
+
+    def test_rotation_keeps_14_most_recent(self, tmp_path: Path) -> None:
+        src = _seed_source(tmp_path)
+        backup_root = tmp_path / "backups"
+
+        # 16 simulated daily syncs. After day 15 we expect 14 files (the
+        # 14 most recent — days 2..15 — kept; days 0..1 evicted).
+        for day in range(16):
+            backup_kobo_db(
+                source_db=src,
+                backup_root=backup_root,
+                device_serial=self.SERIAL,
+                now=_dt.datetime(2026, 5, 1, 10, 0, 0) + _dt.timedelta(days=day),
+            )
+
+        snapshots = sorted((backup_root / self.SERIAL).iterdir())
+        assert len(snapshots) == 14
+        # Oldest remaining should be day 2 (2026-05-03), newest day 15 (2026-05-16).
+        assert "2026-05-03" in snapshots[0].name
+        assert "2026-05-16" in snapshots[-1].name
+
+    def test_missing_source_returns_none(self, tmp_path: Path) -> None:
+        """Best-effort: a missing source file logs but doesn't raise."""
+        missing = tmp_path / "nope.sqlite"
+        result = backup_kobo_db(
+            source_db=missing,
+            backup_root=tmp_path / "backups",
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 26, 10, 0, 0),
+        )
+        assert result is None
+
+    def test_corrupted_backup_dir_does_not_raise(self, tmp_path: Path) -> None:
+        """If <backup_root>/<serial> exists as a file (not a directory),
+        the function returns None instead of blowing up — pushes still go.
+        """
+        src = _seed_source(tmp_path)
+        backup_root = tmp_path / "backups"
+        backup_root.mkdir()
+        # Plant a regular file where the serial directory should live.
+        (backup_root / self.SERIAL).write_text("not a directory")
+
+        result = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial=self.SERIAL,
+            now=_dt.datetime(2026, 5, 26, 10, 0, 0),
+        )
+        assert result is None
+
+    def test_separate_devices_get_separate_dirs(self, tmp_path: Path) -> None:
+        src = _seed_source(tmp_path)
+        backup_root = tmp_path / "backups"
+        a = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial="DEV-A",
+            now=_dt.datetime(2026, 5, 26, 10, 0, 0),
+        )
+        b = backup_kobo_db(
+            source_db=src,
+            backup_root=backup_root,
+            device_serial="DEV-B",
+            now=_dt.datetime(2026, 5, 26, 10, 0, 0),
+        )
+        assert a is not None
+        assert b is not None
+        assert a.parent.name == "DEV-A"
+        assert b.parent.name == "DEV-B"

--- a/tests/unit/test_device_kobo_reader.py
+++ b/tests/unit/test_device_kobo_reader.py
@@ -255,9 +255,12 @@ class TestPullReadState:
         assert bs["status"] == 2
         assert bs["updated_at"] == "2026-05-20T10:00:00"
 
-    def test_second_call_is_idempotent_and_preserves_book_status(
+    def test_pull_does_not_overwrite_when_catalog_is_newer(
         self, tmp_path: Path
     ) -> None:
+        """The P2 merge: catalog with a strictly newer timestamp wins, so the
+        user's bookery read/unread/reading intent is preserved across syncs.
+        """
         mount, kobo_dir = self._build_mount(tmp_path)
         _create_kobo_db(kobo_dir / "KoboReader.sqlite")
         conn = open_library(tmp_path / "library.db")
@@ -273,14 +276,12 @@ class TestPullReadState:
             remote_path="/mnt/onboard/Bookery/A/T/T.kepub.epub",
             now="2026-05-26T08:00:00",
         )
-        # Simulate the user setting status in the catalog (P1b path) AFTER the
-        # first pull seeded book_status. A second pull must not overwrite that.
+        # Fixture's DateLastRead is "2026-05-20T10:00:00". Stamp the catalog
+        # with a strictly-later ISO timestamp via the user write path.
         pull_read_state(catalog, device_id=device_id, mount_path=mount, now="t1")
-        conn.execute(
-            "UPDATE book_status SET status = 0, updated_at = 'user-edit' WHERE book_id = ?",
-            (book_id,),
+        catalog.set_book_status(
+            book_id=book_id, status=0, updated_at="2026-05-21T10:00:00"
         )
-        conn.commit()
 
         pulled, skipped = pull_read_state(
             catalog, device_id=device_id, mount_path=mount, now="t2"
@@ -291,13 +292,52 @@ class TestPullReadState:
             (book_id,),
         ).fetchone()
         assert bs["status"] == 0
-        assert bs["updated_at"] == "user-edit"
+        assert bs["updated_at"] == "2026-05-21T10:00:00"
         # device_read_state was re-upserted with new pulled_at.
         row = conn.execute(
             "SELECT pulled_at FROM device_read_state WHERE device_id = ? AND book_id = ?",
             (device_id, book_id),
         ).fetchone()
         assert row["pulled_at"] == "t2"
+
+    def test_pull_overwrites_book_status_when_device_is_newer(
+        self, tmp_path: Path
+    ) -> None:
+        """The other side of the merge: device with a strictly newer timestamp
+        clobbers the catalog. Closes the "user read on device after marking
+        unread on desktop" hole from #178's sync model.
+        """
+        mount, kobo_dir = self._build_mount(tmp_path)
+        _create_kobo_db(kobo_dir / "KoboReader.sqlite")
+        conn = open_library(tmp_path / "library.db")
+        catalog = LibraryCatalog(conn)
+        device_id = catalog.upsert_device(
+            kind="kobo", serial="N1", label=None, now="2026-05-26T08:00:00"
+        )
+        book_id = _add_book_with_remote_path(
+            catalog,
+            title="T",
+            author="A",
+            device_id=device_id,
+            remote_path="/mnt/onboard/Bookery/A/T/T.kepub.epub",
+            now="2026-05-26T08:00:00",
+        )
+        # User marked unread on a date before the device's DateLastRead.
+        catalog.set_book_status(
+            book_id=book_id, status=0, updated_at="2026-05-19T10:00:00"
+        )
+
+        pulled, _ = pull_read_state(
+            catalog, device_id=device_id, mount_path=mount, now="t"
+        )
+        assert pulled == 1
+        bs = conn.execute(
+            "SELECT status, updated_at FROM book_status WHERE book_id = ?",
+            (book_id,),
+        ).fetchone()
+        # Fixture row has ReadStatus=2 (finished) and DateLastRead="2026-05-20T10:00:00".
+        assert bs["status"] == 2
+        assert bs["updated_at"] == "2026-05-20T10:00:00"
 
     def test_returns_zero_when_kobo_db_missing(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -72,8 +72,13 @@ class StubCatalog:
     def upsert_device_read_state(self, **kwargs) -> None:
         self.read_state_upserts.append(kwargs)
 
-    def seed_book_status_if_absent(self, **kwargs) -> None:
+    def merge_book_status_from_device(self, **kwargs) -> None:
         self.book_status_seeds.append(kwargs)
+
+    def list_push_candidates(self, *, device_id: int) -> list:
+        # Stub catalog never produces push candidates; the push phase
+        # short-circuits without touching the device DB.
+        return []
 
 
 def _make_record(

--- a/tests/unit/test_device_kobo_writer.py
+++ b/tests/unit/test_device_kobo_writer.py
@@ -1,0 +1,35 @@
+# ABOUTME: Unit tests for device/kobo_writer — the narrow R/W API to KoboReader.sqlite.
+# ABOUTME: Covers connection opening, the push_read_status writer, and rollback safety.
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from bookery.device.kobo_writer import open_kobo_db_rw
+
+
+class TestOpenKoboDbRw:
+    def test_opens_existing_db_for_writes(self, tmp_path: Path) -> None:
+        """An existing SQLite file opens in read-write mode."""
+        db_path = tmp_path / "KoboReader.sqlite"
+        # Seed an empty SQLite file so the URI has something to attach to.
+        seed = sqlite3.connect(str(db_path))
+        seed.execute("CREATE TABLE marker (id INTEGER)")
+        seed.commit()
+        seed.close()
+
+        conn = open_kobo_db_rw(db_path)
+        try:
+            conn.execute("INSERT INTO marker (id) VALUES (1)")
+            conn.commit()
+            row = conn.execute("SELECT id FROM marker").fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 1
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """A non-existent path raises sqlite3.OperationalError (no silent create)."""
+        missing = tmp_path / "does-not-exist.sqlite"
+        with pytest.raises(sqlite3.OperationalError):
+            open_kobo_db_rw(missing)

--- a/tests/unit/test_device_kobo_writer.py
+++ b/tests/unit/test_device_kobo_writer.py
@@ -1,12 +1,49 @@
 # ABOUTME: Unit tests for device/kobo_writer — the narrow R/W API to KoboReader.sqlite.
 # ABOUTME: Covers connection opening, the push_read_status writer, and rollback safety.
 
+import hashlib
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from bookery.device.kobo_writer import open_kobo_db_rw
+from bookery.db.status import STATUS_FINISHED, STATUS_READING, STATUS_UNREAD
+from bookery.device.kobo_writer import (
+    ReadStatusUpdate,
+    open_kobo_db_rw,
+    push_read_status,
+)
+
+FROZEN_NOW = "2026-05-26T15:30:00"
+
+
+def _seed_content_table(db_path: Path, rows: list[tuple]) -> None:
+    """Build a minimal KoboReader.sqlite content table for writer tests.
+
+    Each row is (ContentID, ReadStatus, ___PercentRead, DateLastRead,
+    ___SyncTime, Synced). The extra columns let us assert the writer leaves
+    them alone.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE content (
+            ContentID       TEXT PRIMARY KEY,
+            ReadStatus      INTEGER,
+            ___PercentRead  REAL,
+            DateLastRead    TEXT,
+            ___SyncTime     TEXT,
+            Synced          INTEGER
+        )
+        """
+    )
+    conn.executemany("INSERT INTO content VALUES (?, ?, ?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.close()
+
+
+def _file_sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 class TestOpenKoboDbRw:
@@ -33,3 +70,180 @@ class TestOpenKoboDbRw:
         missing = tmp_path / "does-not-exist.sqlite"
         with pytest.raises(sqlite3.OperationalError):
             open_kobo_db_rw(missing)
+
+
+class TestPushReadStatus:
+    """The writer's central contract: status maps to the right columns, in one
+    transaction, with DateLastRead stamped, leaving every other column alone.
+    """
+
+    _CID_A = "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub"
+    _CID_B = "file:///mnt/onboard/Books/LeGuin/Earthsea/Earthsea.kepub.epub"
+
+    def _seed(self, tmp_path: Path) -> Path:
+        db = tmp_path / "KoboReader.sqlite"
+        _seed_content_table(
+            db,
+            [
+                (self._CID_A, 0, 0.0, None, "2026-01-01T00:00:00", 1),
+                (self._CID_B, 1, 33.0, "2026-02-15T10:00:00", "2026-01-01T00:00:00", 1),
+            ],
+        )
+        return db
+
+    def test_finished_sets_read_status_2_and_percent_100(self, tmp_path: Path) -> None:
+        db = self._seed(tmp_path)
+        report = push_read_status(
+            db_path=db,
+            updates=[ReadStatusUpdate(content_id=self._CID_A, status=STATUS_FINISHED)],
+            now=lambda: FROZEN_NOW,
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT ReadStatus, ___PercentRead, DateLastRead "
+                "FROM content WHERE ContentID = ?",
+                (self._CID_A,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == (2, 100.0, FROZEN_NOW)
+        assert report.pushed_count == 1
+        assert report.failed == []
+        assert report.pull_only_count == 0
+
+    def test_unread_sets_read_status_0_and_percent_0(self, tmp_path: Path) -> None:
+        db = self._seed(tmp_path)
+        push_read_status(
+            db_path=db,
+            updates=[ReadStatusUpdate(content_id=self._CID_B, status=STATUS_UNREAD)],
+            now=lambda: FROZEN_NOW,
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT ReadStatus, ___PercentRead, DateLastRead "
+                "FROM content WHERE ContentID = ?",
+                (self._CID_B,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == (0, 0.0, FROZEN_NOW)
+
+    def test_reading_leaves_percent_untouched(self, tmp_path: Path) -> None:
+        """STATUS_READING updates ReadStatus + DateLastRead, but not ___PercentRead."""
+        db = self._seed(tmp_path)
+        push_read_status(
+            db_path=db,
+            updates=[ReadStatusUpdate(content_id=self._CID_B, status=STATUS_READING)],
+            now=lambda: FROZEN_NOW,
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT ReadStatus, ___PercentRead, DateLastRead "
+                "FROM content WHERE ContentID = ?",
+                (self._CID_B,),
+            ).fetchone()
+        finally:
+            conn.close()
+        # ReadStatus and DateLastRead got stamped; ___PercentRead kept its seeded 33.0.
+        assert row == (1, 33.0, FROZEN_NOW)
+
+    def test_other_columns_untouched(self, tmp_path: Path) -> None:
+        """Non-allow-listed columns (___SyncTime, Synced) keep their seeded values."""
+        db = self._seed(tmp_path)
+        push_read_status(
+            db_path=db,
+            updates=[ReadStatusUpdate(content_id=self._CID_A, status=STATUS_FINISHED)],
+            now=lambda: FROZEN_NOW,
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            row = conn.execute(
+                "SELECT ___SyncTime, Synced FROM content WHERE ContentID = ?",
+                (self._CID_A,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == ("2026-01-01T00:00:00", 1)
+
+    def test_unknown_content_id_counted_as_pull_only(self, tmp_path: Path) -> None:
+        """ContentIDs the device doesn't know about don't fail — they're pull-only."""
+        db = self._seed(tmp_path)
+        report = push_read_status(
+            db_path=db,
+            updates=[
+                ReadStatusUpdate(
+                    content_id="file:///mnt/onboard/Books/Unknown.kepub.epub",
+                    status=STATUS_FINISHED,
+                ),
+                ReadStatusUpdate(content_id=self._CID_A, status=STATUS_FINISHED),
+            ],
+            now=lambda: FROZEN_NOW,
+        )
+        assert report.pushed_count == 1
+        assert report.pull_only_count == 1
+        assert report.failed == []
+
+    def test_rollback_on_error_leaves_db_unchanged(self, tmp_path: Path) -> None:
+        """Any sqlite3 error mid-batch rolls back the whole transaction.
+
+        We install a BEFORE-UPDATE trigger that aborts when ContentID matches
+        the second row, then hash the DB. The trigger fires partway through
+        the writer's batch — the writer must rollback the first row's update
+        (which succeeded against the trigger) so the file hash is unchanged.
+        """
+        db = self._seed(tmp_path)
+        seed_conn = sqlite3.connect(str(db))
+        try:
+            seed_conn.execute(
+                "CREATE TRIGGER fail_on_b BEFORE UPDATE ON content "
+                f"WHEN NEW.ContentID = '{self._CID_B}' "
+                "BEGIN SELECT RAISE(ABORT, 'forced'); END"
+            )
+            seed_conn.commit()
+        finally:
+            seed_conn.close()
+        pre_hash = _file_sha(db)
+
+        report = push_read_status(
+            db_path=db,
+            updates=[
+                ReadStatusUpdate(content_id=self._CID_A, status=STATUS_FINISHED),
+                ReadStatusUpdate(content_id=self._CID_B, status=STATUS_FINISHED),
+            ],
+            now=lambda: FROZEN_NOW,
+        )
+        assert report.pushed_count == 0
+        assert len(report.failed) >= 1
+        assert _file_sha(db) == pre_hash
+
+    def test_empty_updates_is_a_noop(self, tmp_path: Path) -> None:
+        db = self._seed(tmp_path)
+        pre_hash = _file_sha(db)
+        report = push_read_status(db_path=db, updates=[], now=lambda: FROZEN_NOW)
+        assert report.pushed_count == 0
+        assert report.pull_only_count == 0
+        assert report.failed == []
+        assert _file_sha(db) == pre_hash
+
+    def test_single_transaction_all_or_nothing(self, tmp_path: Path) -> None:
+        """If the writer commits, all rows reflect the same now() stamp atomically."""
+        db = self._seed(tmp_path)
+        push_read_status(
+            db_path=db,
+            updates=[
+                ReadStatusUpdate(content_id=self._CID_A, status=STATUS_FINISHED),
+                ReadStatusUpdate(content_id=self._CID_B, status=STATUS_FINISHED),
+            ],
+            now=lambda: FROZEN_NOW,
+        )
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = conn.execute(
+                "SELECT DateLastRead FROM content ORDER BY ContentID"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert all(r[0] == FROZEN_NOW for r in rows)


### PR DESCRIPTION
## Summary
Closes the bidirectional sync loop: marks made in bookery (`bookery read/unread/reading`) now flow back to `KoboReader.sqlite` on every `bookery sync kobo`. Per the #178 sync model, per-book last-writer-wins with `>=` tiebreak to the device — and the device DB gets a per-device-per-day SQLite snapshot before any push so the user can roll back by hand.

## Changes

### New modules
- **`device/kobo_writer.py`** — narrow R/W API: `ReadStatusUpdate`, `PushReport`, `open_kobo_db_rw`, `push_read_status`. Column allow-list (`ReadStatus`, `___PercentRead`, `DateLastRead`), single transaction with rollback on any `sqlite3.Error`, `DateLastRead` stamped on every push, `STATUS_READING` leaves percent untouched.
- **`device/kobo_backup.py`** — `backup_kobo_db` snapshots into `~/.bookery/backups/<serial>/<YYYY-MM-DD>-<HHMMSS>.sqlite`. Idempotent per device-day, rotation keeps 14 most recent, best-effort throughout.

### Modified
- **`device/kobo_reader.py`** — `pull_read_state` now calls `merge_book_status_from_device` instead of `seed_book_status_if_absent`, so device-newer-or-equal overwrites the catalog (the merge half of #178).
- **`device/kobo.py`** — new `_push_read_state` phase after the copy loop. `SyncReport` grows `read_statuses_pushed`, `read_status_pull_only`, `read_status_push_failed`, `backup_path`. New params: `backup_root`, `status_push_enabled`.
- **`db/catalog.py`** — `merge_book_status_from_device` (timestamp-gated overwrite) and `list_push_candidates` (JOIN of `book_status`, `device_files`, LEFT JOIN `device_read_state`).
- **`db/status.py`** — `PushCandidate` dataclass.
- **`cli/commands/sync_cmd.py`** — `--no-status-push` flag; Rich output gains `Pushed N` / `Backup: …` / `Read-status push failed` lines.

## Testing
- [x] **Unit (36 new):** writer transactional contract, backup rotation + idempotency, catalog merge + push-candidate query, pull merge in both directions.
- [x] **Integration (5 new):** round-trip catalog→device push, idempotent second sync, device-newer overwrite, `--no-status-push` skips writer + backup, `STATUS_READING` preserves device percent.
- [x] **E2E (2 new):** `bookery sync kobo` shows `Pushed 1` / `Backup:` lines and mutates the device row; `--no-status-push` exits cleanly with unchanged device row.
- [x] **Resilience (2 new):** read-only `KoboReader.sqlite` lets pull/copy finish and reports push failure cleanly; corrupted backup dir doesn't block sync (returns `backup_path=None`).
- [x] **Full suite:** 1795 passed (was 1759), no regressions.
- [x] **Lint + types:** ruff clean, pyright 0 errors.

## Related Issues
Fixes #182. Parent epic #178. Builds on #180 (P1a) and #181 (P1b). P3 (web bidirectional UI) tracked as #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)