### PR TITLE
Fix #205: Enrich apply uses library copy when source_path is missing

### DIFF
--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -797,10 +797,18 @@ def enrich_apply(book_id):
 
     detail_url = url_for("web.book_detail", book_id=book_id)
 
-    source = book.source_path
+    # The library copy is the canonical file post-import. The original
+    # source_path may no longer exist (e.g. user emptied Calibre's trash
+    # after importing from there), so prefer output_path when it's readable.
+    library_copy = book.output_path
+    if library_copy is not None and library_copy.exists():
+        source = library_copy
+    else:
+        source = book.source_path
     if source is None or not source.exists():
         flash(
-            f"Cannot apply: source file is missing ({source})",
+            "Cannot apply: no readable EPUB for this book "
+            f"(source={book.source_path}, library={book.output_path})",
             "error",
         )
         response = make_response("", 200)

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -463,6 +463,84 @@ class TestEnrichApplyPost:
         assert any(category == "error" for category, _ in flashes)
         assert any("source" in msg.lower() for _, msg in flashes)
 
+    def test_uses_library_copy_when_source_path_missing(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        """Imported books keep their original source_path even when the user
+        deletes the original file (e.g. empties Calibre's trash). The library
+        copy at output_path is the canonical file and must be used as the
+        read source for enrichment in that case.
+        """
+        missing_source = tmp_path / "gone-from-calibre-trash.epub"  # never created
+        library_copy = tmp_path / "library" / "Author - Title.epub"
+        library_copy.parent.mkdir()
+        library_copy.write_bytes(b"epub")
+
+        mock_catalog.get_by_id.return_value = make_book(
+            1, source_path=missing_source, output_path=library_copy
+        )
+
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+        dest = tmp_path / "library" / "Author - Title (enriched).epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # apply_metadata_safely must be called with the library copy as source,
+        # writing into the library directory.
+        mock_apply.assert_called_once()
+        called_source, _called_metadata, called_output_dir = mock_apply.call_args.args
+        assert called_source == library_copy
+        assert called_output_dir == library_copy.parent
+
+        # Catalog write proceeds normally.
+        mock_catalog.update_book.assert_called_once()
+        mock_catalog.set_output_path.assert_called_once_with(1, dest)
+        assert response.headers.get("HX-Redirect") == "/books/1"
+
+    def test_no_readable_file_flashes_error(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        """Both source_path and output_path missing → flash error, no writes."""
+        missing_source = tmp_path / "missing-source.epub"
+        missing_output = tmp_path / "missing-library.epub"
+        mock_catalog.get_by_id.return_value = make_book(
+            1, source_path=missing_source, output_path=missing_output
+        )
+
+        open_library.by_isbn = [
+            make_candidate(source="Open Library", source_id="OL:1"),
+        ]
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "query": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        mock_apply.assert_not_called()
+        mock_catalog.update_book.assert_not_called()
+        mock_catalog.set_output_path.assert_not_called()
+        assert response.headers.get("HX-Redirect") == "/books/1"
+
+        with client.session_transaction() as session:
+            flashes = session.get("_flashes", [])
+        assert any(category == "error" for category, _ in flashes)
+
     def test_write_failure_flashes_error(self, mock_catalog, client, open_library, tmp_path):
         source = tmp_path / "src.epub"
         source.write_bytes(b"epub")


### PR DESCRIPTION
## Summary
- Web enrich apply now prefers `book.output_path` (the library-canonical copy) as the read source, falling back to `book.source_path` only when no library copy exists.
- Repro from the field: import a book from Calibre, empty Calibre's trash, then try to apply enriched metadata in the web UI — previously short-circuited with "source file is missing" even though the imported copy was sitting in `library_root`.
- Error flash now lists both path candidates so the failure mode is diagnosable.

Fixes #205.

## Test plan
- [x] New failing test (`test_uses_library_copy_when_source_path_missing`) covers the bug: source_path missing, output_path present → apply succeeds against library copy.
- [x] New regression test (`test_no_readable_file_flashes_error`) covers the genuine no-file case.
- [x] Existing `test_missing_source_flashes_error_no_db_write` unchanged and still passes (no output_path set).
- [x] Full suite: `uv run pytest tests/` → 1922 passed.
- [x] `uv run ruff check` → clean.