### PR TITLE
Refactor #199: Consolidate read/reading/unread under `bookery mark`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ CLI-first ebook library manager. EPUB-focused, metadata-first, non-destructive.
 - Tests are mandatory: unit, integration, and e2e for every feature
 - TDD: write failing test first, then minimal code to pass
 - Never modify original EPUB file contents — work on copies in the library
+- When you change user-facing surface (CLI commands, flags, config keys, output format), update `README.md` and `docs/` in the same PR
 
 ## Package Layout
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ bookery info 42
 | `genre ls` | List all canonical genres with book counts |
 | `genre stats` | Show the most common subjects that don't map to a canonical genre |
 | `genre unmatched` | Show books with subjects but no genre assigned |
+| `mark finished <id>` | Mark a book as finished (also `mark reading <id>`, `mark unread <id>`; supports `--bulk-from FILE`) |
 | `verify` | Check for missing or changed files (supports `--check-hash`) |
 
 ### Web UI

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -16,13 +16,13 @@ from bookery.cli.commands import (
     inspect_cmd,
     inventory_cmd,
     ls_cmd,
+    mark_cmd,
     match_cmd,
     prune_cmd,
     rematch_cmd,
     remove_cmd,
     search_cmd,
     serve_cmd,
-    status_cmd,
     sync_cmd,
     tag_cmd,
     vault_export_cmd,
@@ -67,15 +67,13 @@ cli.add_command(info_cmd.info)
 cli.add_command(inspect_cmd.inspect)
 cli.add_command(inventory_cmd.inventory)
 cli.add_command(ls_cmd.ls)
+cli.add_command(mark_cmd.mark)
 cli.add_command(match_cmd.match)
 cli.add_command(prune_cmd.prune)
 cli.add_command(rematch_cmd.rematch)
 cli.add_command(remove_cmd.remove)
 cli.add_command(search_cmd.search)
 cli.add_command(serve_cmd.serve)
-cli.add_command(status_cmd.read_cmd)
-cli.add_command(status_cmd.reading_cmd)
-cli.add_command(status_cmd.unread_cmd)
 cli.add_command(sync_cmd.sync)
 cli.add_command(tag_cmd.tag)
 cli.add_command(vault_export_cmd.vault_export)

--- a/src/bookery/cli/commands/mark_cmd.py
+++ b/src/bookery/cli/commands/mark_cmd.py
@@ -1,4 +1,4 @@
-# ABOUTME: The `bookery read`, `bookery unread`, `bookery reading` commands.
+# ABOUTME: The `bookery mark finished|reading|unread` command group.
 # ABOUTME: Set catalog-side book_status; --bulk-from FILE applies to many books at once.
 
 from datetime import UTC, datetime
@@ -127,28 +127,33 @@ _bulk_from_option = click.option(
 )
 
 
-@click.command("read")
+@click.group("mark")
+def mark() -> None:
+    """Set a book's read status."""
+
+
+@mark.command("finished")
 @click.argument("book_id", type=int, required=False)
 @_bulk_from_option
 @db_option
-def read_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
+def finished_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
     """Mark a book as finished (status = 2)."""
     _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_FINISHED)
 
 
-@click.command("unread")
-@click.argument("book_id", type=int, required=False)
-@_bulk_from_option
-@db_option
-def unread_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
-    """Mark a book as unread (status = 0)."""
-    _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_UNREAD)
-
-
-@click.command("reading")
+@mark.command("reading")
 @click.argument("book_id", type=int, required=False)
 @_bulk_from_option
 @db_option
 def reading_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
     """Mark a book as in-progress (status = 1)."""
     _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_READING)
