### PR TITLE
Fix #209: Web enrich form sends title and author as separate provider args

### DIFF
--- a/src/bookery/core/enrichment.py
+++ b/src/bookery/core/enrichment.py
@@ -62,40 +62,47 @@ def looks_like_url(value: str) -> bool:
 class QueryDispatch:
     """The parsed shape of an enrich search request.
 
-    Exactly one of the three slots is populated, mirroring the dispatch
-    branches in :func:`multi_provider_search`.
+    Exactly one of ISBN, URL, or title is populated. Author is only
+    meaningful alongside title — providers receive (title, author) as
+    structured arguments, not as a concatenated string.
     """
 
     isbn: str | None = None
     url: str | None = None
-    title_author: str | None = None
+    title: str | None = None
+    author: str | None = None
 
     @property
     def is_empty(self) -> bool:
-        return not (self.isbn or self.url or self.title_author)
+        return not (self.isbn or self.url or self.title)
 
 
-def dispatch_from_form(isbn_field: str, query_field: str) -> QueryDispatch:
+def dispatch_from_form(
+    isbn_field: str,
+    title_field: str,
+    author_field: str = "",
+) -> QueryDispatch:
     """Parse raw form fields into a :class:`QueryDispatch`.
 
-    A non-empty ``isbn_field`` always wins. Otherwise the free-text
-    ``query_field`` is inspected: ISBN-shaped digits route to the ISBN
-    branch (digits/hyphens stripped), anything starting with ``http(s)://``
-    or ``www.`` routes to the URL branch, and the remainder is treated
-    as a title+author search string.
+    A non-empty ``isbn_field`` always wins. Otherwise ``title_field`` is
+    inspected: ISBN-shaped digits route to the ISBN branch (digits/hyphens
+    stripped), URL-shaped values route to the URL branch (author is
+    ignored in both escape hatches), and the remainder is treated as a
+    title search paired with ``author_field``.
     """
     isbn_input = (isbn_field or "").strip()
-    query = (query_field or "").strip()
+    title = (title_field or "").strip()
+    author = (author_field or "").strip() or None
 
     if isbn_input:
         return QueryDispatch(isbn=normalize_isbn(isbn_input))
-    if not query:
+    if not title:
         return QueryDispatch()
