### PR TITLE
Fix #188: Backfill device_files on the cached sync path

### DIFF
--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -210,6 +210,18 @@ def _sync_record(
             if compute_file_hash(dest) == cached_kepub_sha:
                 stage("cached")
                 report.skipped.append((dest, "already up to date"))
+                # Re-stamp device_files even on the cached path; otherwise
+                # books that pre-date P1a (#180) — or any book that's been on
+                # the device long enough to hit this branch — stay invisible
+                # to ``list_push_candidates`` and the read-status push
+                # silently no-ops (#188). The upsert is idempotent.
+                if device_id is not None:
+                    catalog.upsert_device_file(
+                        device_id=device_id,
+                        book_id=record.id,
+                        remote_path=_to_device_path(dest, target),
+                        now=now,
+                    )
                 return
         except OSError:
             pass  # fall through to re-convert

--- a/tests/integration/test_sync_kobo_push.py
+++ b/tests/integration/test_sync_kobo_push.py
@@ -287,6 +287,86 @@ def test_no_status_push_skips_writer_and_backup(tmp_path: Path) -> None:
     assert device_row[0] == 0
 
 
+def test_cached_path_backfills_device_files_for_pre_p1a_book(tmp_path: Path) -> None:
+    """Regression for #188.
+
+    Simulates a book that pre-dates P1a (#180): the kepub is already on the
+    device, the kepubify cache row exists, but ``device_files`` has no row
+    for it. Pre-P1a syncs never wrote one, and the cached short-circuit in
+    ``_sync_record`` was skipping the upsert on every subsequent run — so
+    the read-status push half of the sync couldn't see the book at all.
+
+    With the fix, the cached path re-stamps ``device_files`` and a later
+    status change in the catalog gets pushed to the device on the next sync.
+    """
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+                0,
+                0.0,
+                "2026-05-20T10:00:00",
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+
+    # The repro requires the kepubify cache to persist across syncs so that
+    # the second run hits the cached short-circuit in ``_sync_record``. The
+    # shared ``_run_sync`` helper creates a fresh cache per call, so wire up
+    # an explicit shared cache + workspace here.
+    shared_cache = KepubCache(tmp_path / "kepub.db")
+    stub = _StubKepubify()
+
+    def _sync(workspace_root: Path, *, backup_root: Path | None = None):
+        return sync_library_to_kobo(
+            catalog=catalog,
+            target=mount,
+            cache=shared_cache,
+            run_kepubify=stub.run,
+            kepubify_version=stub.get_version,
+            workspace_dir=workspace_root,
+            books_subdir="Books",
+            backup_root=backup_root,
+        )
+
+    # Sync once normally — populates the kepubify cache and writes a
+    # device_files row via the copy path.
+    _sync(tmp_path / "sync1-ws")
+
+    # Simulate pre-P1a state: wipe device_files so the cached path on the
+    # next sync is the only opportunity to recreate the row.
+    catalog._conn.execute("DELETE FROM device_files")
+    catalog._conn.commit()
+
+    catalog.set_book_status(
+        book_id=book_id, status=STATUS_FINISHED, updated_at="2026-05-26T11:00:00"
+    )
+
+    # Second sync hits the cached path (kepub already on device, cache row
+    # present). Without the fix, no device_files row is written and the
+    # push silently no-ops.
+    report = _sync(tmp_path / "sync2-ws", backup_root=tmp_path / "backups")
+
+    assert report.read_statuses_pushed == 1
+    assert report.read_status_push_failed == []
+    device_row = sqlite3.connect(str(kobo_db)).execute(
+        "SELECT ReadStatus FROM content WHERE ContentID = ?",
+        ("file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",),
+    ).fetchone()
+    assert device_row[0] == 2
+
+
 def test_reading_status_pushes_without_clobbering_percent(tmp_path: Path) -> None:
     """STATUS_READING preserves the device's progress percentage."""
     db_path = tmp_path / "library.db"

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -548,7 +548,12 @@ class TestDeviceWiring:
             assert call["remote_path"].endswith(".kepub.epub")
             assert call["device_id"] == catalog.device_id
 
-    def test_no_device_file_upsert_when_copy_skipped(self, tmp_path: Path) -> None:
+    def test_device_file_re_upserted_on_cached_path(self, tmp_path: Path) -> None:
+        # Regression for #188: when the kepub cache hits on a subsequent sync,
+        # the device_file row must still be re-stamped. Otherwise books that
+        # were synced before P1a shipped — or any book that's been on the
+        # device long enough to hit the cached path — stay invisible to
+        # ``list_push_candidates`` and the read-status push silently no-ops.
         env = _setup(tmp_path)
         epub = env["library"] / "A" / "T" / "T.epub"
         _write_epub(epub)
@@ -566,8 +571,11 @@ class TestDeviceWiring:
             books_subdir="Books",
         )
         baseline = len(catalog.upsert_device_file_calls)