+
+
+@mark.command("unread")
+@click.argument("book_id", type=int, required=False)
+@_bulk_from_option
+@db_option
+def unread_cmd(book_id: int | None, bulk_from: Path | None, db_path: Path | None) -> None:
+    """Mark a book as unread (status = 0)."""
+    _apply_status(db_path=db_path, book_id=book_id, bulk_from=bulk_from, status=STATUS_UNREAD)

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -948,7 +948,7 @@ class LibraryCatalog:
         """Insert book_status only if no row exists for this book.
 
         The pull seeds the catalog-side mirror from device state, but P1b lets
-        users set status directly via `bookery read/unread/reading`. Once the
+        users set status directly via `bookery mark finished/reading/unread`. Once the
         user has set a value, the pull must never clobber it — hence ON CONFLICT
         DO NOTHING. Later phases overwrite via a different method.
         """
@@ -1002,7 +1002,7 @@ class LibraryCatalog:
         """Upsert book_status for the user-write path.
 
         Differs from `seed_book_status_if_absent` in that this overwrites on
-        conflict — the user's `bookery read/unread/reading` command is the
+        conflict — the user's `bookery mark finished/reading/unread` command is the
         authoritative signal for catalog-side state. Raises ValueError if
         `book_id` is not in the books table so a bad CLI argument fails
         loudly instead of silently writing an orphan row that an FK

--- a/src/bookery/db/status.py
+++ b/src/bookery/db/status.py
@@ -28,7 +28,7 @@ def status_name(status: int) -> str:
 class BookStatus:
     """A row from the ``book_status`` table — catalog-side read state.
 
