### PR TITLE
Fix #217: Replace vault-export --uuid with boolean --random-ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ index_min_count = 1
 exclude_tags = ["type/meeting"]      # drop notes with these exact frontmatter tags
 default_author = "Your Name"
 uuid_mode = "stable"                 # "stable" keeps the same dc:identifier
-                                     # across re-exports so Kobo updates in place
+                                     # across re-exports so Kobo updates in place.
+                                     # Pass `--random-ids` on the command line
+                                     # for a fresh identifier per export.
 catalog = true                       # auto-add the EPUB to the bookery library
                                      # so it ships on the next `sync kobo`
 ```

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -68,6 +68,8 @@ max_tokens = 262144
 #   uuid_mode = "stable"        # "stable" reuses the dc:identifier across
 #                               # exports so re-sync to Kobo updates the book
 #                               # in place; "random" produces a fresh id.
+#                               # Per-run override on the command line is
+#                               # `--random-ids` (boolean flag, off by default).
 #   exclude_tags = ["type/meeting", "type/daily"]
 #                               # Skip any note whose frontmatter tags include
 #                               # one of these exact strings. Useful for

--- a/src/bookery/cli/commands/vault_export_cmd.py
+++ b/src/bookery/cli/commands/vault_export_cmd.py
@@ -19,6 +19,7 @@ from rich.progress import (
 )
 
 from bookery.cli._match_helpers import build_progress_fn
+from bookery.cli.deprecation import deprecated_option
 from bookery.cli.options import db_option, resolve_db_path
 from bookery.core.config import get_library_root, load_config
 from bookery.core.importer import import_books
@@ -59,9 +60,16 @@ console = Console()
                    "(repeatable). Overrides vault_export.exclude_tags in config.")
 @click.option("--title", "title_opt", default=None, help="EPUB title metadata.")
 @click.option("--author", "author_opt", default=None, help="EPUB author metadata.")
-@click.option("--uuid", "uuid_opt",
-              type=click.Choice(["stable", "random"], case_sensitive=False), default=None,
-              help="EPUB identifier strategy. stable=deterministic for re-sync.")
+@deprecated_option(
+    ["--uuid"],
+    canonical="--random-ids",
+    type=click.Choice(["stable", "random"], case_sensitive=False),
+    transform=lambda v: {"random_ids": v.lower() == "random"} if v is not None else {},
+)
+@click.option("--random-ids", "random_ids", is_flag=True, default=False,
+              help="Generate a fresh random UUID identifier for the EPUB instead "
+                   "of the stable, vault-path-derived one. Off by default — the "
+                   "stable identifier lets Kobo update the book in place on re-sync.")
 @click.option("--version-label", "version_label_opt", default=None,
               help="Version label injected into the EPUB title (default: today's date).")
 @click.option("--catalog/--no-catalog", "catalog_opt", default=None,
@@ -78,7 +86,7 @@ def vault_export(
     exclude_tags_opt: tuple[str, ...],
     title_opt: str | None,
     author_opt: str | None,
-    uuid_opt: str | None,
+    random_ids: bool,
     version_label_opt: str | None,
     catalog_opt: bool | None,
     db_path: Path | None,
@@ -105,7 +113,10 @@ def vault_export(
     exclude_tags = list(exclude_tags_opt) if exclude_tags_opt else cfg.exclude_tags
     do_catalog = cfg.catalog if catalog_opt is None else catalog_opt
     author = author_opt or cfg.default_author
-    uuid_mode = (uuid_opt or cfg.uuid_mode).lower()
+    # `--random-ids` is the canonical surface; `cfg.uuid_mode` from config
+    # still drives the identifier when no flag is passed, for back-compat
+    # with existing `~/.bookery/config.toml` files.
+    use_random = random_ids or cfg.uuid_mode.lower() == "random"
     # Only stamp the title with a date when the user explicitly asks for one;
     # the stable filename is more useful for re-sync (Kobo and disk) than a
     # date-versioned snapshot that piles up duplicates.
@@ -142,7 +153,7 @@ def vault_export(
     overall_task = overall.add_task("Walking vault", total=None)
     current_task = current.add_task("(scanning…)", total=None)
 
-    identifier = stable_uuid(vault_path) if uuid_mode == "stable" else random_uuid()
+    identifier = random_uuid() if use_random else stable_uuid(vault_path)
     metadata = EpubMetadata(
         title=title,
         author=author,

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -339,3 +339,45 @@ def test_vault_export_default_output_lands_in_library_root_with_catalog(
     # Default filename is derived from --title so the EPUB lands at a
     # stable, predictable path under the library root.
     assert (_isolate_library_root / "Test Vault.epub").exists()
+
+
+def test_vault_export_random_ids_flag_produces_random_identifier(tmp_path: Path) -> None:
+    """`--random-ids` should produce a fresh, non-stable identifier — two runs
+    with the same vault path must yield different dc:identifier values.
+    """
+    from bookery.cli.deprecation import reset_deprecation_state
+    reset_deprecation_state()
+
+    first, out = _run(tmp_path, "--random-ids")
+    assert first.exit_code == 0, first.output
+    ids_first = [v for v, _ in epub.read_epub(str(out)).get_metadata("DC", "identifier")]
+
+    out.unlink()
+    reset_deprecation_state()
+    second, _ = _run(tmp_path, "--random-ids")
+    assert second.exit_code == 0, second.output
+    ids_second = [v for v, _ in epub.read_epub(str(out)).get_metadata("DC", "identifier")]
+
+    assert ids_first != ids_second
+    assert all(v.startswith("urn:uuid:") for v in ids_first + ids_second)
+
+
+def test_vault_export_deprecated_uuid_random_alias_warns_and_works(tmp_path: Path) -> None:
+    """`--uuid random` is a deprecated alias that still works and prints a
+    one-line warning to stderr.
+    """
+    from bookery.cli.deprecation import reset_deprecation_state
+    reset_deprecation_state()
+
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(FIXTURE), "-o", str(out), "--uuid", "random"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert "warning: '--uuid' is deprecated; use '--random-ids' instead." in result.stderr
+    ids = [v for v, _ in epub.read_epub(str(out)).get_metadata("DC", "identifier")]
+    assert any(v.startswith("urn:uuid:") for v in ids)

--- a/tests/integration/test_vault_export_ids_integration.py
+++ b/tests/integration/test_vault_export_ids_integration.py
@@ -1,0 +1,108 @@
+# ABOUTME: Integration tests for vault-export's --random-ids flag and --uuid alias.
+# ABOUTME: Exercises the full CLI surface through to EpubMetadata without invoking pandoc.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.cli.deprecation import reset_deprecation_state
+from bookery.core.config import Config, VaultExportConfig
+from bookery.core.vault.epub import stable_uuid
+
+
+@pytest.fixture
+def vault_with_note(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "n.md").write_text("# n\n\nbody\n", encoding="utf-8")
+    return vault
+
+
+@pytest.fixture
+def patched_render(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def _render(markdown, assets, metadata, output_path) -> None:
+        captured["metadata"] = metadata
+        Path(output_path).write_bytes(b"fake-epub")
+
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.render_epub", _render,
+    )
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.load_config",
+        lambda: Config(
+            library_root=Path("/tmp/_lib"),
+            data_dir=Path("/tmp/_data"),
+            vault_export=VaultExportConfig(),
+        ),
+    )
+    return captured
+
+
+def test_random_ids_and_old_alias_route_to_same_branch(
+    vault_with_note: Path, patched_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    """`--random-ids` and `--uuid random` must both produce a non-stable
+    identifier — proves the alias is fully wired into the boolean path.
+    """
+    runner = CliRunner()
+
+    reset_deprecation_state()
+    out_new = tmp_path / "new.epub"
+    runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(vault_with_note), "-o", str(out_new),
+         "--random-ids"],
+        catch_exceptions=False,
+    )
+    id_new = patched_render["metadata"].identifier
+
+    reset_deprecation_state()
+    out_old = tmp_path / "old.epub"
+    runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(vault_with_note), "-o", str(out_old),
+         "--uuid", "random"],
+        catch_exceptions=False,
+    )
+    id_old = patched_render["metadata"].identifier
+
+    stable = stable_uuid(vault_with_note)
+    assert id_new != stable
+    assert id_old != stable
+    # Both random; not equal to each other either (random_uuid is uuid4).
+    assert id_new != id_old
+
+
+def test_uuid_stable_alias_matches_default_behavior(
+    vault_with_note: Path, patched_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    """`--uuid stable` should produce the same identifier as no flag at all."""
+    runner = CliRunner()
+
+    reset_deprecation_state()
+    out_default = tmp_path / "default.epub"
+    runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(vault_with_note), "-o", str(out_default)],
+        catch_exceptions=False,
+    )
+    id_default = patched_render["metadata"].identifier
+
+    reset_deprecation_state()
+    out_alias = tmp_path / "alias.epub"
+    runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(vault_with_note), "-o", str(out_alias),
+         "--uuid", "stable"],
+        catch_exceptions=False,
+    )
+    id_alias = patched_render["metadata"].identifier
+
+    assert id_default == id_alias == stable_uuid(vault_with_note)

--- a/tests/unit/test_vault_export_cli_ids.py
+++ b/tests/unit/test_vault_export_cli_ids.py
@@ -1,0 +1,223 @@
+# ABOUTME: Unit tests for the vault-export CLI's `--random-ids` flag and `--uuid` alias.
+# ABOUTME: Mocks pandoc so the flag wiring can be tested without a real EPUB render.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bookery.cli import cli
+from bookery.cli.deprecation import reset_deprecation_state
+
+
+@pytest.fixture
+def fake_vault(tmp_path: Path) -> Path:
+    """A minimal vault with one markdown note so walk_vault produces output."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("# Note\n\nbody\n", encoding="utf-8")
+    return vault
+
+
+@pytest.fixture
+def stub_render(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Capture the EpubMetadata passed to render_epub without invoking pandoc.
+
+    Also stubs load_config so the developer's real ~/.bookery/config.toml
+    (which may set vault_path, folders, etc.) does not leak into the test.
+    """
+    captured: dict[str, Any] = {}
+
+    def _fake_render(
+        markdown: str,
+        assets: list[Path],
+        metadata: Any,
+        output_path: Path,
+    ) -> None:
+        captured["metadata"] = metadata
+        captured["output_path"] = output_path
+        output_path.write_bytes(b"not-a-real-epub")
+
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.render_epub",
+        _fake_render,
+    )
+
+    from bookery.core.config import Config, VaultExportConfig
+
+    def _fake_load_config() -> Config:
+        return Config(
+            library_root=Path("/tmp/bookery-lib"),
+            data_dir=Path("/tmp/bookery-data"),
+            vault_export=VaultExportConfig(),
+        )
+
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.load_config",
+        _fake_load_config,
+    )
+    return captured
+
+
+def test_default_uses_stable_identifier(
+    fake_vault: Path, stub_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Stable UUIDs are deterministic and derived from the vault path.
+    from bookery.core.vault.epub import stable_uuid
+    assert stub_render["metadata"].identifier == stable_uuid(fake_vault)
+    assert result.stderr == ""
+
+
+def test_random_ids_flag_produces_random_identifier(
+    fake_vault: Path, stub_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out), "--random-ids"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    from bookery.core.vault.epub import stable_uuid
+    identifier = stub_render["metadata"].identifier
+    assert identifier.startswith("urn:uuid:")
+    assert identifier != stable_uuid(fake_vault)
+    # --random-ids is the canonical surface; no deprecation warning expected.
+    assert result.stderr == ""
+
+
+def test_deprecated_uuid_random_translates_to_random_ids(
+    fake_vault: Path, stub_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out), "--uuid", "random"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    from bookery.core.vault.epub import stable_uuid
+    identifier = stub_render["metadata"].identifier
+    assert identifier.startswith("urn:uuid:")
+    assert identifier != stable_uuid(fake_vault)
+    assert (
+        "warning: '--uuid' is deprecated; use '--random-ids' instead."
+        in result.stderr
+    )
+
+
+def test_deprecated_uuid_stable_keeps_stable_identifier(
+    fake_vault: Path, stub_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out), "--uuid", "stable"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    from bookery.core.vault.epub import stable_uuid
+    assert stub_render["metadata"].identifier == stable_uuid(fake_vault)
+    assert "warning: '--uuid' is deprecated" in result.stderr
+
+
+def test_uuid_invalid_value_errors(
+    fake_vault: Path, stub_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out), "--uuid", "bogus"],
+    )
+    assert result.exit_code != 0
+    # Click's choice-validation surfaces the invalid value in its error text.
+    combined = (result.output or "") + (result.stderr or "")
+    assert "bogus" in combined
+
+
+def test_deprecation_warning_fires_once(
+    fake_vault: Path, stub_render: dict[str, Any], tmp_path: Path,
+) -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out), "--uuid", "random"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert result.stderr.count("warning: '--uuid' is deprecated") == 1
+
+
+def test_config_uuid_mode_random_still_honored_without_flag(
+    fake_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`uuid_mode = "random"` in config still drives the identifier when no
+    flag is passed. Config-level deprecation is out of scope for this change.
+    """
+    reset_deprecation_state()
+    captured: dict[str, Any] = {}
+
+    def _fake_render(
+        markdown: str,
+        assets: list[Path],
+        metadata: Any,
+        output_path: Path,
+    ) -> None:
+        captured["metadata"] = metadata
+        output_path.write_bytes(b"not-a-real-epub")
+
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.render_epub",
+        _fake_render,
+    )
+
+    from bookery.core.config import Config, VaultExportConfig
+
+    def _fake_load_config() -> Config:
+        return Config(
+            library_root=Path("/tmp/bookery-lib"),
+            data_dir=Path("/tmp/bookery-data"),
+            vault_export=VaultExportConfig(uuid_mode="random"),
+        )
+
+    monkeypatch.setattr(
+        "bookery.cli.commands.vault_export_cmd.load_config",
+        _fake_load_config,
+    )
+
+    runner = CliRunner()
+    out = tmp_path / "out.epub"
+    result = runner.invoke(
+        cli,
+        ["vault-export", "--vault", str(fake_vault), "-o", str(out)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    from bookery.core.vault.epub import stable_uuid
+    identifier = captured["metadata"].identifier
+    assert identifier.startswith("urn:uuid:")
+    assert identifier != stable_uuid(fake_vault)


### PR DESCRIPTION
## Summary

- `--uuid stable|random` reads like "supply a UUID value" — it actually picks an identifier strategy. Replaced with a boolean `--random-ids` flag (off by default; stable IDs remain the default behavior).
- Old `--uuid stable|random` kept as a deprecated alias via the shared `@deprecated_option` helper landed in PR #222 (issue #221). Prints a one-line stderr warning at most once per invocation, then translates: `random` → `random_ids=True`, `stable` → `random_ids=False`. Invalid values still error via Click's choice validation.
- README and `docs/config.example.toml` cross-reference the new flag.

Closes #217. Depends on the `@deprecated_option` helper from #221 (merged in PR #222).

## Before / after

```bash
# Before
bookery vault-export --vault ~/vault -o out.epub --uuid random
bookery vault-export --vault ~/vault -o out.epub --uuid stable