-    if looks_like_isbn(query):
-        return QueryDispatch(isbn=normalize_isbn(query))
-    if looks_like_url(query):
-        return QueryDispatch(url=query)
-    return QueryDispatch(title_author=query)
+    if looks_like_isbn(title):
+        return QueryDispatch(isbn=normalize_isbn(title))
+    if looks_like_url(title):
+        return QueryDispatch(url=title)
+    return QueryDispatch(title=title, author=author)
 
 
 def multi_provider_search(
@@ -103,14 +110,16 @@ def multi_provider_search(
     *,
     isbn: str | None = None,
     url: str | None = None,
-    title_author: str | None = None,
+    title: str | None = None,
+    author: str | None = None,
 ) -> list[ProviderResult]:
     """Fan a single query out across every registered provider.
 
-    Exactly one of ``isbn``, ``url``, or ``title_author`` should be provided.
-    For each provider, the matching method is called and results are wrapped
-    in a :class:`ProviderResult` ordered by confidence descending. URL lookups
-    return at most one candidate per provider.
+    Exactly one of ``isbn``, ``url``, or ``title`` should be provided.
+    ``author`` is optional and only consulted alongside ``title``. For
+    each provider, the matching method is called and results are wrapped
+    in a :class:`ProviderResult` ordered by confidence descending. URL
+    lookups return at most one candidate per provider.
 
     Provider iteration order matches ``providers`` insertion order so the UI
     layout is deterministic.
@@ -124,8 +133,8 @@ def multi_provider_search(
             single = provider.lookup_by_url(url)
             if single is not None:
                 candidates = [single]
-        elif title_author:
-            candidates = list(provider.search_by_title_author(title_author))
+        elif title:
+            candidates = list(provider.search_by_title_author(title, author))
         candidates.sort(key=lambda c: c.confidence, reverse=True)
         results.append(ProviderResult(name=provider.name, candidates=candidates))
     return results

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -515,14 +515,45 @@ def enrich_form(book_id):
     in-place swap into ``#book-content``. A plain GET — direct nav, browser
     refresh, shared link — returns the full styled page so the user lands
     on a real URL rather than an unstyled fragment.
+
+    Accepts optional ``isbn``/``title``/``author`` query params. When any
+    are present, the form is prefilled with those values (overriding the
+    metadata-based prefill) and the same multi-provider search is re-run
+    so the candidate list is restored on the page. This is what the diff
+    panel's "Back to results" button relies on to avoid forcing the user
+    to retype their query.
     """
     catalog = current_app.config["CATALOG"]
     book = catalog.get_by_id(book_id)
     if book is None:
         abort(404)
 
-    prefill_isbn, prefill_title, prefill_author = _prefill_for_book(book)
     return_to = _safe_return_to(request.args.get("return_to"))
+
+    query_isbn = (request.args.get("isbn") or "").strip()
+    query_title = (request.args.get("title") or "").strip()
+    query_author = (request.args.get("author") or "").strip()
+    has_query = bool(query_isbn or query_title or query_author)
+
+    if has_query:
+        prefill_isbn = query_isbn or None
+        prefill_title = query_title or None
+        prefill_author = query_author or None
+        providers = current_app.config.get("PROVIDERS", {})
+        dispatch = dispatch_from_form(query_isbn, query_title, query_author)
+        results = multi_provider_search(
+            providers,
+            isbn=dispatch.isbn,
+            url=dispatch.url,
+            title=dispatch.title,
+            author=dispatch.author,
+        )
+        any_results = any(not r.is_empty for r in results)
+    else:
+        prefill_isbn, prefill_title, prefill_author = _prefill_for_book(book)
+        results = None
+        any_results = False
+
     template = "_enrich_search.html" if request.headers.get("HX-Request") else "enrich.html"
     return render_template(
         template,
@@ -531,6 +562,8 @@ def enrich_form(book_id):
         prefill_title=prefill_title,
         prefill_author=prefill_author,
         return_to=return_to,
+        results=results,
+        any_results=any_results,
     )
 
 

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -490,21 +490,21 @@ def update_book(book_id):
     return response
 
 
-def _prefill_for_book(book) -> tuple[str | None, str | None]:
+def _prefill_for_book(book) -> tuple[str | None, str | None, str | None]:
     """Compute the search-form pre-fill values for a BookRecord.
 
-    Returns ``(isbn, free_text_query)``. ISBN is preferred when present;
-    otherwise a ``"title author"`` string is composed for the free-text input.
-    Either tuple slot may be ``None``.
+    Returns ``(isbn, title, author)``. Title and author come from the
+    book's structured metadata so providers receive them as separate
+    arguments — concatenating them into a single free-text query produces
+    misses on most provider search APIs.
     """
     isbn = book.metadata.isbn or None
-    if isbn:
-        return isbn, None
-    parts = [book.metadata.title or ""]
+    title = (book.metadata.title or "").strip() or None
+    author = None
     if book.metadata.authors:
-        parts.append(book.metadata.authors[0])
-    query = " ".join(p for p in parts if p).strip()
-    return None, query or None
+        first = (book.metadata.authors[0] or "").strip()
+        author = first or None
+    return isbn, title, author
 
 
 @bp.route("/books/<int:book_id>/enrich", methods=["GET"])
@@ -521,14 +521,15 @@ def enrich_form(book_id):
     if book is None:
         abort(404)
 
-    prefill_isbn, prefill_query = _prefill_for_book(book)
+    prefill_isbn, prefill_title, prefill_author = _prefill_for_book(book)
     return_to = _safe_return_to(request.args.get("return_to"))
     template = "_enrich_search.html" if request.headers.get("HX-Request") else "enrich.html"
     return render_template(
         template,
         book=book,
         prefill_isbn=prefill_isbn,
-        prefill_query=prefill_query,
+        prefill_title=prefill_title,
+        prefill_author=prefill_author,
         return_to=return_to,
     )
 
@@ -545,29 +546,33 @@ def enrich_search(book_id):
 
     dispatch = dispatch_from_form(
         request.form.get("isbn", ""),
-        request.form.get("query", ""),
+        request.form.get("title", ""),
+        request.form.get("author", ""),
     )
 
     results = multi_provider_search(
         providers,
         isbn=dispatch.isbn,
         url=dispatch.url,
-        title_author=dispatch.title_author,
+        title=dispatch.title,
+        author=dispatch.author,
     )
     any_results = any(not r.is_empty for r in results)
 
-    # Reconstruct the query string passed to the diff route so View can
-    # re-fetch without keeping per-session state. Whatever dispatch path
-    # was taken (ISBN, URL, title/author), the diff route's own
-    # ``dispatch_from_form`` will resolve the same shape.
-    diff_query = dispatch.isbn or dispatch.url or dispatch.title_author or ""
-
+    # The View buttons rendered into the candidate list need to carry
+    # enough state for the diff/apply routes to re-run the same provider
+    # query and locate the chosen candidate by source_id. We pass the
+    # populated dispatch slots as separate URL params rather than a single
+    # merged "query" string — that's the bug that produced #209.
     return render_template(
         "_enrich_candidates.html",
         book=book,
         results=results,
         any_results=any_results,
-        diff_query=diff_query,
+        dispatch_isbn=dispatch.isbn or "",
+        dispatch_url=dispatch.url or "",
+        dispatch_title=dispatch.title or "",
+        dispatch_author=dispatch.author or "",
     )
 
 
@@ -601,22 +606,29 @@ def _find_provider_by_name(name: str) -> MetadataProvider | None:
     return providers.get(name)
 
 
-def _refetch_candidate(provider: MetadataProvider, query: str) -> list[MetadataCandidate]:
-    """Re-run the original search against ``provider`` for ``query``.
+def _refetch_candidate(
+    provider: MetadataProvider,
+    *,
+    isbn: str = "",
+    url: str = "",
+    title: str = "",
+    author: str = "",
+) -> list[MetadataCandidate]:
+    """Re-run the original search against ``provider`` from dispatch slots.
 
-    Apply requests carry no candidate state across the wire, so we re-call
-    the same dispatch path used by ``enrich_search`` and pick the candidate
-    by ``source_id``. ISBN-shaped queries hit ``search_by_isbn``, URLs go to
-    ``lookup_by_url``, everything else is treated as a title/author search.
+    Diff/apply requests carry no candidate state across the wire, so we
+    re-call the same dispatch path used by ``enrich_search`` and pick the
+    candidate by ``source_id``. Only the populated slot is honored — the
+    caller threads exactly one of ``isbn``/``url``/``title`` (with
+    optional ``author``) back from the candidate row.
     """
-    dispatch = dispatch_from_form("", query)
-    if dispatch.isbn:
-        return list(provider.search_by_isbn(dispatch.isbn))
-    if dispatch.url:
-        single = provider.lookup_by_url(dispatch.url)
+    if isbn:
+        return list(provider.search_by_isbn(isbn))
+    if url:
+        single = provider.lookup_by_url(url)
         return [single] if single is not None else []
-    if dispatch.title_author:
-        return list(provider.search_by_title_author(dispatch.title_author))
+    if title:
+        return list(provider.search_by_title_author(title, author or None))
     return []
 
 
@@ -733,14 +745,19 @@ def enrich_candidate(book_id):
         abort(404)
 
     provider_name = request.args.get("provider", "")
-    query = request.args.get("query", "")
+    isbn = request.args.get("isbn", "")
+    url = request.args.get("url", "")
+    title = request.args.get("title", "")
+    author = request.args.get("author", "")
     candidate_id = request.args.get("candidate_id", "")
 
     provider = _find_provider_by_name(provider_name)
     if provider is None:
         abort(404)
 
-    candidates = _refetch_candidate(provider, query)
+    candidates = _refetch_candidate(
+        provider, isbn=isbn, url=url, title=title, author=author
+    )
     candidate = _find_candidate(candidates, candidate_id)
     if candidate is None:
         abort(404)
@@ -757,7 +774,10 @@ def enrich_candidate(book_id):
         candidate=candidate,
         diffs=diffs,
         provider_name=provider_name,
-        query=query,
+        dispatch_isbn=isbn,
+        dispatch_url=url,
+        dispatch_title=title,
+        dispatch_author=author,
         candidate_id=candidate_id,
         return_to=return_to,
     )
@@ -783,14 +803,19 @@ def enrich_apply(book_id):
         abort(404)
 
     provider_name = request.form.get("provider", "")
-    query = request.form.get("query", "")
+    isbn = request.form.get("isbn", "")
+    url = request.form.get("url", "")
+    title = request.form.get("title", "")
+    author = request.form.get("author", "")
     candidate_id = request.form.get("candidate_id", "")
 
     provider = _find_provider_by_name(provider_name)
     if provider is None:
         abort(404)
 
-    candidates = _refetch_candidate(provider, query)
+    candidates = _refetch_candidate(
+        provider, isbn=isbn, url=url, title=title, author=author
+    )
     candidate = _find_candidate(candidates, candidate_id)
     if candidate is None:
         abort(404)

--- a/src/bookery/web/templates/_enrich_candidate_row.html
+++ b/src/bookery/web/templates/_enrich_candidate_row.html
@@ -22,7 +22,7 @@
     </div>
     <button type="button"
             class="btn btn-secondary"
-            hx-get="{{ url_for('web.enrich_candidate', book_id=book.id, provider=candidate.source, query=diff_query, candidate_id=candidate.source_id) }}"
+            hx-get="{{ url_for('web.enrich_candidate', book_id=book.id, provider=candidate.source, isbn=dispatch_isbn, url=dispatch_url, title=dispatch_title, author=dispatch_author, candidate_id=candidate.source_id) }}"
             hx-target="#book-content"
             hx-swap="innerHTML">View</button>
 </li>

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -36,7 +36,10 @@
               hx-post="{{ url_for('web.enrich_apply', book_id=book.id) }}"
               hx-swap="none">
             <input type="hidden" name="provider" value="{{ provider_name }}">
-            <input type="hidden" name="query" value="{{ query }}">
+            <input type="hidden" name="isbn" value="{{ dispatch_isbn }}">
+            <input type="hidden" name="url" value="{{ dispatch_url }}">
+            <input type="hidden" name="title" value="{{ dispatch_title }}">
+            <input type="hidden" name="author" value="{{ dispatch_author }}">
             <input type="hidden" name="candidate_id" value="{{ candidate_id }}">
             <button type="submit" class="btn btn-primary">
                 Apply{% if write_count %} ({{ write_count }} change{{ '' if write_count == 1 else 's' }}){% endif %}

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -53,7 +53,7 @@
 
         <button type="button"
                 class="btn btn-secondary"
-                hx-get="{{ url_for('web.enrich_form', book_id=book.id) }}"
+                hx-get="{{ url_for('web.enrich_form', book_id=book.id, isbn=dispatch_isbn or none, title=dispatch_title or none, author=dispatch_author or none) }}"
                 hx-target="#book-content"
                 hx-swap="innerHTML">Back to results</button>
 

--- a/src/bookery/web/templates/_enrich_search.html
+++ b/src/bookery/web/templates/_enrich_search.html
@@ -50,5 +50,9 @@
         </div>
     </form>
 
-    <div id="enrich-results" aria-live="polite"></div>
+    <div id="enrich-results" aria-live="polite">
+        {% if results is not none %}
+            {% include "_enrich_candidates.html" %}
+        {% endif %}
+    </div>
 </section>

--- a/src/bookery/web/templates/_enrich_search.html
+++ b/src/bookery/web/templates/_enrich_search.html
@@ -1,5 +1,5 @@
 {# ABOUTME: Search form partial for the multi-provider enrich flow. #}
-{# ABOUTME: Pre-fills ISBN when present; otherwise pre-fills "title author" free-text. #}
+{# ABOUTME: ISBN, Title, and Author are independent inputs; pasting a URL or ISBN into Title is honored. #}
 {% include "_book_subhead.html" %}
 <section class="enrich" aria-labelledby="enrich-heading">
     <h3 id="enrich-heading">Search providers</h3>
@@ -20,12 +20,22 @@
         </div>
 
         <div class="form-group">
-            <label for="enrich-query">or free text / URL</label>
+            <label for="enrich-title">Title</label>
             <input type="text"
-                   id="enrich-query"
-                   name="query"
-                   value="{{ prefill_query or '' }}"
-                   placeholder="title author or https://openlibrary.org/..."
+                   id="enrich-title"
+                   name="title"
+                   value="{{ prefill_title or '' }}"
+                   placeholder="title (or paste a provider URL)"
+                   autocomplete="off">
+        </div>
+
+        <div class="form-group">
+            <label for="enrich-author">Author</label>
+            <input type="text"
+                   id="enrich-author"
+                   name="author"
+                   value="{{ prefill_author or '' }}"
+                   placeholder="author name (optional)"
                    autocomplete="off">
         </div>
 

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -112,9 +112,14 @@ class TestMultiProviderSearch:
 
     def test_title_author_dispatch(self):
         p = _Provider("A")
-        multi_provider_search({"a": p}, title_author="Dune Herbert")
-        assert p.title_author_calls == [("Dune Herbert", None)]
+        multi_provider_search({"a": p}, title="Dune", author="Frank Herbert")
+        assert p.title_author_calls == [("Dune", "Frank Herbert")]
         assert p.isbn_calls == []
+
+    def test_title_only_dispatch_passes_none_author(self):
+        p = _Provider("A")
+        multi_provider_search({"a": p}, title="Dune")
+        assert p.title_author_calls == [("Dune", None)]
 
     def test_url_dispatch_returns_single_candidate(self):
         cand = _cand("via url", 0.8)
@@ -134,47 +139,56 @@ class TestMultiProviderSearch:
             "A",
             by_title_author=[_cand("low", 0.1), _cand("high", 0.9), _cand("mid", 0.5)],
         )
-        results = multi_provider_search({"a": p}, title_author="x")
+        results = multi_provider_search({"a": p}, title="x")
         assert [c.metadata.title for c in results[0].candidates] == ["high", "mid", "low"]
 
     def test_preserves_provider_order(self):
         a = _Provider("Alpha")
         b = _Provider("Beta")
         c = _Provider("Gamma")
-        results = multi_provider_search({"a": a, "b": b, "c": c}, title_author="x")
+        results = multi_provider_search({"a": a, "b": b, "c": c}, title="x")
         assert [r.name for r in results] == ["Alpha", "Beta", "Gamma"]
 
 
 class TestDispatchFromForm:
-    def test_isbn_field_wins_over_query(self):
-        d = dispatch_from_form("9780441172719", "ignored free text")
+    def test_isbn_field_wins_over_title(self):
+        d = dispatch_from_form("9780441172719", "ignored title", "ignored author")
         assert d.isbn == "9780441172719"
         assert d.url is None
-        assert d.title_author is None
+        assert d.title is None
+        assert d.author is None
 
     def test_isbn_field_normalizes_hyphens(self):
         d = dispatch_from_form("978-0-441-17271-9", "")
         assert d.isbn == "9780441172719"
 
-    def test_isbn_like_query_routes_to_isbn(self):
+    def test_isbn_like_title_routes_to_isbn(self):
         d = dispatch_from_form("", "9780441172719")
         assert d.isbn == "9780441172719"
 
-    def test_url_query_routes_to_url(self):
+    def test_url_in_title_routes_to_url(self):
         d = dispatch_from_form("", "https://openlibrary.org/works/OL1")
         assert d.url == "https://openlibrary.org/works/OL1"
         assert d.isbn is None
+        assert d.title is None
 
-    def test_free_text_routes_to_title_author(self):
-        d = dispatch_from_form("", "Dune Frank Herbert")
-        assert d.title_author == "Dune Frank Herbert"
+    def test_title_and_author_route_separately(self):
+        d = dispatch_from_form("", "Dune", "Frank Herbert")
+        assert d.title == "Dune"
+        assert d.author == "Frank Herbert"
+
+    def test_title_only_route(self):
+        d = dispatch_from_form("", "Dune")
+        assert d.title == "Dune"
+        assert d.author is None
 
     def test_empty_inputs_produce_empty_dispatch(self):
         d = dispatch_from_form("", "")
         assert d.is_empty
         assert d.isbn is None
         assert d.url is None
-        assert d.title_author is None
+        assert d.title is None
+        assert d.author is None
 
 
 class TestProviderResult:

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -140,7 +140,7 @@ class TestEnrichCandidateGet:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:M/123",
             },
         )
@@ -168,7 +168,7 @@ class TestEnrichCandidateGet:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "Old Title",
+                "title": "Old Title",
                 "candidate_id": "OL:1",
             },
         )
@@ -191,7 +191,7 @@ class TestEnrichCandidateGet:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:1",
             },
         )
@@ -204,7 +204,7 @@ class TestEnrichCandidateGet:
         mock_catalog.get_by_id.return_value = None
         response = client.get(
             "/books/999/enrich/candidate",
-            query_string={"provider": "Open Library", "query": "x", "candidate_id": "x"},
+            query_string={"provider": "Open Library", "title": "x", "candidate_id": "x"},
         )
         assert response.status_code == 404
 
@@ -212,7 +212,7 @@ class TestEnrichCandidateGet:
         mock_catalog.get_by_id.return_value = make_book(1)
         response = client.get(
             "/books/1/enrich/candidate",
-            query_string={"provider": "Unknown", "query": "x", "candidate_id": "x"},
+            query_string={"provider": "Unknown", "title": "x", "candidate_id": "x"},
         )
         assert response.status_code == 404
 
@@ -226,7 +226,7 @@ class TestEnrichCandidateGet:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:does-not-exist",
             },
         )
@@ -242,15 +242,19 @@ class TestEnrichCandidateGet:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:1",
             },
         )
 
         html = response.data.decode()
-        # Apply form carries provider, query, candidate_id so POST can re-fetch.
+        # Apply form carries dispatch slots so POST can re-fetch the same
+        # candidate (issue #209 — was a single "query" string before).
         assert 'name="provider"' in html
-        assert 'name="query"' in html
+        assert 'name="isbn"' in html
+        assert 'name="url"' in html
+        assert 'name="title"' in html
+        assert 'name="author"' in html
         assert 'name="candidate_id"' in html
 
     def test_back_to_results_link_present(self, mock_catalog, client, open_library):
@@ -263,7 +267,7 @@ class TestEnrichCandidateGet:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:1",
             },
         )
@@ -304,7 +308,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -340,7 +344,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -370,7 +374,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -393,7 +397,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -416,7 +420,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -445,7 +449,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -491,7 +495,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -527,7 +531,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -558,7 +562,7 @@ class TestEnrichApplyPost:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -571,7 +575,7 @@ class TestEnrichApplyPost:
         mock_catalog.get_by_id.return_value = None
         response = client.post(
             "/books/999/enrich/apply",
-            data={"provider": "Open Library", "query": "x", "candidate_id": "x"},
+            data={"provider": "Open Library", "title": "x", "candidate_id": "x"},
         )
         assert response.status_code == 404
 
@@ -581,7 +585,7 @@ class TestEnrichApplyPost:
         mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
         response = client.post(
             "/books/1/enrich/apply",
-            data={"provider": "Unknown", "query": "x", "candidate_id": "x"},
+            data={"provider": "Unknown", "title": "x", "candidate_id": "x"},
         )
         assert response.status_code == 404
 
@@ -596,7 +600,7 @@ class TestEnrichApplyPost:
             "/books/1/enrich/apply",
             data={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:missing",
             },
         )
@@ -642,7 +646,7 @@ class TestEnrichApplyStripsDescriptionHtml:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -697,7 +701,7 @@ class TestCandidateRowViewWiring:
 
         response = client.post(
             "/books/1/enrich/search",
-            data={"isbn": "9780441172719", "query": ""},
+            data={"isbn": "9780441172719", "title": ""},
         )
 
         html = response.data.decode()
@@ -793,7 +797,7 @@ class TestEnrichApplySkipClear:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -827,7 +831,7 @@ class TestEnrichApplySkipClear:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -861,7 +865,7 @@ class TestEnrichApplySkipClear:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -897,7 +901,7 @@ class TestEnrichApplySkipClear:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -933,7 +937,7 @@ class TestEnrichApplySkipClear:
                 "/books/1/enrich/apply",
                 data={
                     "provider": "Open Library",
-                    "query": "9780441172719",
+                    "isbn": "9780441172719",
                     "candidate_id": "OL:1",
                 },
             )
@@ -961,7 +965,7 @@ class TestEnrichDiffSkipClearRendering:
             "/books/1/enrich/candidate",
             query_string={
                 "provider": "Open Library",
-                "query": "9780441172719",
+                "isbn": "9780441172719",
                 "candidate_id": "OL:1",
             },
         )

--- a/tests/web/test_enrich_search.py
+++ b/tests/web/test_enrich_search.py
@@ -38,10 +38,12 @@ class TestEnrichSearchForm:
         )
 
         html = client.get("/books/1/enrich").data.decode()
-        # Free-text query input pre-fills with "title author".
-        assert 'name="query"' in html
-        assert "Dune" in html
-        assert "Herbert, Frank" in html
+        # Title and author go into their own inputs so providers receive
+        # them as structured args (see #209).
+        assert 'name="title"' in html
+        assert 'name="author"' in html
+        assert 'value="Dune"' in html
+        assert 'value="Herbert, Frank"' in html
 
     def test_form_posts_to_search_endpoint(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = make_book(1)
@@ -83,53 +85,73 @@ class TestEnrichSearchPost:
         mock_catalog.get_by_id.return_value = make_book(1)
         open_library.by_isbn = [make_candidate(title="A", confidence=0.9)]
 
-        client.post("/books/1/enrich/search", data={"isbn": "9780441172719", "query": ""})
+        client.post(
+            "/books/1/enrich/search",
+            data={"isbn": "9780441172719", "title": "", "author": ""},
+        )
 
         assert open_library.isbn_calls == ["9780441172719"]
         assert google_books.isbn_calls == ["9780441172719"]
         assert open_library.title_author_calls == []
         assert open_library.url_calls == []
 
-    def test_isbn_like_query_dispatches_to_search_by_isbn(
+    def test_isbn_like_title_dispatches_to_search_by_isbn(
         self, mock_catalog, client, open_library
     ):
         mock_catalog.get_by_id.return_value = make_book(1)
 
-        client.post("/books/1/enrich/search", data={"query": "9780441172719"})
+        client.post("/books/1/enrich/search", data={"title": "9780441172719"})
 
         assert open_library.isbn_calls == ["9780441172719"]
         assert open_library.title_author_calls == []
 
-    def test_isbn10_query_dispatches_to_search_by_isbn(self, mock_catalog, client, open_library):
+    def test_isbn10_in_title_dispatches_to_search_by_isbn(
+        self, mock_catalog, client, open_library
+    ):
         mock_catalog.get_by_id.return_value = make_book(1)
 
-        client.post("/books/1/enrich/search", data={"query": "044117271X"})
+        client.post("/books/1/enrich/search", data={"title": "044117271X"})
 
         assert open_library.isbn_calls == ["044117271X"]
 
-    def test_url_query_dispatches_to_lookup_by_url(self, mock_catalog, client, open_library):
+    def test_url_in_title_dispatches_to_lookup_by_url(self, mock_catalog, client, open_library):
         mock_catalog.get_by_id.return_value = make_book(1)
         open_library.by_url = make_candidate(title="From URL", confidence=0.95)
 
         client.post(
             "/books/1/enrich/search",
-            data={"query": "https://openlibrary.org/works/OL1234W"},
+            data={"title": "https://openlibrary.org/works/OL1234W"},
         )
 
         assert open_library.url_calls == ["https://openlibrary.org/works/OL1234W"]
         assert open_library.isbn_calls == []
         assert open_library.title_author_calls == []
 
-    def test_free_text_query_dispatches_to_search_by_title_author(
+    def test_title_and_author_dispatch_to_search_by_title_author(
+        self, mock_catalog, client, open_library
+    ):
+        """Author goes through as a structured argument, not concatenated
+        into the title — that's the fix for #209.
+        """
+        mock_catalog.get_by_id.return_value = make_book(1)
+
+        client.post(
+            "/books/1/enrich/search",
+            data={"title": "Dune", "author": "Frank Herbert"},
+        )
+
+        assert open_library.title_author_calls == [("Dune", "Frank Herbert")]
+        assert open_library.isbn_calls == []
+        assert open_library.url_calls == []
+
+    def test_title_only_dispatch_passes_none_author(
         self, mock_catalog, client, open_library
     ):
         mock_catalog.get_by_id.return_value = make_book(1)
 
-        client.post("/books/1/enrich/search", data={"query": "Dune Frank Herbert"})
+        client.post("/books/1/enrich/search", data={"title": "Dune"})
 
-        assert open_library.title_author_calls == [("Dune Frank Herbert", None)]
-        assert open_library.isbn_calls == []
-        assert open_library.url_calls == []
+        assert open_library.title_author_calls == [("Dune", None)]
 
     def test_renders_candidates_for_each_provider(
         self, mock_catalog, client, open_library, google_books
@@ -143,7 +165,7 @@ class TestEnrichSearchPost:
             make_candidate(title="GB One", confidence=0.8, source="Google Books"),
         ]
 
-        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+        html = client.post("/books/1/enrich/search", data={"title": "Dune"}).data.decode()
 
         assert "Open Library" in html
         assert "Open Library (2)" in html
@@ -164,7 +186,7 @@ class TestEnrichSearchPost:
         ]
         google_books.by_title_author = []
 
-        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+        html = client.post("/books/1/enrich/search", data={"title": "Dune"}).data.decode()
 
         high_pos = html.find("High")
         mid_pos = html.find("Mid")
@@ -178,7 +200,7 @@ class TestEnrichSearchPost:
         open_library.by_title_author = [make_candidate(title="OL", confidence=0.5)]
         google_books.by_title_author = []  # empty
 
-        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+        html = client.post("/books/1/enrich/search", data={"title": "Dune"}).data.decode()
 
         assert "No candidates from Google Books" in html
 
@@ -190,7 +212,7 @@ class TestEnrichSearchPost:
         google_books.by_title_author = []
 
         html = client.post(
-            "/books/1/enrich/search", data={"query": "Nothing matches"}
+            "/books/1/enrich/search", data={"title": "Nothing matches"}
         ).data.decode()
 
         assert "No candidates found" in html
@@ -213,7 +235,7 @@ class TestEnrichSearchPost:
         ]
         google_books.by_title_author = []
 
-        html = client.post("/books/1/enrich/search", data={"query": "Dune"}).data.decode()
+        html = client.post("/books/1/enrich/search", data={"title": "Dune"}).data.decode()
 
         assert "Dune" in html
         assert "Herbert, Frank" in html
@@ -229,7 +251,7 @@ class TestEnrichSearchPost:
         open_library.by_title_author = [make_candidate(title="X", confidence=0.5)]
         google_books.by_title_author = []
 
-        html = client.post("/books/1/enrich/search", data={"query": "X"}).data.decode()
+        html = client.post("/books/1/enrich/search", data={"title": "X"}).data.decode()
 
         assert "View" in html
         # View now fires the diff fetch into #book-content (issue #115).
@@ -238,7 +260,7 @@ class TestEnrichSearchPost:
 
     def test_missing_book_returns_404(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = None
-        response = client.post("/books/999/enrich/search", data={"query": "Dune"})
+        response = client.post("/books/999/enrich/search", data={"title": "Dune"})
         assert response.status_code == 404
 
 

--- a/tests/web/test_enrich_search.py
+++ b/tests/web/test_enrich_search.py
@@ -273,3 +273,112 @@ class TestEnrichButtonOnDetail:
         # The toolbar no longer carries Enrich as disabled.
         # (Delete may still be disabled — narrow the check to Enrich's block.)
         assert "Enrich" in html
+
+
+class TestEnrichFormRestoresResults:
+    """GET /books/<id>/enrich with isbn/title/author query params should
+    re-run the same search and inline the candidates into the form, so the
+    'Back to results' button on the diff panel restores the user's state
+    without forcing them to re-type their query.
+    """
+
+    def test_query_params_override_metadata_prefill(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Original", authors=["Original Author"]
+        )
+
+        html = client.get(
+            "/books/1/enrich?title=Searched&author=Searched+Author"
+        ).data.decode()
+
+        # Form is prefilled with the searched values, not the book metadata.
+        assert 'value="Searched"' in html
+        assert 'value="Searched Author"' in html
+        assert 'value="Original"' not in html
+        assert 'value="Original Author"' not in html
+
+    def test_query_params_trigger_search_and_render_candidates(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [
+            make_candidate(title="Restored Hit", confidence=0.9)
+        ]
+
+        html = client.get(
+            "/books/1/enrich?title=Dune&author=Frank+Herbert"
+        ).data.decode()
+
+        # The search was actually dispatched with the structured args.
+        assert open_library.title_author_calls == [("Dune", "Frank Herbert")]
+        # And the candidate is rendered inline in the response.
+        assert "Restored Hit" in html
+
+    def test_isbn_query_param_triggers_isbn_search(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_isbn = [make_candidate(title="ISBN Hit", confidence=0.95)]
+
+        html = client.get("/books/1/enrich?isbn=9780441172719").data.decode()
+
+        assert open_library.isbn_calls == ["9780441172719"]
+        assert "ISBN Hit" in html
+
+    def test_no_query_params_renders_form_without_search(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(
+            1, title="Dune", authors=["Frank Herbert"]
+        )
+
+        html = client.get("/books/1/enrich").data.decode()
+
+        # No provider call when no query params present — original behavior.
+        assert open_library.title_author_calls == []
+        assert open_library.isbn_calls == []
+        # Form is prefilled from book metadata as before.
+        assert 'value="Dune"' in html
+        assert 'value="Frank Herbert"' in html
+
+    def test_empty_query_params_treated_as_absent(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+
+        client.get("/books/1/enrich?isbn=&title=&author=")
+
+        # Whitespace/empty params shouldn't fire a no-op search.
+        assert open_library.title_author_calls == []
+        assert open_library.isbn_calls == []
+        assert open_library.url_calls == []
+
+
+class TestEnrichDiffBackToResults:
+    """The 'Back to results' button on the diff panel should restore the
+    candidate list — not drop the user back on an empty form.
+    """
+
+    def test_back_to_results_button_carries_dispatch_params(
+        self, mock_catalog, client, open_library, google_books
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        open_library.by_title_author = [
+            make_candidate(
+                title="Dune", confidence=0.9, source_id="ol:1", source="Open Library"
+            )
+        ]
+
+        html = client.get(
+            "/books/1/enrich/candidate"
+            "?provider=Open+Library&title=Dune&author=Frank+Herbert"
+            "&candidate_id=ol:1"
+        ).data.decode()
+
+        # Back-to-results hx-get must include the dispatch params so the
+        # enrich_form route re-runs the search instead of showing an empty form.
+        assert "Back to results" in html
+        assert "title=Dune" in html
+        assert "author=Frank" in html  # url-encoded space tolerated

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -331,7 +331,8 @@ class TestEnrichUrlIsReal:
         assert 'class="logo"' in html
         # Search form is still rendered.
         assert 'name="isbn"' in html
-        assert 'name="query"' in html
+        assert 'name="title"' in html
+        assert 'name="author"' in html
 
     def test_search_htmx_get_returns_fragment_only(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = make_book(1, title="Book One")
@@ -343,7 +344,8 @@ class TestEnrichUrlIsReal:
         assert "Skip to main content" not in html
         # Form fields still present in the partial.
         assert 'name="isbn"' in html
-        assert 'name="query"' in html
+        assert 'name="title"' in html
+        assert 'name="author"' in html
 
     def test_search_refresh_renders_full_page(self, mock_catalog, client):
         """Browser refresh sends no HX-Request header — same path as direct nav."""
@@ -360,7 +362,7 @@ class TestEnrichUrlIsReal:
     # --- /books/<id>/enrich/candidate (diff panel) ----------------------------
 
     def _candidate_url(self) -> str:
-        return "/books/1/enrich/candidate?provider=fake&query=9780441172719&candidate_id=fake:1"
+        return "/books/1/enrich/candidate?provider=fake&isbn=9780441172719&candidate_id=fake:1"
 
     def test_candidate_plain_get_returns_full_styled_page(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = make_book(1, title="Diff Book")


### PR DESCRIPTION
## Summary
This branch now ships **two related fixes** to the web enrich flow.

### Fix #209 — title and author sent as separate provider args
- The web enrich form was prefilling one free-text field with `"{title} {first author}"`. `dispatch_from_form` routed that combined string to `QueryDispatch.title_author`, and `multi_provider_search` passed it to `provider.search_by_title_author(title_author)` — as just the `title` arg, with `author=None`. Providers then queried for a literal title like "The Charlemagne Pursuit Steve Berry" and found nothing.
- Replaced the single free-text field with separate **Title** and **Author** inputs. `QueryDispatch` gains a real `author` slot. `multi_provider_search` and `_refetch_candidate` take title and author as structured args. The diff/apply round-trip carries `isbn`/`url`/`title`/`author` as separate URL/form params instead of one merged `query`.
- CLI path (`pipeline.py:240`) was already correct; no change needed there.

Fixes #209.

### Additional fix — "Back to results" preserves candidate list
- On the enrich diff panel, "Back to results" was `hx-get`ting `enrich_form` with no query params, so it dropped the user on an empty form and lost the candidate list they'd been browsing.
- `enrich_form` now accepts optional `isbn`/`title`/`author` query params. When present, the form is prefilled with those values and the same `multi_provider_search` is re-run, with results inlined into `#enrich-results`. Empty params fall back to the original metadata-based prefill.
- The diff template's `hx-get` URL now carries the `dispatch_*` params so the round-trip restores state. Side benefit: URL is bookmarkable and browser refresh on the results page preserves the candidates.

## Manual verification (#209)

| Form input | Result before | Result after |
|---|---|---|
| title="The Charlemagne Pursuit", author="Steve Berry" | (n/a — old form merged) | 5 candidates |
| title="The Charlemagne Pursuit Steve Berry" (combined) | 0 candidates | 0 candidates (expected — confirms repro) |

## Test plan
- [x] New unit tests for split title/author dispatch and round-trip
- [x] Updated web tests to use the new form field names; new test asserts `provider.search_by_title_author("Dune", "Frank Herbert")` shape
- [x] Updated nav-state tests for the new candidate URL shape
- [x] **New:** `TestEnrichFormRestoresResults` + `TestEnrichDiffBackToResults` covering query-param prefill override, GET-dispatched search (ISBN + title/author), no-query baseline, empty-param baseline, and the diff button URL
- [x] Full suite: `uv run pytest` → 1932 passed
- [x] `uv run ruff check` → clean
- [x] `uv run pyright src/bookery/web/routes.py` → clean
- [x] Smoke tested against the live web app on local catalog