-    This is the truth that the user manipulates via ``bookery read/unread/reading``
+    This is the truth that the user manipulates via ``bookery mark finished/reading/unread``
     and that the web detail page surfaces. The device-side mirror lives in
     ``DeviceReadState`` and is populated by the P1a pull.
     """

--- a/src/bookery/device/kobo_reader.py
+++ b/src/bookery/device/kobo_reader.py
@@ -148,7 +148,7 @@ def pull_read_state(
     the device's most recent reality. ``book_status`` goes through the
     timestamp-aware merge in :meth:`LibraryCatalog.merge_book_status_from_device`:
     device-newer-or-equal overwrites catalog, catalog-newer keeps the user's
-    bookery read/unread/reading intent intact. The push half of the sync
+    bookery mark finished/reading/unread intent intact. The push half of the sync
     (in :mod:`bookery.device.kobo`) handles the reverse direction.
 
     Best-effort: a missing or unreadable KoboReader.sqlite logs a warning and

--- a/tests/e2e/test_status_cli.py
+++ b/tests/e2e/test_status_cli.py
@@ -1,4 +1,4 @@
-# ABOUTME: End-to-end tests for `bookery read`, `unread`, `reading`, and the
+# ABOUTME: End-to-end tests for `bookery mark finished|reading|unread`, and the
 # ABOUTME: `ls --reading/--finished/--unread` filters plus info Reading section.
 
 from pathlib import Path
@@ -23,19 +23,19 @@ class TestStatusAuthoring:
         _import_one(runner, db_path, sample_epub)
 
         # Mark finished — title should appear in confirmation.
-        result = runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+        result = runner.invoke(cli, ["mark", "finished", "1", "--db", str(db_path)])
         assert result.exit_code == 0
         assert "Marked" in result.output
         assert "finished" in result.output
         assert "Name of the Rose" in result.output
 
         # Mark unread.
-        result = runner.invoke(cli, ["unread", "1", "--db", str(db_path)])
+        result = runner.invoke(cli, ["mark", "unread", "1", "--db", str(db_path)])
         assert result.exit_code == 0
         assert "unread" in result.output
 
         # Mark in-progress.
-        result = runner.invoke(cli, ["reading", "1", "--db", str(db_path)])
+        result = runner.invoke(cli, ["mark", "reading", "1", "--db", str(db_path)])
         assert result.exit_code == 0
         assert "reading" in result.output
 
@@ -44,7 +44,7 @@ class TestStatusAuthoring:
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
 
-        result = runner.invoke(cli, ["read", "999", "--db", str(db_path)])
+        result = runner.invoke(cli, ["mark", "finished", "999", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "999" in result.output
 
@@ -52,7 +52,7 @@ class TestStatusAuthoring:
         db_path = tmp_path / "status.db"
         runner = CliRunner()
         # Empty DB but the command should still fail at usage validation.
-        result = runner.invoke(cli, ["read", "--db", str(db_path)])
+        result = runner.invoke(cli, ["mark", "finished", "--db", str(db_path)])
         assert result.exit_code != 0
         assert "BOOK_ID" in result.output or "bulk-from" in result.output
 
@@ -65,7 +65,9 @@ class TestStatusAuthoring:
         bulk = tmp_path / "ids.txt"
         bulk.write_text("1\n")
 
-        result = runner.invoke(cli, ["read", "1", "--bulk-from", str(bulk), "--db", str(db_path)])
+        result = runner.invoke(
+            cli, ["mark", "finished", "1", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output
 
@@ -79,7 +81,9 @@ class TestBulkFrom:
         bulk = tmp_path / "ids.txt"
         bulk.write_text("# bulk wave 1\n1\n\n# trailing comment\n")
 
-        result = runner.invoke(cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)])
+        result = runner.invoke(
+            cli, ["mark", "finished", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
         assert result.exit_code == 0
         assert "1 book(s) as finished" in result.output
 
@@ -92,7 +96,9 @@ class TestBulkFrom:
 
         bulk = tmp_path / "ids.txt"
         bulk.write_text("1\n999\n")
-        result = runner.invoke(cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)])
+        result = runner.invoke(
+            cli, ["mark", "finished", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
         assert result.exit_code == 0
         assert "Skipped 999" in result.output
         assert "1 book(s) as finished" in result.output
@@ -104,7 +110,9 @@ class TestBulkFrom:
 
         bulk = tmp_path / "ids.txt"
         bulk.write_text("1\nnot-a-number\n")
-        result = runner.invoke(cli, ["read", "--bulk-from", str(bulk), "--db", str(db_path)])
+        result = runner.invoke(
+            cli, ["mark", "finished", "--bulk-from", str(bulk), "--db", str(db_path)]
+        )
         assert result.exit_code != 0
         assert "not-a-number" in result.output
 
@@ -116,7 +124,7 @@ class TestInfoReadingSection:
         db_path = tmp_path / "info.db"
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
-        runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+        runner.invoke(cli, ["mark", "finished", "1", "--db", str(db_path)])
 
         result = runner.invoke(cli, ["info", "1", "--db", str(db_path)])
         assert result.exit_code == 0
@@ -142,7 +150,7 @@ class TestLsStatusFilters:
         db_path = tmp_path / "lsfilters.db"
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
-        runner.invoke(cli, ["read", "1", "--db", str(db_path)])
+        runner.invoke(cli, ["mark", "finished", "1", "--db", str(db_path)])
 
         result = runner.invoke(cli, ["ls", "--finished", "--db", str(db_path)])
         assert result.exit_code == 0
@@ -173,8 +181,8 @@ class TestLsStatusFilters:
         db_path = tmp_path / "lsunread2.db"
         runner = CliRunner()
         _import_one(runner, db_path, sample_epub)
-        runner.invoke(cli, ["read", "1", "--db", str(db_path)])
-        runner.invoke(cli, ["unread", "1", "--db", str(db_path)])
+        runner.invoke(cli, ["mark", "finished", "1", "--db", str(db_path)])
+        runner.invoke(cli, ["mark", "unread", "1", "--db", str(db_path)])
 
         result = runner.invoke(cli, ["ls", "--unread", "--db", str(db_path)])
         assert result.exit_code == 0

--- a/tests/unit/test_catalog_devices.py
+++ b/tests/unit/test_catalog_devices.py
@@ -217,7 +217,7 @@ class TestSeedBookStatusIfAbsent:
         assert row["updated_at"] == "2026-05-26T08:00:00"
 
     def test_second_call_does_not_overwrite(self, catalog: LibraryCatalog) -> None:
-        # P1b: `bookery read` sets status via a different path. The pull must
+        # P1b: `bookery mark finished` sets status via a different path. The pull must
         # never clobber a user's intentional status change — it only seeds when
         # the row is absent. ON CONFLICT (book_id) DO NOTHING.
         book_id = _add_book(catalog)

--- a/tests/unit/test_device_kobo_reader.py
+++ b/tests/unit/test_device_kobo_reader.py
@@ -259,7 +259,7 @@ class TestPullReadState:
         self, tmp_path: Path
     ) -> None:
         """The P2 merge: catalog with a strictly newer timestamp wins, so the