# After (canonical, no warning)
bookery vault-export --vault ~/vault -o out.epub --random-ids
bookery vault-export --vault ~/vault -o out.epub                  # stable is default

# Old form still works for one release, prints stderr warning
bookery vault-export --vault ~/vault -o out.epub --uuid random
# warning: '--uuid' is deprecated; use '--random-ids' instead. This alias will be removed in a future release.
```

## Internal plumbing

The boolean swap was minimal — only the command body had to switch from a tri-string `uuid_mode` ("stable" | "random" | config default) to a `use_random` bool. `cfg.uuid_mode` from `~/.bookery/config.toml` still drives the identifier when no flag is passed, so existing config files keep working untouched (config-level deprecation is out of scope).

No core code outside `vault_export_cmd.py` touched the strategy string — `random_uuid()` / `stable_uuid()` were already two separate functions.

## Test plan

- [x] `uv run pytest` green (1957 tests pass).
- [x] `uv run ruff check src/ tests/` clean.
- [x] `uv run pyright src/bookery/cli/commands/vault_export_cmd.py` clean.
- [x] `bookery vault-export --help` shows `--random-ids` and hides `--uuid`.
- [x] Unit tests: 7 new tests covering canonical flag, alias translation in both directions, invalid value, warn-once dedupe, and config back-compat.
- [x] Integration tests: 2 tests proving `--random-ids` and `--uuid random` route to the same branch, and `--uuid stable` matches default behavior.
- [x] E2E tests: 2 new tests producing real EPUBs via pandoc to verify identifier differences and the stderr deprecation warning.