### PR TITLE
Fix #166: Contain provenance overflow and move panel into a disclosure

### DIFF
--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -394,7 +394,7 @@ header .logo {
 
 .metadata-grid {
     display: grid;
-    grid-template-columns: 8rem 1fr;
+    grid-template-columns: 8rem minmax(0, 1fr);
     gap: 0.25rem 1rem;
 }
 
@@ -403,9 +403,15 @@ header .logo {
     color: var(--color-muted);
 }
 
+.metadata-grid dd {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
 .metadata-grid code {
     font-size: 0.85rem;
     word-break: break-all;
+    overflow-wrap: anywhere;
 }
 
 /* Edit layout — two columns >=720px, stacked below. */

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -416,31 +416,33 @@ header .logo {
 
 /* Edit layout — two columns >=720px, stacked below. */
 
-.edit-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.5rem;
-}
-
-@media (min-width: 720px) {
-    .edit-layout {
-        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-    }
-}
+/* Provenance disclosure — collapsible reference panel below the edit form. */
 
 .provenance {
+    margin-top: 1.5rem;
+    max-width: 600px;
     background: var(--color-hover);
-    padding: 1rem;
     border-radius: 4px;
     font-size: 0.9rem;
 }
 
-.provenance h3 {
+.provenance summary {
+    padding: 0.75rem 1rem;
+    cursor: pointer;
     font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--color-muted);
-    margin-bottom: 0.5rem;
+    user-select: none;
+}
+
+.provenance[open] summary {
+    border-bottom: 1px solid var(--color-border);
+}
+
+.provenance > .metadata-grid {
+    padding: 1rem;
 }
 
 /* Mobile: collapse detail metadata-grid to single column. */

--- a/src/bookery/web/templates/_edit_form.html
+++ b/src/bookery/web/templates/_edit_form.html
@@ -1,72 +1,70 @@
-{# ABOUTME: Inline edit form with read-only provenance panel and Esc-to-cancel. #}
-{# ABOUTME: Two-column on >=720px viewports, stacked on mobile (handled by CSS). #}
+{# ABOUTME: Inline edit form with collapsible provenance disclosure and Esc-to-cancel. #}
+{# ABOUTME: Provenance lives below the form — reference data, not editing data. #}
 {% include "_book_subhead.html" %}
 <h1 class="page-title">Edit: {{ book.metadata.title }}</h1>
-<div class="edit-layout">
-    <form class="edit-form"
-          hx-post="{{ url_for('web.update_book', book_id=book.id, return_to=return_to or none) }}"
-          hx-target="#book-content"
-          hx-swap="innerHTML">
-        {% if error %}
-        <div class="form-error" role="alert">{{ error }}</div>
-        {% endif %}
+<form class="edit-form"
+      hx-post="{{ url_for('web.update_book', book_id=book.id, return_to=return_to or none) }}"
+      hx-target="#book-content"
+      hx-swap="innerHTML">
+    {% if error %}
+    <div class="form-error" role="alert">{{ error }}</div>
+    {% endif %}
 
-        <div class="form-group">
-            <label for="title">Title <span class="required">*</span></label>
-            <input type="text" id="title" name="title" value="{{ book.metadata.title }}" required>
+    <div class="form-group">
+        <label for="title">Title <span class="required">*</span></label>
+        <input type="text" id="title" name="title" value="{{ book.metadata.title }}" required>
+    </div>
+
+    <div class="form-group">
+        <label for="authors">Authors <span class="hint">(semicolon-separated)</span></label>
+        <input type="text" id="authors" name="authors" value="{{ book.metadata.authors | join('; ') }}">
+    </div>
+
+    <div class="form-group">
+        <label for="isbn">ISBN</label>
+        <input type="text" id="isbn" name="isbn" value="{{ book.metadata.isbn or '' }}">
+    </div>
+
+    <div class="form-group">
+        <label for="language">Language</label>
+        <input type="text" id="language" name="language" value="{{ book.metadata.language or '' }}">
+    </div>
+
+    <div class="form-group">
+        <label for="publisher">Publisher</label>
+        <input type="text" id="publisher" name="publisher" value="{{ book.metadata.publisher or '' }}">
+    </div>
+
+    <div class="form-group">
+        <label for="description">Description</label>
+        <textarea id="description" name="description" rows="4">{{ book.metadata.description or '' }}</textarea>
+    </div>
+
+    <div class="form-group form-row">
+        <div>
+            <label for="series">Series</label>
+            <input type="text" id="series" name="series" value="{{ book.metadata.series or '' }}">
         </div>
-
-        <div class="form-group">
-            <label for="authors">Authors <span class="hint">(semicolon-separated)</span></label>
-            <input type="text" id="authors" name="authors" value="{{ book.metadata.authors | join('; ') }}">
+        <div>
+            <label for="series_index">Series #</label>
+            <input type="number" id="series_index" name="series_index" step="any" value="{{ book.metadata.series_index if book.metadata.series_index is not none else '' }}">
         </div>
+    </div>
 
-        <div class="form-group">
-            <label for="isbn">ISBN</label>
-            <input type="text" id="isbn" name="isbn" value="{{ book.metadata.isbn or '' }}">
-        </div>
+    <div class="form-actions">
+        <button type="submit" class="btn btn-primary">Save</button>
+        {%- set cancel_url = url_for('web.book_detail', book_id=book.id, return_to=return_to or none) -%}
+        <button type="button"
+                class="btn btn-secondary"
+                id="edit-cancel"
+                hx-get="{{ cancel_url }}"
+                hx-push-url="{{ cancel_url }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Cancel</button>
+    </div>
+</form>
 
-        <div class="form-group">
-            <label for="language">Language</label>
-            <input type="text" id="language" name="language" value="{{ book.metadata.language or '' }}">
-        </div>
-
-        <div class="form-group">
-            <label for="publisher">Publisher</label>
-            <input type="text" id="publisher" name="publisher" value="{{ book.metadata.publisher or '' }}">
-        </div>
-
-        <div class="form-group">
-            <label for="description">Description</label>
-            <textarea id="description" name="description" rows="4">{{ book.metadata.description or '' }}</textarea>
-        </div>
-
-        <div class="form-group form-row">
-            <div>
-                <label for="series">Series</label>
-                <input type="text" id="series" name="series" value="{{ book.metadata.series or '' }}">
-            </div>
-            <div>
-                <label for="series_index">Series #</label>
-                <input type="number" id="series_index" name="series_index" step="any" value="{{ book.metadata.series_index if book.metadata.series_index is not none else '' }}">
-            </div>
-        </div>
-
-        <div class="form-actions">
-            <button type="submit" class="btn btn-primary">Save</button>
-            {%- set cancel_url = url_for('web.book_detail', book_id=book.id, return_to=return_to or none) -%}
-            <button type="button"
-                    class="btn btn-secondary"
-                    id="edit-cancel"
-                    hx-get="{{ cancel_url }}"
-                    hx-push-url="{{ cancel_url }}"
-                    hx-target="#book-content"
-                    hx-swap="innerHTML">Cancel</button>
-        </div>
-    </form>
-
-    {% include "_provenance.html" %}
-</div>
+{% include "_provenance.html" %}
 
 <script>
     // Esc cancels the edit and swaps back to the detail view.

--- a/src/bookery/web/templates/_provenance.html
+++ b/src/bookery/web/templates/_provenance.html
@@ -1,7 +1,7 @@
-{# ABOUTME: Read-only provenance panel for the edit page — paths, hash, dates. #}
-{# ABOUTME: Mirrors _detail_file.html content so editors see file context alongside the form. #}
-<aside class="provenance" aria-labelledby="edit-provenance">
-    <h2 id="edit-provenance">Provenance</h2>
+{# ABOUTME: Collapsible provenance disclosure for the edit page — paths, hash, dates. #}
+{# ABOUTME: Reference data, not editing data — closed by default to keep the form focused. #}
+<details class="provenance">
+    <summary>Provenance</summary>
     <dl class="metadata-grid">
         <dt>Format</dt>
         <dd>{{ file_info.format or "—" }}</dd>
@@ -18,4 +18,4 @@
         <dt>Modified</dt>
         <dd>{{ book.date_modified }}</dd>
     </dl>
-</aside>
+</details>

--- a/tests/web/test_edit.py
+++ b/tests/web/test_edit.py
@@ -69,6 +69,37 @@ class TestUpdateStillRendersDetail:
         assert 'aria-labelledby="detail-header"' in html
 
 
+class TestProvenanceDisclosure:
+    """Provenance is a collapsible disclosure below the form (issue #166)."""
+
+    def _html(self, mock_catalog, client) -> str:
+        mock_catalog.get_by_id.return_value = make_book(1)
+        return client.get("/books/1/edit").data.decode()
+
+    def test_provenance_is_a_details_element(self, mock_catalog, client):
+        html = self._html(mock_catalog, client)
+        # The panel must be wrapped in <details> so users can collapse it.
+        assert "<details" in html and "</details>" in html
+
+    def test_provenance_has_summary_label(self, mock_catalog, client):
+        html = self._html(mock_catalog, client)
+        assert re.search(r"<summary[^>]*>\s*Provenance\s*</summary>", html)
+
+    def test_provenance_is_closed_by_default(self, mock_catalog, client):
+        html = self._html(mock_catalog, client)
+        # No `open` attribute — the disclosure is collapsed on first render.
+        match = re.search(r"<details[^>]*>", html)
+        assert match, "expected a <details> element"
+        assert " open" not in match.group(0)
+
+    def test_provenance_renders_below_the_form(self, mock_catalog, client):
+        html = self._html(mock_catalog, client)
+        form_end = html.rfind("</form>")
+        provenance_start = html.find("<details")
+        assert form_end != -1 and provenance_start != -1
+        assert provenance_start > form_end
+
+
 class TestProvenanceOverflowCss:
     """CSS rules that keep long provenance values inside the panel (issue #166)."""
 

--- a/tests/web/test_edit.py
+++ b/tests/web/test_edit.py
@@ -1,6 +1,7 @@
 # ABOUTME: Tests for the restructured edit form + provenance panel (issue #112).
 # ABOUTME: Verifies provenance content, Esc keybind hook, and POST behavior preserved.
 
+import re
 from pathlib import Path
 
 from tests.web.conftest import make_book
@@ -68,6 +69,41 @@ class TestUpdateStillRendersDetail:
         assert 'aria-labelledby="detail-header"' in html
 
 
+class TestProvenanceOverflowCss:
+    """CSS rules that keep long provenance values inside the panel (issue #166)."""
+
+    def _rule_block(self, client, selector: str) -> str:
+        """Return the CSS declaration block for the given selector."""
+        response = client.get("/static/style.css")
+        assert response.status_code == 200
+        css = response.data.decode()
+        # Match `<selector> { ... }` (non-greedy, single block).
+        match = re.search(
+            rf"{re.escape(selector)}\s*\{{([^}}]*)\}}",
+            css,
+        )
+        assert match, f"Selector {selector!r} not found in style.css"
+        return match.group(1)
+
+    def test_metadata_grid_value_track_can_shrink(self, client):
+        # The value column must allow shrinking below content min-content so
+        # long paths/hashes don't blow out the grid track.
+        block = self._rule_block(client, ".metadata-grid")
+        assert "minmax(0, 1fr)" in block
+
+    def test_metadata_grid_dd_breaks_at_any_character(self, client):
+        # dd values need overflow-wrap: anywhere so space-less strings
+        # (hashes, deep paths) wrap inside the panel.
+        block = self._rule_block(client, ".metadata-grid dd")
+        assert "overflow-wrap: anywhere" in block
+        assert "min-width: 0" in block
+
+    def test_metadata_grid_code_breaks_at_any_character(self, client):
+        # <code> inside the grid needs overflow-wrap so hash strings break.
+        block = self._rule_block(client, ".metadata-grid code")
+        assert "overflow-wrap: anywhere" in block
+
+
 class TestDescriptionHtmlStripping:
     """Edit POSTs must store plain text — never HTML markup (issue #123)."""
 
@@ -89,21 +125,15 @@ class TestDescriptionHtmlStripping:
         return mock_catalog.update_book.call_args
 
     def test_html_tags_stripped_on_save(self, mock_catalog, client):
-        call = self._post_description(
-            mock_catalog, client, '<p class="description">A story.</p>'
-        )
+        call = self._post_description(mock_catalog, client, '<p class="description">A story.</p>')
         assert call.kwargs["description"] == "A story."
 
     def test_entities_decoded_on_save(self, mock_catalog, client):
-        call = self._post_description(
-            mock_catalog, client, "foo &amp; bar"
-        )
+        call = self._post_description(mock_catalog, client, "foo &amp; bar")
         assert call.kwargs["description"] == "foo & bar"
 
     def test_paragraphs_preserved_as_blank_lines(self, mock_catalog, client):
-        call = self._post_description(
-            mock_catalog, client, "<p>first</p><p>second</p>"
-        )
+        call = self._post_description(mock_catalog, client, "<p>first</p><p>second</p>")
         assert call.kwargs["description"] == "first\n\nsecond"
 
     def test_empty_html_becomes_none(self, mock_catalog, client):


### PR DESCRIPTION
## Summary

- Long source paths and file hashes were blowing out the provenance panel on the edit page.
- Two-commit fix: defensive CSS overflow rules + an IA change that moves provenance into a `<details>` disclosure below the form.

## Changes

### Commit 1 — `e5bbbd7` Defensive overflow containment

- `src/bookery/web/static/style.css` — `.metadata-grid` value column uses `minmax(0, 1fr)`; `.metadata-grid dd` gets `min-width: 0` + `overflow-wrap: anywhere`; `.metadata-grid code` adds `overflow-wrap: anywhere` alongside the existing `word-break: break-all`.
- `tests/web/test_edit.py` — `TestProvenanceOverflowCss` asserts those rules stay in the served stylesheet (regression guard).

### Commit 2 — `f7908b1` IA restructure

The overflow fix contained values inside the 225px-wide sidebar, but the 8rem label hogged 56% of the panel and values wrapped every four characters (hash row stood 200px tall). Root cause was the IA, not the CSS: provenance is reference data, not editing data, and doesn't belong as a permanent sidebar on a form.

- `_provenance.html` — `<aside>` + `<h2>` → `<details>` + `<summary>`, closed by default.
- `_edit_form.html` — drop the `.edit-layout` 2-column grid wrapper; the include now sits after `</form>`.
- `style.css` — remove `.edit-layout` rules and the dead `.provenance h3` rule; add `<details>`/`<summary>` styling.
- `tests/web/test_edit.py` — `TestProvenanceDisclosure` asserts the wrapper, summary label, closed-by-default state, and below-form placement.

## Testing

- 17/17 tests in `tests/web/test_edit.py` pass.
- 314/314 tests in `tests/web/` pass.
- Visual QA via Playwright at 1280px (closed and open) and 390px (mobile, single-column stacked). Screenshots show long paths wrap on word/character boundaries inside the disclosure's full-width container; hash collapses from a 200px-tall mess to two clean lines.
- Pre-commit hooks: ruff check + pyright clean.

## Related Issues

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)