### PR TITLE
Fix #207: Rematch uses library copy when source_path is missing

### DIFF
--- a/src/bookery/cli/commands/rematch_cmd.py
+++ b/src/bookery/cli/commands/rematch_cmd.py
@@ -218,14 +218,24 @@ def rematch(
                     f"{record.metadata.title} (id={record.id})"
                 )
 
-            if not record.source_path.exists():
+            # The library copy is the canonical file post-import; source_path
+            # may no longer exist (e.g. user emptied Calibre's trash). Prefer
+            # output_path and only fall back to source_path.
+            epub_path: Path | None = None
+            if record.output_path is not None and record.output_path.exists():
+                epub_path = record.output_path
+            elif record.source_path is not None and record.source_path.exists():
+                epub_path = record.source_path
+
+            if epub_path is None:
                 console.print(
-                    f"  [red]Source file missing:[/red] {record.source_path}"
+                    f"  [red]No readable EPUB:[/red] "
+                    f"source={record.source_path}, library={record.output_path}"
                 )
                 errors += 1
                 continue
 
-            result = match_one(record.source_path, provider, review, output_dir)
+            result = match_one(epub_path, provider, review, output_dir)
 
             if not auto_accept and result.normalization and result.normalization.was_modified:
                 console.print(

--- a/tests/e2e/test_rematch_cli.py
+++ b/tests/e2e/test_rematch_cli.py
@@ -132,6 +132,67 @@ class TestRematchQuietMode:
         assert record.output_path is not None
         conn.close()
 
+    def test_rematch_uses_library_copy_when_source_missing(
+        self, sample_epub: Path, tmp_path: Path,
+    ) -> None:
+        """Same bug pattern as issue #205: when the original source file is
+        gone (e.g. the user emptied Calibre's trash after import), rematch
+        must fall through to the library-canonical output_path instead of
+        skipping with "Source file missing".
+        """
+        db_path = tmp_path / "test.db"
+        output_dir = tmp_path / "output"
+
+        # Import, then point output_path at a library copy that *does* exist.
+        book_id = _import_book(sample_epub, db_path)
+        library_dir = tmp_path / "library"
+        library_dir.mkdir()
+        library_copy = library_dir / "imported.epub"
+        shutil.copy(sample_epub, library_copy)
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        catalog.set_output_path(book_id, library_copy)
+        # Re-point source_path at a file that no longer exists.
+        missing_source = tmp_path / "gone-from-calibre-trash.epub"
+        conn.execute(
+            "UPDATE books SET source_path = ? WHERE id = ?",
+            (str(missing_source), book_id),
+        )
+        conn.commit()
+        conn.close()
+
+        candidate = _make_candidate("Il Nome della Rosa", "Umberto Eco", 0.95)
+
+        with patch(
+            "bookery.cli.commands.rematch_cmd._create_provider"
+        ) as mock_fn:
+            mock_provider = MagicMock()
+            mock_provider.search_by_isbn.return_value = []
+            mock_provider.search_by_title_author.return_value = [candidate]
+            mock_fn.return_value = mock_provider
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "rematch", str(book_id),
+                    "-q", "--db", str(db_path),
+                    "-o", str(output_dir),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Source file missing" not in result.output
+        assert "1 matched" in result.output
+
+        conn = open_library(db_path)
+        catalog = LibraryCatalog(conn)
+        record = catalog.get_by_id(book_id)
+        assert record is not None
+        assert record.metadata.title == "Il Nome della Rosa"
+        conn.close()
+
     def test_rematch_all_quiet(
         self, sample_epub: Path, minimal_epub: Path, tmp_path: Path,
     ) -> None:


### PR DESCRIPTION
## Summary
- Same bug pattern as #205, now in \`bookery rematch\`. Reads the library-canonical \`output_path\` first; falls back to \`source_path\` only when no library copy exists.
- Error message now names both path candidates so the failure mode is diagnosable.
- Re-triaged the kobo \`source_path\` references during this work and concluded they are not buggy — they only appear in skip-report display labels where \`output_path\` is already checked first.

Fixes #207. Related to #205.

## Test plan
- [x] New e2e test \`test_rematch_uses_library_copy_when_source_missing\` covers the bug: imported book, source file deleted, output_path still present → rematch succeeds.
- [x] Existing missing-source coverage still passes (no output_path → still errors).
- [x] Full suite: \`uv run pytest tests/\` → 1923 passed.
- [x] \`uv run ruff check\` → clean.