### PR TITLE
Add #190: Pre-pull discovery phase reconciles device_files

### DIFF
--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -35,6 +35,11 @@ def _print_status_summary(report) -> None:  # type: ignore[no-untyped-def]
     whenever a snapshot was taken (i.e. a push actually ran) regardless of
     the push outcome — the user wants to know where the safety net is.
     """
+    if report.device_files_discovered:
+        console.print(
+            f"[dim]Discovered {report.device_files_discovered} existing "
+            f"book(s) on device[/dim]"
+        )
     if report.read_states_pulled or report.read_states_skipped:
         console.print(
             f"[dim]Read-state: pulled {report.read_states_pulled}, "

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -95,6 +95,11 @@ class SyncReport:
     failed: list[tuple[Path, str]] = field(default_factory=list)
     read_states_pulled: int = 0
     read_states_skipped: int = 0
+    # Number of device_files rows the pre-pull discovery phase wrote (or
+    # re-stamped) by matching catalog records against files already on the
+    # mount. Surfaces the self-healing pass so users can see why a previously
+    # quiet pull suddenly resolves a large cohort.
+    device_files_discovered: int = 0
     # P2: device-side write counts. ``read_statuses_pushed`` is rows we
     # actually mutated on the Kobo; ``read_status_pull_only`` is push
     # candidates whose ContentID didn't match a current device row (book
@@ -163,6 +168,65 @@ def _book_dest_dir(target: Path, books_subdir: str, record: BookRecord) -> Path:
     return target / books_subdir / author / title
 
 
+def _compute_device_dest(target: Path, books_subdir: str, record: BookRecord) -> Path:
+    """Host-side path where the kepub for ``record`` would live on the mount.
+
+    Pure function — does no I/O. Shared by the copy phase (which writes to this
+    path) and the discovery phase (which checks whether it exists). Keeping the
+    naming convention in one place prevents the two phases from drifting.
+    """
+    dest_dir = _book_dest_dir(target, books_subdir, record)
+    title = sanitize_component(record.metadata.title, fallback="Untitled")
+    return dest_dir / f"{title}.kepub.epub"
+
+
+class _DiscoveryCatalogProto(Protocol):
+    def upsert_device_file(
+        self, *, device_id: int, book_id: int, remote_path: str, now: str
+    ) -> None: ...
+
+
+def discover_existing_device_files(
+    catalog: _DiscoveryCatalogProto,
+    *,
+    records: list[BookRecord],
+    target: Path,
+    books_subdir: str,
+    device_id: int,
+    now: str,
+) -> int:
+    """Reconcile ``device_files`` against books already present on the mount.
+
+    For each catalog record with an ``output_path``, compute the host-side
+    path where the kepub would live (:func:`_compute_device_dest`) and, if a
+    file is present there, upsert the corresponding ``device_files`` row.
+
+    Runs before :func:`pull_read_state` so that books bookery copied in a
+    prior session — or in this same session's cached path — are visible to
+    ``resolve_book_id_for_remote_path``. Without this pass, a brand-new
+    ``device_files`` schema (introduced in #180) sees only the books bookery
+    has just full-converted, missing the long tail.
+
+    Cost is one ``Path.exists()`` per record; sub-second for thousands of
+    books. Returns the number of upserts performed.
+    """
+    discovered = 0
+    for record in records:
+        if record.output_path is None:
+            continue
+        dest = _compute_device_dest(target, books_subdir, record)
+        if not dest.exists():
+            continue
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=record.id,
+            remote_path=_to_device_path(dest, target),
+            now=now,
+        )
+        discovered += 1
+    return discovered
+
+
 def _sync_record(
     record: BookRecord,
     *,
@@ -193,9 +257,8 @@ def _sync_record(
         report.failed.append((source, f"source missing: {source}"))
         return
 
-    dest_dir = _book_dest_dir(target, books_subdir, record)
-    title = sanitize_component(record.metadata.title, fallback="Untitled")
-    dest = dest_dir / f"{title}.kepub.epub"
+    dest = _compute_device_dest(target, books_subdir, record)
+    dest_dir = dest.parent
 
     stage("hash")
     try:
@@ -380,9 +443,7 @@ def sync_library_to_kobo(
             if source.suffix.lower() != ".epub":
                 report.skipped.append((source, "output is not an EPUB"))
                 continue
-            dest_dir = _book_dest_dir(target, books_subdir, record)
-            title = sanitize_component(record.metadata.title, fallback="Untitled")
-            report.copied.append(dest_dir / f"{title}.kepub.epub")
+            report.copied.append(_compute_device_dest(target, books_subdir, record))
         return report
 
     version = kepubify_version()
@@ -405,6 +466,24 @@ def sync_library_to_kobo(
         )
     if serial is not None:
         device_id = catalog.upsert_device(kind="kobo", serial=serial, label=None, now=now)
+        # Discovery runs *before* the pull so that books bookery copied in a
+        # prior session — or that pre-date the `device_files` schema (#180) —
+        # are resolvable by ContentID. Without this, the pull can only see
+        # books bookery has just full-converted in this session, missing the
+        # long tail (#190).
+        try:
+            report.device_files_discovered = discover_existing_device_files(
+                catalog,
+                records=records,
+                target=target,
+                books_subdir=books_subdir,
+                device_id=device_id,
+                now=now,
+            )
+        except Exception as exc:
+            logger.warning(
+                "device_files discovery failed; continuing with pull: %s", exc
+            )
         try:
             pulled, skipped = pull_read_state(
                 catalog, device_id=device_id, mount_path=target, now=now

--- a/tests/integration/test_sync_kobo_read_status.py
+++ b/tests/integration/test_sync_kobo_read_status.py
@@ -205,6 +205,125 @@ def test_round_trip_sync_populates_read_state_and_book_status(tmp_path: Path) ->
     conn.close()
 
 
+def test_discovery_resolves_legacy_cohort_on_first_sync(tmp_path: Path) -> None:
+    """Regression for #190: device has books, catalog has them, device_files empty.
+
+    Reproduces the real-world case where a user has been syncing books to a
+    Kobo for ages (so the device has them and KoboReader.sqlite has read-status
+    for them) but the catalog's ``device_files`` table is empty because that
+    schema only landed in #180. Without the pre-pull discovery phase, the
+    first sync resolves zero books. With it, the first sync resolves the
+    cohort that is actually on disk.
+    """
+    db_path = tmp_path / "library.db"
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub_a = library / "Asimov" / "Foundation" / "Foundation.epub"
+    epub_b = library / "Le Guin" / "Earthsea" / "Earthsea.epub"
+    epub_c = library / "Tolkien" / "Hobbit" / "Hobbit.epub"
+    for path in (epub_a, epub_b, epub_c):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"EPUB")
+    book_a = catalog.add_book(
+        BookMetadata(title="Foundation", authors=["Asimov"], source_path=epub_a),
+        file_hash="hash-a",
+        output_path=epub_a,
+    )
+    book_b = catalog.add_book(
+        BookMetadata(title="Earthsea", authors=["Le Guin"], source_path=epub_b),
+        file_hash="hash-b",
+        output_path=epub_b,
+    )
+    book_c = catalog.add_book(
+        BookMetadata(title="Hobbit", authors=["Tolkien"], source_path=epub_c),
+        file_hash="hash-c",
+        output_path=epub_c,
+    )
+
+    # Pre-populate the mount with two of the three books (the third is in the
+    # library but hasn't been copied yet). Critically, do NOT pre-populate
+    # device_files — that's the bug we're proving discovery fixes.
+    mount = _build_fake_kobo_mount(tmp_path)
+    for rel in (
+        "Books/Asimov/Foundation/Foundation.kepub.epub",
+        "Books/Le Guin/Earthsea/Earthsea.kepub.epub",
+    ):
+        dest = mount / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"FAKE-KEPUB-FROM-LEGACY-SYNC")
+
+    # KoboReader.sqlite has read-status for all three books.
+    kobo_db = mount / ".kobo" / "KoboReader.sqlite"
+    _seed_kobo_db(
+        kobo_db,
+        [
+            (
+                "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub",
+                None,
+                2,
+                1.0,
+                "2026-05-20T10:00:00",
+                None,
+                "application/x-kobo-epub+zip",
+            ),
+            (
+                "file:///mnt/onboard/Books/Le Guin/Earthsea/Earthsea.kepub.epub",
+                None,
+                1,
+                0.42,
+                "2026-05-21T11:00:00",
+                None,
+                "application/x-kobo-epub+zip",
+            ),
+            (
+                "file:///mnt/onboard/Books/Tolkien/Hobbit/Hobbit.kepub.epub",
+                None,
+                2,
+                1.0,
+                "2026-05-22T12:00:00",
+                None,
+                "application/x-kobo-epub+zip",
+            ),
+        ],
+    )
+
+    cache = KepubCache(tmp_path / "kepub.db")
+    kepubify = _StubKepubify()
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=cache,
+        run_kepubify=kepubify.run,
+        kepubify_version=kepubify.get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+    )
+
+    # The two books already on the device should have been discovered and
+    # pulled in this single sync. The third book has no file on the mount
+    # at pull time, so discovery cannot stamp it — its row in KoboReader is
+    # skipped this round (it does get copied later in the same sync's copy
+    # phase, so a subsequent sync will pick it up).
+    assert report.device_files_discovered == 2
+    assert report.read_states_pulled == 2
+    assert report.read_states_skipped == 1
+
+    # book_status mirror should reflect the device's read-state for the two
+    # discovered books — proving the pull actually merged the values, not
+    # just that the count is right.
+    statuses = {
+        row["book_id"]: row["status"]
+        for row in conn.execute("SELECT book_id, status FROM book_status").fetchall()
+    }
+    assert statuses[book_a] == 2
+    assert statuses[book_b] == 1
+    assert book_c not in statuses  # not pulled this sync
+
+    conn.close()
+
+
 def test_regression_sync_still_works_when_kobo_db_missing(tmp_path: Path) -> None:
     """Existing kepub-copy path must keep working when KoboReader.sqlite is absent."""
     db_path = tmp_path / "library.db"

--- a/tests/unit/test_device_kobo_discovery.py
+++ b/tests/unit/test_device_kobo_discovery.py
@@ -1,0 +1,185 @@
+# ABOUTME: Unit tests for discover_existing_device_files — the pre-pull phase
+# ABOUTME: that reconciles device_files against what's actually on the mount.
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from bookery.db.mapping import BookRecord
+from bookery.device.kobo import discover_existing_device_files
+from bookery.metadata.types import BookMetadata
+
+
+@dataclass
+class _StubCatalog:
+    upsert_calls: list[dict] = field(default_factory=list)
+
+    def upsert_device_file(
+        self, *, device_id: int, book_id: int, remote_path: str, now: str
+    ) -> None:
+        self.upsert_calls.append(
+            {
+                "device_id": device_id,
+                "book_id": book_id,
+                "remote_path": remote_path,
+                "now": now,
+            }
+        )
+
+
+def _record(
+    *, rec_id: int, title: str, author: str, output_path: Path | None
+) -> BookRecord:
+    metadata = BookMetadata(title=title, authors=[author] if author else [])
+    return BookRecord(
+        id=rec_id,
+        metadata=metadata,
+        file_hash="hash",
+        source_path=output_path or Path("/missing.epub"),
+        output_path=output_path,
+        date_added="2026-04-18T00:00:00",
+        date_modified="2026-04-18T00:00:00",
+    )
+
+
+def _seed_on_device(
+    target: Path, books_subdir: str, author: str, title: str, body: bytes = b"x"
+) -> Path:
+    # Mirror bookery's layout: <root>/<subdir>/<Author>/<Title>/<Title>.kepub.epub
+    dest = target / books_subdir / author / title / f"{title}.kepub.epub"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(body)
+    return dest
+
+
+def test_upserts_device_file_for_each_existing_book(tmp_path: Path) -> None:
+    target = tmp_path / "kobo"
+    target.mkdir()
+    _seed_on_device(target, "Bookery", "Asimov", "Foundation")
+    _seed_on_device(target, "Bookery", "Le Guin", "Earthsea")
+
+    catalog = _StubCatalog()
+    records = [
+        _record(
+            rec_id=1,
+            title="Foundation",
+            author="Asimov",
+            output_path=tmp_path / "lib" / "a.epub",
+        ),
+        _record(
+            rec_id=2,
+            title="Earthsea",
+            author="Le Guin",
+            output_path=tmp_path / "lib" / "b.epub",
+        ),
+    ]
+
+    discovered = discover_existing_device_files(
+        catalog,
+        records=records,
+        target=target,
+        books_subdir="Bookery",
+        device_id=7,
+        now="2026-05-26T16:30:00",
+    )
+
+    assert discovered == 2
+    assert len(catalog.upsert_calls) == 2
+    by_book = {call["book_id"]: call for call in catalog.upsert_calls}
+    assert (
+        by_book[1]["remote_path"]
+        == "/mnt/onboard/Bookery/Asimov/Foundation/Foundation.kepub.epub"
+    )
+    assert (
+        by_book[2]["remote_path"]
+        == "/mnt/onboard/Bookery/Le Guin/Earthsea/Earthsea.kepub.epub"
+    )
+    assert all(call["device_id"] == 7 for call in catalog.upsert_calls)
+    assert all(call["now"] == "2026-05-26T16:30:00" for call in catalog.upsert_calls)
+
+
+def test_skips_records_whose_dest_file_is_absent(tmp_path: Path) -> None:
+    target = tmp_path / "kobo"
+    target.mkdir()
+    # Only "Foundation" is actually on the device.
+    _seed_on_device(target, "Bookery", "Asimov", "Foundation")
+
+    catalog = _StubCatalog()
+    records = [
+        _record(
+            rec_id=1,
+            title="Foundation",
+            author="Asimov",
+            output_path=tmp_path / "lib" / "a.epub",
+        ),
+        _record(
+            rec_id=2,
+            title="Earthsea",
+            author="Le Guin",
+            output_path=tmp_path / "lib" / "b.epub",
+        ),
+    ]
+
+    discovered = discover_existing_device_files(
+        catalog,
+        records=records,
+        target=target,
+        books_subdir="Bookery",
+        device_id=7,
+        now="2026-05-26T16:30:00",
+    )
+
+    assert discovered == 1
+    assert [call["book_id"] for call in catalog.upsert_calls] == [1]
+
+
+def test_skips_records_with_no_output_path(tmp_path: Path) -> None:
+    target = tmp_path / "kobo"
+    target.mkdir()
+    # Seed a file at the path bookery would compute for the record — even so,
+    # a record with no output_path is not in the library and must not be
+    # claimed as if bookery had put it there.
+    _seed_on_device(target, "Bookery", "Asimov", "Foundation")
+
+    catalog = _StubCatalog()
+    records = [
+        _record(rec_id=1, title="Foundation", author="Asimov", output_path=None),
+    ]
+
+    discovered = discover_existing_device_files(
+        catalog,
+        records=records,
+        target=target,
+        books_subdir="Bookery",
+        device_id=7,
+        now="2026-05-26T16:30:00",
+    )
+
+    assert discovered == 0
+    assert catalog.upsert_calls == []
+
+
+def test_returns_zero_when_target_is_empty(tmp_path: Path) -> None:
+    target = tmp_path / "kobo"
+    target.mkdir()
+
+    catalog = _StubCatalog()
+    records = [
+        _record(
+            rec_id=1,
+            title="Foundation",
+            author="Asimov",
+            output_path=tmp_path / "lib" / "a.epub",
+        ),
+    ]
+
+    discovered = discover_existing_device_files(
+        catalog,
+        records=records,
+        target=target,
+        books_subdir="Bookery",
+        device_id=7,
+        now="2026-05-26T16:30:00",
+    )
+
+    assert discovered == 0
+    assert catalog.upsert_calls == []

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -574,8 +574,10 @@ class TestDeviceWiring:
         assert baseline == 1
         first_remote = catalog.upsert_device_file_calls[0]["remote_path"]
 
-        # Second sync — kepub cache hits, copy is skipped. The device_file
-        # upsert still runs (idempotent) so push_candidates can see the book.
+        # Second sync — two upserts now: the pre-pull discovery phase (#190)
+        # sees the file already on the device and stamps device_files, and
+        # the cached path in the copy loop re-stamps it again (#188). Both
+        # are idempotent and must point at the same canonical remote_path.
         sync_library_to_kobo(
             catalog=catalog,
             target=env["target"],
@@ -585,11 +587,11 @@ class TestDeviceWiring:
             workspace_dir=env["workspace"],
             books_subdir="Books",
         )
-        assert len(catalog.upsert_device_file_calls) == baseline + 1
-        cached_call = catalog.upsert_device_file_calls[-1]
-        assert cached_call["book_id"] == 1
-        assert cached_call["device_id"] == catalog.device_id
-        assert cached_call["remote_path"] == first_remote
+        assert len(catalog.upsert_device_file_calls) == baseline + 2
+        for call in catalog.upsert_device_file_calls[baseline:]:
+            assert call["book_id"] == 1
+            assert call["device_id"] == catalog.device_id
+            assert call["remote_path"] == first_remote
 
     def test_dry_run_does_not_touch_device_tables(self, tmp_path: Path) -> None:
         env = _setup(tmp_path)


### PR DESCRIPTION
Closes #190.

## Summary
- Before pulling read-state, walk the catalog and stamp `device_files` for any book whose expected device path already exists on the mount.
- Makes the pull's exact-match resolver work for books bookery copied in prior sessions or that pre-date the `device_files` schema (#180).
- Surfaces a `Discovered N existing book(s) on device` line in the CLI when non-zero.

## Why
On a real Kobo with ~1100 sideloaded books, the first sync after #180/#188 only resolved ~10 books — the small set bookery happened to full-convert this session. The pull was gated on `device_files`, which is brand new and only got written by the copy phase. Discovery is the missing reconciliation step: cheap (`stat` per record), idempotent, runs every sync.

## Test plan
- [x] Unit tests for `discover_existing_device_files` — existing files upserted, missing files skipped, `output_path=None` skipped, empty mount returns 0
- [x] Integration test: device has 2/3 books on disk, `device_files` empty, KoboReader.sqlite has 3 rows. After **one** sync, `read_states_pulled == 2` (was 0 before the fix)
- [x] #188 regression test updated — second sync now correctly shows both discovery + cached-path upserts (both idempotent, same `remote_path`)
- [x] Full suite: 1863 passed
- [x] ruff clean, pyright clean
- [ ] Smoke test on the real Libra Colour — run `uv run bookery sync kobo` once, expect `Read-state: pulled <large>, skipped <small>` and `Discovered <N> existing book(s) on device`