-        user's bookery read/unread/reading intent is preserved across syncs.
+        user's bookery mark finished/reading/unread intent is preserved across syncs.
         """
         mount, kobo_dir = self._build_mount(tmp_path)
         _create_kobo_db(kobo_dir / "KoboReader.sqlite")

--- a/tests/unit/test_mark_cmd_bulk_parser.py
+++ b/tests/unit/test_mark_cmd_bulk_parser.py
@@ -1,9 +1,9 @@
-# ABOUTME: Unit tests for the parse_bulk_ids helper used by `bookery read --bulk-from`.
+# ABOUTME: Unit tests for the parse_bulk_ids helper used by `bookery mark ... --bulk-from`.
 # ABOUTME: Covers blank-line, comment, whitespace, and bad-ID handling rules.
 
 import pytest
 
-from bookery.cli.commands.status_cmd import parse_bulk_ids
+from bookery.cli.commands.mark_cmd import parse_bulk_ids
 
 
 class TestParseBulkIds:


### PR DESCRIPTION
## Summary
- Three top-level read-status verbs (`bookery read` / `reading` / `unread`) consolidated into a single `bookery mark` group.
- CLI surface now aligns with internal terminology end-to-end — `bookery mark finished` instead of `bookery read` printing "Marked X as finished".
- Querying read status stays in `bookery info <id>`; no parallel query group added.

```
bookery mark finished <id>
bookery mark reading  <id>
bookery mark unread   <id>
bookery mark finished --bulk-from FILE
```

## UX rationale
The issue originally proposed `bookery status <state> <id>` (noun-noun-arg). A UX review pushed back: the action is hidden, and modern CLIs (gh, kubectl, docker, systemctl) put the verb first. See [issue comment](https://github.com/JoeCotellese/bookery/issues/199#issuecomment-4554432317) for the full critique.

## Changes
- **`src/bookery/cli/commands/mark_cmd.py`** (renamed from `status_cmd.py`): `@click.group("mark")` with three `@mark.command` leaves. Internal helpers (`parse_bulk_ids`, `_apply_status`, `_bulk_from_option`) unchanged.
- **`src/bookery/cli/__init__.py`**: register `mark` group; drop three old top-level commands.
- **Docstring/comment sweep**: updated stale `bookery read/unread/reading` references in `db/status.py`, `db/catalog.py`, `device/kobo_reader.py`, and two unit-test comments.
- **Tests**: `tests/e2e/test_status_cli.py` rewritten to invoke the new form; unit test file renamed for consistency.

## Testing
- [x] Full suite: 1920 passing
- [x] Ruff + pyright clean (pre-commit)
- [x] Manual smoke: `bookery mark --help` shows the group; `bookery mark finished 1`, `mark reading 1`, `mark unread 1` all work; `bookery info 1` shows status; `bookery read 1` errors with "No such command 'read'".

## Breaking change
Clean break — old verbs are removed outright (no deprecation aliases). Per issue spec Option A. Nothing in-tree scripts the old commands; verify cron jobs / shell aliases before merging.

Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)