### PR TITLE
Add shared deprecation alias helper for CLI renames (#221)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,33 @@ Implement the `MetadataProvider` protocol in `metadata/provider.py`:
 
 See `metadata/openlibrary.py` for a complete example.
 
+### Renaming a CLI Command or Flag
+
+When renaming a Click command or option, keep the old name working for one
+release as a deprecated alias. Use the shared helpers in
+`bookery.cli.deprecation` rather than rolling your own warning callback:
+
+```python
+from bookery.cli.deprecation import deprecated_command_alias, deprecated_option
+
+# Command rename: old `import` -> canonical `add`
+deprecated_command_alias(cli, alias="import", canonical="add")
+
+# Flag rename: old `--uuid stable|random` -> canonical `--random-ids`
+@deprecated_option(
+    ["--uuid"],
+    canonical="--random-ids",
+    type=click.Choice(["stable", "random"]),
+    transform=lambda v: {"random_ids": v == "random"} if v is not None else {},
+)
+@click.option("--random-ids", is_flag=True, default=False)
+def cmd(random_ids: bool) -> None: ...
+```
+
+Both helpers print a one-line warning to stderr (once per invocation) and
+forward args/options to the canonical surface unchanged. See
+`src/bookery/cli/deprecation.py` and `tests/unit/test_cli_deprecation.py`.
+
 ### Adding a Format
 
 Format handlers live in `formats/`. Each format needs:

--- a/src/bookery/cli/deprecation.py
+++ b/src/bookery/cli/deprecation.py
@@ -1,0 +1,208 @@
+# ABOUTME: Shared helpers for deprecating CLI commands and options with a one-release alias.
+# ABOUTME: Provides deprecated_command_alias and deprecated_option for consistent warnings.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import click
+
+WARNING_TEMPLATE = (
+    "warning: '{old}' is deprecated; use '{new}' instead. "
+    "This alias will be removed in a future release."
+)
+
+# Module-level dedupe so a warning fires at most once per process invocation
+# even when the deprecated surface is hit multiple times (e.g., a flag that
+# resolves repeatedly or a command invoked in a loop). Tests reset this via
+# `reset_deprecation_state`.
+_emitted: set[str] = set()
+
+
+def reset_deprecation_state() -> None:
+    """Clear the per-process dedupe set. Intended for tests."""
+    _emitted.clear()
+
+
+def _emit_warning(old: str, new: str) -> None:
+    """Print a deprecation warning to stderr at most once per process."""
+    key = f"{old}->{new}"
+    if key in _emitted:
+        return
+    _emitted.add(key)
+    click.echo(WARNING_TEMPLATE.format(old=old, new=new), err=True)
+
+
+def deprecated_command_alias(
+    group: click.Group,
+    *,
+    alias: str,
+    canonical: str,
+    hidden: bool = True,
+) -> click.Command:
+    """Register `alias` on `group` as a deprecated forwarder to `canonical`.
+
+    The alias command accepts arbitrary args/options (`ignore_unknown_options`
+    + `UNPROCESSED` argument), prints a one-line deprecation warning to
+    stderr, and then re-invokes the canonical command via `group.main` so
+    Click's normal parsing, exit codes, and error surface apply identically.
+
+    Example:
+        deprecated_command_alias(cli, alias="import", canonical="add")
+    """
+    canonical_cmd = group.get_command(click.Context(group), canonical)
+    if canonical_cmd is None:
+        raise ValueError(
+            f"deprecated_command_alias: canonical command '{canonical}' "
+            f"not registered on group '{group.name}'"
+        )
+
+    help_text = (
+        f"Deprecated alias for '{canonical}'. Use '{canonical}' instead; "
+        "this alias will be removed in a future release."
+    )
+
+    @group.command(
+        name=alias,
+        hidden=hidden,
+        help=help_text,
+        short_help=f"Deprecated alias for '{canonical}'.",
+        context_settings={
+            "ignore_unknown_options": True,
+            "allow_extra_args": True,
+            "help_option_names": ["-h", "--help"],
+        },
+    )
+    @click.argument("args", nargs=-1, type=click.UNPROCESSED)
+    @click.pass_context
+    def _alias(ctx: click.Context, args: tuple[str, ...]) -> None:
+        _emit_warning(alias, canonical)
+        # Forward to the canonical command. Use ctx.invoke on the parsed
+        # subcommand so we stay inside Click's machinery — exit codes,
+        # UsageError surface, and stdout/stderr behavior match the canonical
+        # path exactly.
+        sub_ctx = canonical_cmd.make_context(
+            canonical,
+            list(args),
+            parent=ctx.parent,
+        )
+        with sub_ctx:
+            result = canonical_cmd.invoke(sub_ctx)
+        ctx.exit(0 if result is None else int(bool(result)))
+
+    return _alias
+
+
+def deprecated_option(
+    old_names: Iterable[str],
+    *,
+    canonical: str,
+    transform: Callable[[Any], dict[str, Any]] | None = None,
+    **option_kwargs: Any,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare a deprecated CLI option that maps to a canonical option/flag.
+
+    The returned decorator adds a hidden Click option for each name in
+    `old_names`. When the user supplies one of the old names, a one-line
+    deprecation warning is printed to stderr and the value is translated
+    into the canonical parameter(s).
+
+    `canonical` is the human-facing canonical flag spelling (e.g.
+    `'--random-ids'`) used in the warning message.
+
+    `transform`, if provided, receives the raw value of the deprecated option
+    and returns a dict of {canonical_param_name: value} entries to merge into
+    the command's kwargs. The canonical_param_name is the Click parameter
+    name (e.g., `'random_ids'` not `'--random-ids'`). If `transform` is
+    omitted, the value is forwarded under the Click-derived name of
+    `canonical` (dashes -> underscores, stripped of leading dashes).
+
+    The canonical option itself must be declared separately by the caller —
+    this helper only handles the deprecated surface.
+
+    Example (boolean rename):
+        @deprecated_option(["--old-name"], canonical="--new-name")
+        @click.option("--new-name", default="")
+        def cmd(new_name): ...
+
+    Example (value-to-bool translation):
+        @deprecated_option(
+            ["--uuid"],
+            canonical="--random-ids",
+            type=click.Choice(["stable", "random"]),
+            transform=lambda v: {"random_ids": v == "random"} if v is not None else {},
+        )
+        @click.option("--random-ids", is_flag=True, default=False)
+        def cmd(random_ids): ...
+    """
+    old_names_list = list(old_names)
+    if not old_names_list:
+        raise ValueError("deprecated_option: at least one old name is required")
+    primary_old = old_names_list[0]
+    default_param_name = canonical.lstrip("-").replace("-", "_")
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        callback = _build_callback(
+            primary_old=primary_old,
+            canonical=canonical,
+            transform=transform,
+            default_param_name=default_param_name,
+        )
+        # Reserve a hidden, non-exposed param destination so Click doesn't
+        # try to pass `--uuid=...` to the wrapped function.
+        param_dest = f"_deprecated_{default_param_name}"
+        # Build args for click.option: all old names, then a destination.
+        opt_args = (*old_names_list, param_dest)
+        opt_kwargs: dict[str, Any] = {
+            "default": None,
+            "hidden": True,
+            "expose_value": False,
+            "callback": callback,
+            "help": f"Deprecated alias for {canonical}.",
+        }
+        opt_kwargs.update(option_kwargs)
+        return click.option(*opt_args, **opt_kwargs)(func)
+
+    return decorator
+
+
+def _build_callback(
+    *,
+    primary_old: str,
+    canonical: str,
+    transform: Callable[[Any], dict[str, Any]] | None,
+    default_param_name: str,
+) -> Callable[[click.Context, click.Parameter, Any], Any]:
+    """Build the Click callback that fires when a deprecated option is set."""
+
+    def callback(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
+        # `value is None` means the user did not supply the deprecated option;
+        # leave the canonical value untouched. For flags whose default is
+        # False, treat False the same way so unused flags stay quiet.
+        if value is None or value is False:
+            return value
+        _emit_warning(primary_old, canonical)
+        mapping = (
+            transform(value)
+            if transform is not None
+            else {default_param_name: value}
+        )
+        # Push translated values into the params dict that Click will pass to
+        # the wrapped function. We overwrite any existing default but do not
+        # clobber a value the user explicitly set on the canonical name — if
+        # both old and new are given, the canonical wins (last write loses
+        # for the deprecated channel because the canonical option is
+        # processed after by virtue of stacking order).
+        if ctx.params is None:  # pragma: no cover - defensive
+            ctx.params = {}
+        for key, translated in mapping.items():
+            # Only overwrite when the canonical key is still at its default
+            # (i.e., the user did not supply it). Click stores user-provided
+            # values in ctx.params at parse time; falling back to the
+            # default-driven slot lets us distinguish.
+            if key not in ctx.params or ctx.params[key] in (None, False, ""):
+                ctx.params[key] = translated
+        return value
+
+    return callback

--- a/tests/unit/test_cli_deprecation.py
+++ b/tests/unit/test_cli_deprecation.py
@@ -1,0 +1,229 @@
+# ABOUTME: Unit tests for the shared CLI deprecation alias helper.
+# ABOUTME: Covers command-level and flag-level aliases, warning dedupe, and value forwarding.
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from bookery.cli.deprecation import (
+    deprecated_command_alias,
+    deprecated_option,
+    reset_deprecation_state,
+)
+
+# --- helpers -------------------------------------------------------------
+
+
+def _make_canonical_group() -> click.Group:
+    """Build a small group with one canonical command for alias tests."""
+
+    @click.group()
+    def cli() -> None:
+        pass
+
+    @cli.command("add")
+    @click.argument("path", required=False)
+    @click.option("--flag/--no-flag", default=False)
+    @click.option("--value", default="")
+    def add(path: str | None, flag: bool, value: str) -> None:
+        click.echo(f"add path={path} flag={flag} value={value}")
+
+    return cli
+
+
+# --- command-level alias --------------------------------------------------
+
+
+def test_canonical_command_works() -> None:
+    reset_deprecation_state()
+    cli = _make_canonical_group()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["add", "book.epub", "--flag", "--value", "x"])
+    assert result.exit_code == 0
+    assert "add path=book.epub flag=True value=x" in result.stdout
+    assert result.stderr == ""
+
+
+def test_alias_forwards_args_and_options() -> None:
+    reset_deprecation_state()
+    cli = _make_canonical_group()
+    deprecated_command_alias(cli, alias="import", canonical="add")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", "book.epub", "--flag", "--value", "y"])
+    assert result.exit_code == 0
+    assert "add path=book.epub flag=True value=y" in result.stdout
+
+
+def test_alias_prints_warning_to_stderr() -> None:
+    reset_deprecation_state()
+    cli = _make_canonical_group()
+    deprecated_command_alias(cli, alias="import", canonical="add")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", "book.epub"])
+    assert result.exit_code == 0
+    assert (
+        "warning: 'import' is deprecated; use 'add' instead. "
+        "This alias will be removed in a future release."
+    ) in result.stderr
+    # Warning must not pollute stdout.
+    assert "deprecated" not in result.stdout
+
+
+def test_alias_exit_code_matches_canonical_on_error() -> None:
+    reset_deprecation_state()
+
+    @click.group()
+    def cli() -> None:
+        pass
+
+    @cli.command("add")
+    def add() -> None:
+        raise click.UsageError("bad input")
+
+    deprecated_command_alias(cli, alias="import", canonical="add")
+    runner = CliRunner()
+    canonical = runner.invoke(cli, ["add"])
+    reset_deprecation_state()
+    aliased = runner.invoke(cli, ["import"])
+    assert canonical.exit_code == aliased.exit_code
+    assert canonical.exit_code != 0
+
+
+def test_alias_help_marks_deprecation() -> None:
+    reset_deprecation_state()
+    cli = _make_canonical_group()
+    deprecated_command_alias(cli, alias="import", canonical="add")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", "--help"])
+    assert result.exit_code == 0
+    assert "deprecated" in result.stdout.lower()
+
+
+# --- flag-level alias -----------------------------------------------------
+
+
+def test_flag_alias_canonical_works() -> None:
+    reset_deprecation_state()
+
+    @click.command()
+    @deprecated_option(
+        ["--uuid"],
+        canonical="--random-ids",
+        type=click.Choice(["stable", "random"]),
+        transform=lambda v: {"random_ids": v == "random"} if v is not None else {},
+    )
+    @click.option("--random-ids", is_flag=True, default=False)
+    def cmd(random_ids: bool) -> None:
+        click.echo(f"random_ids={random_ids}")
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--random-ids"])
+    assert result.exit_code == 0
+    assert "random_ids=True" in result.stdout
+    assert result.stderr == ""
+
+
+def test_flag_alias_translates_old_to_canonical() -> None:
+    reset_deprecation_state()
+
+    @click.command()
+    @deprecated_option(
+        ["--uuid"],
+        canonical="--random-ids",
+        type=click.Choice(["stable", "random"]),
+        transform=lambda v: {"random_ids": v == "random"} if v is not None else {},
+    )
+    @click.option("--random-ids", is_flag=True, default=False)
+    def cmd(random_ids: bool) -> None:
+        click.echo(f"random_ids={random_ids}")
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--uuid", "random"])
+    assert result.exit_code == 0
+    assert "random_ids=True" in result.stdout
+    assert (
+        "warning: '--uuid' is deprecated; use '--random-ids' instead. "
+        "This alias will be removed in a future release."
+    ) in result.stderr
+
+
+def test_flag_alias_stable_value_translates_to_false() -> None:
+    reset_deprecation_state()
+
+    @click.command()
+    @deprecated_option(
+        ["--uuid"],
+        canonical="--random-ids",
+        type=click.Choice(["stable", "random"]),
+        transform=lambda v: {"random_ids": v == "random"} if v is not None else {},
+    )
+    @click.option("--random-ids", is_flag=True, default=False)
+    def cmd(random_ids: bool) -> None:
+        click.echo(f"random_ids={random_ids}")
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--uuid", "stable"])
+    assert result.exit_code == 0
+    assert "random_ids=False" in result.stdout
+    assert "warning: '--uuid'" in result.stderr
+
+
+def test_flag_alias_simple_passthrough_without_transform() -> None:
+    reset_deprecation_state()
+
+    @click.command()
+    @deprecated_option(["--old-name"], canonical="--new-name")
+    @click.option("--new-name", default="")
+    def cmd(new_name: str) -> None:
+        click.echo(f"new_name={new_name}")
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--old-name", "hello"])
+    assert result.exit_code == 0
+    assert "new_name=hello" in result.stdout
+    assert "warning: '--old-name' is deprecated" in result.stderr
+
+
+# --- dedupe ---------------------------------------------------------------
+
+
+def test_warning_emitted_once_per_invocation_for_command_alias() -> None:
+    reset_deprecation_state()
+    cli = _make_canonical_group()
+    deprecated_command_alias(cli, alias="import", canonical="add")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["import", "book.epub"])
+    assert result.exit_code == 0
+    assert result.stderr.count("warning: 'import' is deprecated") == 1
+
+
+def test_warning_emitted_once_per_invocation_for_flag_alias() -> None:
+    reset_deprecation_state()
+
+    @click.command()
+    @deprecated_option(["--old-name"], canonical="--new-name")
+    @click.option("--new-name", default="")
+    def cmd(new_name: str) -> None:
+        click.echo(f"new_name={new_name}")
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--old-name", "hello"])
+    assert result.exit_code == 0
+    assert result.stderr.count("warning: '--old-name' is deprecated") == 1
+
+
+def test_separate_invocations_each_warn() -> None:
+    # Each fresh CLI invocation in production starts a new process, so the
+    # dedupe state must be resettable. Validate by resetting between runs.
+    cli = _make_canonical_group()
+    deprecated_command_alias(cli, alias="import", canonical="add")
+    runner = CliRunner()
+
+    reset_deprecation_state()
+    first = runner.invoke(cli, ["import", "book.epub"])
+    reset_deprecation_state()
+    second = runner.invoke(cli, ["import", "book.epub"])
+
+    assert "warning: 'import' is deprecated" in first.stderr
+    assert "warning: 'import' is deprecated" in second.stderr


### PR DESCRIPTION
## Summary

Closes #221. Foundation for the upcoming CLI renames under #84 (#214, #216, #217, #218, #219). Provides two small helpers in `src/bookery/cli/deprecation.py` so every rename PR is one line of config instead of hand-rolling a callback.

- `deprecated_command_alias(group, *, alias, canonical)` — registers a hidden Click command that forwards args/options to the canonical command and prints a one-line deprecation warning to stderr.
- `deprecated_option(old_names, *, canonical, transform=None, **option_kwargs)` — decorator that attaches a hidden Click option mapping deprecated flags onto the canonical parameter destination, with optional value translation (e.g. `--uuid stable|random` -> `--random-ids` bool).

Both surfaces share the same warning template:

> `warning: '<old>' is deprecated; use '<new>' instead. This alias will be removed in a future release.`

Warnings are emitted to **stderr only**, at most **once per process invocation**, via a module-level dedupe set. `reset_deprecation_state()` is exposed for tests.

CONTRIBUTING.md gets a short pointer in a new "Renaming a CLI Command or Flag" subsection so future renames find the helper.

## Why

Five upcoming rename PRs (#214, #216, #217, #218, #219) all need identical "keep the old name working for one release" plumbing. Build the pattern once.

## How downstream renames will use it

Command rename (e.g. `import` -> `add`, #216):

```python
from bookery.cli.deprecation import deprecated_command_alias

cli.add_command(add_cmd.add_command)
deprecated_command_alias(cli, alias="import", canonical="add")
```

Flag rename with value translation (e.g. `--uuid stable|random` -> `--random-ids`, #218):

```python
from bookery.cli.deprecation import deprecated_option

@deprecated_option(
    ["--uuid"],
    canonical="--random-ids",
    type=click.Choice(["stable", "random"]),
    transform=lambda v: {"random_ids": v == "random"} if v is not None else {},
)
@click.option("--random-ids", is_flag=True, default=False)
def some_cmd(random_ids: bool) -> None: ...
```

Simple flag rename without transform:

```python
@deprecated_option(["--old-name"], canonical="--new-name")
@click.option("--new-name", default="")
def cmd(new_name: str) -> None: ...
```

## Test plan

- [x] `uv run pytest tests/unit/test_cli_deprecation.py` — 12 unit tests cover canonical works, alias works, warning prints to stderr, warning prints once per invocation, args/options forward, exit code matches canonical on error, alias help marks deprecation, value transform, simple passthrough, both old and new names, multiple invocations re-warn after reset.
- [x] `uv run pytest` — full suite 1946 passed.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run pyright src/bookery/cli/deprecation.py` — 0 errors.
- [x] Real-process smoke test (outside CliRunner) confirms warning hits real stderr stream, canonical stdout is untouched.

## Notes

- Existing one-off pattern at `src/bookery/cli/options.py::auto_accept_option` (the `-q/--quiet` -> `-y/--yes` alias) is left in place; downstream renames can migrate it later if they touch that file. This PR does not refactor existing code, only provides the helper for new renames.
- Click 8.3.1 dropped `CliRunner(mix_stderr=False)` — stderr/stdout are separated by default now; tests use plain `CliRunner()`.