### PR TITLE
Add #167: Pre-commit runs ruff format --check on staged files

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -18,6 +18,12 @@ if ! uv run ruff check $STAGED_FILES; then
     FAILED=1
 fi
 
+echo "pre-commit: ruff format --check..."
+if ! uv run ruff format --check $STAGED_FILES; then
+    echo "pre-commit: run 'uv run ruff format <file>' to fix formatting."
+    FAILED=1
+fi
+
 echo "pre-commit: pyright..."
 if ! uv run pyright $STAGED_FILES; then
     FAILED=1


### PR DESCRIPTION
## Summary
- Adds a third step to `hooks/pre-commit` that runs `uv run ruff format --check $STAGED_FILES`, mirroring the existing `ruff check` block and feeding the same `FAILED` flag.
- On failure, prints `pre-commit: run 'uv run ruff format <file>' to fix formatting.` so the fix is one copy-paste away.
- Closes #167.

## Test plan
- [x] With `core.hooksPath=hooks`, staged a Python file with bad formatting (`def foo( x,y ): return x+y`). Hook reported `1 file would be reformatted`, emitted the fix-suggestion message, and exited 1 — commit blocked.
- [x] Ran `uv run ruff format` on the same file, re-staged, retried commit. All three steps (ruff check, ruff format --check, pyright) passed and the commit went through.
- [x] Confirmed no other files were modified — diff is the 6-line addition to `hooks/pre-commit`.