### PR TITLE
Fix #196: Backfill author_sort so NULL values don't clump in browse

### DIFF
--- a/src/bookery/core/pathformat.py
+++ b/src/bookery/core/pathformat.py
@@ -5,6 +5,7 @@ import re
 import unicodedata
 from pathlib import Path
 
+from bookery.core.text_sort import compute_author_sort
 from bookery.metadata.types import BookMetadata
 
 # Characters unsafe for common filesystems (Windows, macOS, Linux)
@@ -62,27 +63,11 @@ def derive_author_sort(metadata: BookMetadata) -> str:
     Priority: author_sort field > first author inverted > "Unknown".
     Single-word names and names already containing commas are kept as-is.
     Multi-word names are inverted: "First Middle Last" -> "Last, First Middle".
+
+    Thin wrapper around `compute_author_sort` so the catalog write path
+    (`db.mapping`) and the V10 backfill (`db.schema`) share the same rule.
     """
-    if metadata.author_sort:
-        return metadata.author_sort
-
-    if not metadata.authors:
-        return "Unknown"
-
-    name = metadata.authors[0].strip()
-    if not name:
-        return "Unknown"
-
-    # Already contains a comma — assume it's already "Last, First"
-    if "," in name:
-        return name
-
-    parts = name.split()
-    if len(parts) == 1:
-        return name
-
-    # Invert: "First Middle Last" -> "Last, First Middle"
-    return f"{parts[-1]}, {' '.join(parts[:-1])}"
+    return compute_author_sort(metadata.authors, metadata.author_sort)
 
 
 def build_output_path(

--- a/src/bookery/core/text_sort.py
+++ b/src/bookery/core/text_sort.py
@@ -24,3 +24,36 @@ def compute_title_sort(title: str) -> str:
         return title
     stripped = LEADING_ARTICLE_RE.sub(r"\1", title, count=1).strip()
     return stripped or title
+
+
+def compute_author_sort(
+    authors: list[str], explicit_author_sort: str | None = None
+) -> str:
+    """Return a sortable author key derived from an authors list.
+
+    Mirrors `bookery.core.pathformat.derive_author_sort` but takes the raw
+    list directly so the same logic powers both the write path
+    (`db.mapping.metadata_to_row`) and the V10 backfill (issue #196), which
+    sees a JSON authors string rather than a `BookMetadata` wrapper.
+
+    Rules (in priority order):
+    1. A truthy ``explicit_author_sort`` wins — curator/provider values stay.
+    2. Empty / whitespace-only first author → "Unknown".
+    3. First-author already contains a comma → assumed pre-inverted, kept as-is.
+    4. Single-token first author (e.g. "Madonna") → kept as-is.
+    5. Multi-token name → "Last, First Middle" (split on whitespace, last
+       token first).
+    """
+    if explicit_author_sort:
+        return explicit_author_sort
+    if not authors:
+        return "Unknown"
+    name = authors[0].strip()
+    if not name:
+        return "Unknown"
+    if "," in name:
+        return name
+    parts = name.split()
+    if len(parts) == 1:
+        return name
+    return f"{parts[-1]}, {' '.join(parts[:-1])}"

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -10,7 +10,7 @@ from bookery.core.dedup import (
     normalize_for_dedup,
     normalize_isbn,
 )
-from bookery.core.text_sort import compute_title_sort
+from bookery.core.text_sort import compute_author_sort, compute_title_sort
 from bookery.db.mapping import (
     BookRecord,
     DuplicateMatch,
@@ -423,6 +423,16 @@ class LibraryCatalog:
             fields["title_sort"] = (
                 compute_title_sort(title_val) if isinstance(title_val, str) and title_val else None
             )
+
+        # Author-side twin: when `authors` changes (and the caller didn't
+        # explicitly set `author_sort` in the same call), re-derive the sort
+        # key from the new list so it stays in lock-step. An explicit
+        # `author_sort` always wins — curator/provider intent is respected.
+        # Runs before JSON-serialization so the helper sees a plain list.
+        if "authors" in fields and "author_sort" not in fields:
+            authors_val = fields["authors"]
+            if isinstance(authors_val, list):
+                fields["author_sort"] = compute_author_sort(authors_val)
 
         # JSON-serialize list/dict fields
         if "authors" in fields:

--- a/src/bookery/db/connection.py
+++ b/src/bookery/db/connection.py
@@ -1,12 +1,34 @@
 # ABOUTME: SQLite database connection management for the Bookery library catalog.
 # ABOUTME: Opens or creates the database, applies schema, and provides connection context.
 
+import json
 import sqlite3
 from pathlib import Path
 
+from bookery.core.text_sort import compute_author_sort
 from bookery.db.schema import MIGRATIONS, SCHEMA_V1
 
 DEFAULT_DB_PATH = Path.home() / ".bookery" / "library.db"
+
+
+def _author_sort_from_json(authors_json: str | None) -> str:
+    """SQLite UDF: derive an author sort key from a stored authors-JSON cell.
+
+    Used by the V10 backfill to express the same "Last, First Middle"
+    inversion rule that `compute_author_sort` enforces on the Python write
+    path. Gracefully handles NULL / empty / malformed JSON so the migration
+    can be run against any historical row shape — bad rows fall back to
+    "Unknown" rather than aborting the entire migration.
+    """
+    if not authors_json:
+        return "Unknown"
+    try:
+        authors = json.loads(authors_json)
+    except (TypeError, ValueError):
+        return "Unknown"
+    if not isinstance(authors, list):
+        return "Unknown"
+    return compute_author_sort([str(a) for a in authors])
 
 
 def _schema_exists(conn: sqlite3.Connection) -> bool:
@@ -67,6 +89,11 @@ def open_library(
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
+
+    # Register the JSON-aware author-sort UDF so SCHEMA_V10's backfill can call
+    # it from raw SQL. Registered before migrations run; left in place after
+    # so any future migration (or ad-hoc query) can reuse it.
+    conn.create_function("bookery_author_sort_from_json", 1, _author_sort_from_json)
 
     if not _schema_exists(conn):
         _apply_schema(conn)

--- a/src/bookery/db/mapping.py
+++ b/src/bookery/db/mapping.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from bookery.core.dedup import normalize_isbn
-from bookery.core.text_sort import compute_title_sort
+from bookery.core.text_sort import compute_author_sort, compute_title_sort
 from bookery.metadata.types import BookMetadata
 
 
@@ -67,7 +67,7 @@ def metadata_to_row(
         "title_sort": compute_title_sort(metadata.title) if metadata.title else None,
         "subtitle": metadata.subtitle,
         "authors": json.dumps(metadata.authors),
-        "author_sort": metadata.author_sort,
+        "author_sort": compute_author_sort(metadata.authors, metadata.author_sort),
         "language": metadata.language,
         "publisher": metadata.publisher,
         "isbn": normalize_isbn(metadata.isbn) or None,

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -257,6 +257,23 @@ UPDATE books SET title_sort = title WHERE title_sort IS NULL OR title_sort = '';
 INSERT INTO schema_version (version) VALUES (9);
 """
 
+# Backfill `author_sort` for legacy rows whose source EPUB didn't declare one
+# (issue #196). The column has existed since V1 but was only ever populated
+# when the metadata supplied it, so SQLite's "NULLs sort first" rule made
+# browse-by-author look randomly ordered on the first few pages. SQLite has
+# no REVERSE / split-by-last-whitespace primitive, so the migration delegates
+# to a UDF registered in `db.connection.open_library` that calls the same
+# `compute_author_sort` helper used by the catalog write path — keeping one
+# source of truth for the "Last, First Middle" inversion rule. Only rows with
+# a NULL or empty `author_sort` are touched; explicit values stay untouched.
+SCHEMA_V10 = """
+UPDATE books
+SET author_sort = bookery_author_sort_from_json(authors)
+WHERE author_sort IS NULL OR author_sort = '';
+
+INSERT INTO schema_version (version) VALUES (10);
+"""
+
 MIGRATIONS = [
     (2, SCHEMA_V2),
     (3, SCHEMA_V3),
@@ -266,4 +283,5 @@ MIGRATIONS = [
     (7, SCHEMA_V7),
     (8, SCHEMA_V8),
     (9, SCHEMA_V9),
+    (10, SCHEMA_V10),
 ]

--- a/tests/integration/test_catalog_path_truth.py
+++ b/tests/integration/test_catalog_path_truth.py
@@ -170,7 +170,7 @@ class TestMatchedSignal:
         db_path = tmp_path / "fresh.db"
         conn = open_library(db_path)
         try:
-            assert _get_schema_version(conn) == 9
+            assert _get_schema_version(conn) == 10
             cursor = conn.execute("PRAGMA table_info(books)")
             cols = {row["name"] for row in cursor.fetchall()}
             assert "metadata_matched_at" in cols
@@ -284,7 +284,7 @@ class TestMatchedSignal:
         # Reopen to trigger V7 migration
         conn = open_library(db_path)
         try:
-            assert _get_schema_version(conn) == 9
+            assert _get_schema_version(conn) == 10
             rows = conn.execute(
                 "SELECT title, metadata_matched_at FROM books ORDER BY title"
             ).fetchall()

--- a/tests/integration/test_migration_lifecycle.py
+++ b/tests/integration/test_migration_lifecycle.py
@@ -30,7 +30,7 @@ class TestMigrationLifecycle:
 
         # Step 2: Open with bookery to trigger migration
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 9
+        assert _get_schema_version(conn) == 10
 
         # Step 3: Verify the book survived and tags work
         catalog = LibraryCatalog(conn)
@@ -51,7 +51,7 @@ class TestMigrationLifecycle:
         # Open 3 times
         for _ in range(3):
             conn = open_library(db_path)
-            assert _get_schema_version(conn) == 9
+            assert _get_schema_version(conn) == 10
             conn.close()
 
         # Final open — add a book and tag it
@@ -105,7 +105,7 @@ class TestMigrationLifecycle:
 
         # Step 3: open via the library code, which applies V9.
         conn = open_library(db_path)
-        assert _get_schema_version(conn) == 9
+        assert _get_schema_version(conn) == 10
 
         # Step 4: verify backfill on every row.
         cursor = conn.execute("SELECT title, title_sort FROM books ORDER BY id")
@@ -117,6 +117,68 @@ class TestMigrationLifecycle:
             "Dune": "Dune",
             "the lower case": "lower case",
             "The": "The",  # fallback when stripping leaves empty
+        }
+        conn.close()
+
+    def test_v9_db_with_authorless_books_backfills_author_sort(self, tmp_path: Path) -> None:
+        """V10 backfill derives author_sort from authors for existing rows.
+
+        Stage a database at V9 (the pre-#196 production schema), insert books
+        whose ``author_sort`` is NULL or empty across the derivation rules,
+        then trigger the V10 migration via ``open_library`` and assert each
+        row's ``author_sort`` matches what ``compute_author_sort`` would
+        produce. Existing non-empty values must be preserved.
+        """
+        db_path = tmp_path / "v10_backfill.db"
+
+        # Step 1: hand-roll a V9 database — V1 plus every migration up to and
+        # including V9. Stops short of V10 so we can verify its backfill.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executescript(SCHEMA_V1)
+        for version, sql in MIGRATIONS:
+            if version <= 9:
+                conn.executescript(sql)
+
+        # Step 2: insert rows directly so we bypass any Python-side population
+        # of `author_sort`. Mix NULL/empty author_sort cases (the backfill
+        # targets) with a pre-set value (must survive untouched).
+        # Tuple shape: (title, authors_json, author_sort)
+        rows = [
+            ("Two-word inverts", '["Umberto Eco"]', None),
+            ("Three-word inverts on last", '["Gabriel Garcia Marquez"]', None),
+            ("Single-word kept", '["Madonna"]', None),
+            ("Comma-name kept", '["Eco, Umberto"]', None),
+            ("Co-authors use first", '["Neil Gaiman", "Terry Pratchett"]', None),
+            ("No authors falls to Unknown", "[]", None),
+            ("Empty-string also backfilled", '["Umberto Eco"]', ""),
+            ("Pre-set author_sort preserved", '["Should be ignored"]', "Already, Set"),
+        ]
+        for i, (title, authors_json, author_sort) in enumerate(rows):
+            conn.execute(
+                "INSERT INTO books (title, authors, author_sort, source_path, file_hash) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (title, authors_json, author_sort, f"/{i}.epub", f"hash{i}"),
+            )
+        conn.commit()
+        conn.close()
+
+        # Step 3: open via the library code, which applies V10.
+        conn = open_library(db_path)
+        assert _get_schema_version(conn) == 10
+
+        # Step 4: verify backfill on every row.
+        cursor = conn.execute("SELECT title, author_sort FROM books ORDER BY id")
+        backfilled = {row[0]: row[1] for row in cursor.fetchall()}
+        assert backfilled == {
+            "Two-word inverts": "Eco, Umberto",
+            "Three-word inverts on last": "Marquez, Gabriel Garcia",
+            "Single-word kept": "Madonna",
+            "Comma-name kept": "Eco, Umberto",
+            "Co-authors use first": "Gaiman, Neil",
+            "No authors falls to Unknown": "Unknown",
+            "Empty-string also backfilled": "Eco, Umberto",
+            "Pre-set author_sort preserved": "Already, Set",
         }
         conn.close()
 

--- a/tests/unit/test_db_crud.py
+++ b/tests/unit/test_db_crud.py
@@ -290,6 +290,97 @@ class TestTitleSortPersistence:
         assert self._title_sort_for(catalog, book_id) == "Hobbit"
 
 
+class TestAuthorSortPersistence:
+    """`author_sort` is populated on insert and refreshed on authors updates (#196)."""
+
+    def _author_sort_for(self, catalog: LibraryCatalog, book_id: int) -> str | None:
+        # Mirrors `_title_sort_for`: read the column directly so the test
+        # asserts the persisted value rather than a derived view.
+        row = catalog._conn.execute(
+            "SELECT author_sort FROM books WHERE id = ?", (book_id,)
+        ).fetchone()
+        return row["author_sort"] if row is not None else None
+
+    def test_insert_with_explicit_author_sort_is_stored_as_is(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="The Name of the Rose",
+                authors=["Umberto Eco"],
+                author_sort="Eco, Umberto",
+                source_path=Path("/r.epub"),
+            ),
+            file_hash="hashexplicit",
+        )
+        assert self._author_sort_for(catalog, book_id) == "Eco, Umberto"
+
+    def test_insert_without_author_sort_derives_from_authors(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="The Name of the Rose",
+                authors=["Umberto Eco"],
+                source_path=Path("/r.epub"),
+            ),
+            file_hash="hashderive",
+        )
+        assert self._author_sort_for(catalog, book_id) == "Eco, Umberto"
+
+    def test_insert_no_authors_falls_back_to_unknown(self, catalog: LibraryCatalog) -> None:
+        book_id = catalog.add_book(
+            BookMetadata(title="Anonymous Work", source_path=Path("/a.epub")),
+            file_hash="hashanon",
+        )
+        assert self._author_sort_for(catalog, book_id) == "Unknown"
+
+    def test_update_authors_refreshes_author_sort(self, catalog: LibraryCatalog) -> None:
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="Title",
+                authors=["Umberto Eco"],
+                source_path=Path("/t.epub"),
+            ),
+            file_hash="hashupdate1",
+        )
+        catalog.update_book(book_id, authors=["Gabriel Garcia Marquez"])
+        assert self._author_sort_for(catalog, book_id) == "Marquez, Gabriel Garcia"
+
+    def test_update_unrelated_field_preserves_author_sort(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="Title",
+                authors=["Umberto Eco"],
+                source_path=Path("/t.epub"),
+            ),
+            file_hash="hashupdate2",
+        )
+        catalog.update_book(book_id, description="A description")
+        assert self._author_sort_for(catalog, book_id) == "Eco, Umberto"
+
+    def test_update_with_explicit_author_sort_wins(self, catalog: LibraryCatalog) -> None:
+        """When the caller passes both ``authors`` and ``author_sort``, the
+        explicit value wins — same convention as ``title_sort`` honoring an
+        explicit ``title`` field when both are updated together."""
+        book_id = catalog.add_book(
+            BookMetadata(
+                title="Title",
+                authors=["Umberto Eco"],
+                source_path=Path("/t.epub"),
+            ),
+            file_hash="hashupdate3",
+        )
+        catalog.update_book(
+            book_id,
+            authors=["Gabriel Garcia Marquez"],
+            author_sort="Curator, Override",
+        )
+        assert self._author_sort_for(catalog, book_id) == "Curator, Override"
+
+
 class TestListMethodsArticleStrippedOrder:
     """Catalog list methods sort by the persisted article-stripped key (#192).
 

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -86,7 +86,7 @@ class TestOpenLibrary:
         row = cursor.fetchone()
         conn.close()
         assert row is not None
-        assert row[0] == 9
+        assert row[0] == 10
 
     def test_creates_indexes(self, db_path: Path) -> None:
         """Expected indexes exist on the books table."""

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 9
+        assert version == 10
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -126,7 +126,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 9
+        assert version == 10
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")

--- a/tests/unit/test_text_sort.py
+++ b/tests/unit/test_text_sort.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from bookery.core.text_sort import LEADING_ARTICLE_RE, compute_title_sort
+from bookery.core.text_sort import (
+    LEADING_ARTICLE_RE,
+    compute_author_sort,
+    compute_title_sort,
+)
 
 
 class TestComputeTitleSort:
@@ -63,3 +67,56 @@ class TestLeadingArticleRe:
         # Vault assemble.py reuses this. Lock the import contract.
         assert LEADING_ARTICLE_RE.match("The Hobbit") is not None
         assert LEADING_ARTICLE_RE.match("Hobbit") is None
+
+
+class TestComputeAuthorSort:
+    """Author-side twin of compute_title_sort. Mirrors derive_author_sort's rules
+    so it can be reused both at write-time (mapping.py) and during the V10
+    migration backfill (issue #196)."""
+
+    def test_explicit_value_wins(self) -> None:
+        """An explicit author_sort always overrides the derived value."""
+        assert compute_author_sort(["Umberto Eco"], "Eco, Umberto") == "Eco, Umberto"
+
+    def test_explicit_value_overrides_even_when_unrelated(self) -> None:
+        """The helper trusts the caller — it does not re-derive when an
+        explicit value is supplied."""
+        assert compute_author_sort(["Madonna"], "Curator Override") == "Curator Override"
+
+    def test_empty_explicit_falls_through_to_derivation(self) -> None:
+        """Empty string for the explicit slot is treated as "no value" so we
+        still derive — matches `derive_author_sort`'s `if metadata.author_sort:`
+        truthiness check."""
+        assert compute_author_sort(["Umberto Eco"], "") == "Eco, Umberto"
+
+    def test_none_explicit_falls_through_to_derivation(self) -> None:
+        assert compute_author_sort(["Umberto Eco"], None) == "Eco, Umberto"
+
+    def test_empty_authors_returns_unknown(self) -> None:
+        assert compute_author_sort([]) == "Unknown"
+
+    def test_first_author_whitespace_only_returns_unknown(self) -> None:
+        assert compute_author_sort(["   "]) == "Unknown"
+
+    def test_two_word_name_inverts(self) -> None:
+        assert compute_author_sort(["Umberto Eco"]) == "Eco, Umberto"
+
+    def test_three_word_name_inverts_on_last_token(self) -> None:
+        assert compute_author_sort(["Gabriel Garcia Marquez"]) == "Marquez, Gabriel Garcia"
+
+    def test_single_word_kept_as_is(self) -> None:
+        assert compute_author_sort(["Madonna"]) == "Madonna"
+
+    def test_comma_containing_name_kept_as_is(self) -> None:
+        """Pre-inverted "Last, First" stays as-is — no double inversion."""
+        assert compute_author_sort(["Eco, Umberto"]) == "Eco, Umberto"
+
+    def test_only_first_author_considered(self) -> None:
+        """Co-authors are ignored; sort key derives from the first listed name
+        — same convention as `derive_author_sort`."""
+        assert compute_author_sort(["Neil Gaiman", "Terry Pratchett"]) == "Gaiman, Neil"
+
+    def test_strips_surrounding_whitespace_before_deciding(self) -> None:
+        """Leading/trailing whitespace on the first author is ignored when
+        classifying single-token vs multi-token."""
+        assert compute_author_sort(["  Umberto Eco  "]) == "Eco, Umberto"


### PR DESCRIPTION
## Summary

- New `compute_author_sort` helper in `core/text_sort` encodes the same "Last, First Middle" inversion rule that `derive_author_sort` used to inline, so the catalog write path and the V10 backfill share one source of truth.
- `metadata_to_row` now always ships a non-NULL `author_sort` (explicit value → derived → "Unknown").
- `update_book` keeps `author_sort` in lock-step with `authors` updates — mirroring the title_sort/title pattern shipped in #192.
- New `SCHEMA_V10` migration backfills every legacy row whose `author_sort` is NULL or empty, calling a JSON-aware UDF registered on the connection.

## Why

`/books` sort-by-author looked random within the first few pages. Root cause: SQLite orders `NULL` first in `ASC`, so every imported book without an explicit `author_sort` clumped at the top in insertion order. The fallback derivation already existed (`derive_author_sort`) but was only used for output paths — never persisted. This is the author-side twin of #192.

## Changes

- **`src/bookery/core/text_sort.py`** — added `compute_author_sort(authors, explicit_author_sort)`.
- **`src/bookery/core/pathformat.py`** — `derive_author_sort` now delegates to the new helper.
- **`src/bookery/db/schema.py`** — added `SCHEMA_V10` (UPDATE-only backfill, no ALTER) and appended to `MIGRATIONS`.
- **`src/bookery/db/connection.py`** — added `_author_sort_from_json` helper and registered it as `bookery_author_sort_from_json` on every connection (the SQL migration calls it).
- **`src/bookery/db/mapping.py`** — `metadata_to_row` runs the helper on the way in.
- **`src/bookery/db/catalog.py`** — `update_book` re-derives `author_sort` when `authors` changes (explicit `author_sort` in the same call still wins).

## Testing

- [x] New `TestComputeAuthorSort` unit tests (12 cases covering every derivation branch + explicit-wins precedence).
- [x] New `TestAuthorSortPersistence` integration in `tests/unit/test_db_crud.py` (6 cases mirroring `TestTitleSortPersistence`).
- [x] New `test_v9_db_with_authorless_books_backfills_author_sort` migration test (stages a V9 DB, opens to trigger V10, asserts 8 rows across every derivation case + preservation of pre-set values).
- [x] Bumped V9 → V10 assertions in `test_migration.py`, `test_db_schema.py`, `test_migration_lifecycle.py`, `test_catalog_path_truth.py`.
- [x] Full suite: **1920/1920 passing**.
- [x] `ruff check` clean on changed files. Pre-commit (lint + pyright) green on all 3 commits.

## Related Issues

Fixes #196. Companion to #192 (title_sort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)