+        assert baseline == 1
+        first_remote = catalog.upsert_device_file_calls[0]["remote_path"]
 
-        # Second sync — kepub cache hits, file skipped; no new device_file row.
+        # Second sync — kepub cache hits, copy is skipped. The device_file
+        # upsert still runs (idempotent) so push_candidates can see the book.
         sync_library_to_kobo(
             catalog=catalog,
             target=env["target"],
@@ -577,7 +585,11 @@ class TestDeviceWiring:
             workspace_dir=env["workspace"],
             books_subdir="Books",
         )
-        assert len(catalog.upsert_device_file_calls) == baseline
+        assert len(catalog.upsert_device_file_calls) == baseline + 1
+        cached_call = catalog.upsert_device_file_calls[-1]
+        assert cached_call["book_id"] == 1
+        assert cached_call["device_id"] == catalog.device_id
+        assert cached_call["remote_path"] == first_remote
 
     def test_dry_run_does_not_touch_device_tables(self, tmp_path: Path) -> None:
         env = _setup(tmp_path)


### PR DESCRIPTION
## Summary
- Fixes #188 — read-status push silently no-ops for any book already on the Kobo.
- Root cause: `_sync_record`'s cached short-circuit bailed before `catalog.upsert_device_file(...)`, leaving `device_files` empty for pre-P1a books and for any book that hit the cached path. `list_push_candidates` (FROM device_files) then returned nothing.
- Fix: re-stamp `device_files` on the cached branch with the same idempotent upsert the copy branch already runs.

## Changes
- **src/bookery/device/kobo.py**: add `catalog.upsert_device_file(...)` inside the cached branch of `_sync_record`. One-line conceptual change; the upsert is idempotent (`ON CONFLICT … DO UPDATE`).
- **tests/unit/test_device_kobo_sync.py**: flip the prior `test_no_device_file_upsert_when_copy_skipped` (which pinned the buggy contract) into `test_device_file_re_upserted_on_cached_path` asserting the fix.
- **tests/integration/test_sync_kobo_push.py**: new `test_cached_path_backfills_device_files_for_pre_p1a_book` reproduces the bug end-to-end (sync → wipe device_files → mark Finished → second sync hits cached path → push update lands). Uses an explicit shared `KepubCache` because the shared `_run_sync` helper creates a fresh cache per call — that was why the existing P2 push tests didn't catch this.

## Testing
- [x] Unit test fails on baseline, passes with fix (verified via `git stash` revert).
- [x] Integration test fails on baseline (`read_statuses_pushed=0`), passes with fix (`=1`).
- [x] Full suite: 1858 passed.
- [x] `ruff check` clean; pre-commit pyright clean.
- [ ] Verify on real device that a pre-existing book reflects a status change after one extra sync.

## Related Issues
Fixes #188
Part of epic #178 (Kobo read-status sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)