### PR TITLE
Refactor #214: Rename folder->reveal and vault-export --folder->--include-folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ bookery info 42
 | `info <id>` | Show detailed metadata for a book by ID (`--provenance`, `--set field=value`, `--lock field`, `--unlock field`) |
 | `search <query>` | Search the catalog by title, author, or description |
 | `inventory <path>` | Scan a directory tree and report ebook format coverage |
-| `folder <query>` | Open the on-disk folder for a book (`--print` to print the path instead) |
+| `reveal <query>` | Open the on-disk folder for a book (`--print` to print the path instead). `folder` is a deprecated alias. |
 
 ### Organization
 
@@ -210,9 +210,12 @@ Run with flags:
 
 ```bash
 bookery vault-export --vault ~/obsidian-vault -o vault.epub \
-  --folder "3_Permanent Notes" --folder "2_Literature Notes" \
+  --include-folder "3_Permanent Notes" --include-folder "2_Literature Notes" \
   --index --exclude-tag type/meeting
 ```
+
+`--folder` is accepted as a deprecated alias for `--include-folder` and will
+be removed in a future release.
 
 Or set defaults once in `~/.bookery/config.toml` and just run
 `bookery vault-export -o vault.epub`:

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -9,7 +9,6 @@ import click
 from bookery.cli.commands import (
     add_cmd,
     convert_cmd,
-    folder_cmd,
     genre_cmd,
     import_cmd,
     info_cmd,
@@ -21,6 +20,7 @@ from bookery.cli.commands import (
     prune_cmd,
     rematch_cmd,
     remove_cmd,
+    reveal_cmd,
     search_cmd,
     serve_cmd,
     sync_cmd,
@@ -28,6 +28,7 @@ from bookery.cli.commands import (
     vault_export_cmd,
     verify_cmd,
 )
+from bookery.cli.deprecation import deprecated_command_alias
 
 
 @click.group()
@@ -60,7 +61,6 @@ def cli(ctx: click.Context, verbose: int, db_path: Path | None) -> None:
 
 cli.add_command(add_cmd.add_command)
 cli.add_command(convert_cmd.convert)
-cli.add_command(folder_cmd.folder)
 cli.add_command(genre_cmd.genre)
 cli.add_command(import_cmd.import_command)
 cli.add_command(info_cmd.info)
@@ -72,9 +72,13 @@ cli.add_command(match_cmd.match)
 cli.add_command(prune_cmd.prune)
 cli.add_command(rematch_cmd.rematch)
 cli.add_command(remove_cmd.remove)
+cli.add_command(reveal_cmd.reveal)
 cli.add_command(search_cmd.search)
 cli.add_command(serve_cmd.serve)
 cli.add_command(sync_cmd.sync)
 cli.add_command(tag_cmd.tag)
 cli.add_command(vault_export_cmd.vault_export)
 cli.add_command(verify_cmd.verify)
+
+# Deprecated alias for the old `folder` command name. Remove after one release.
+deprecated_command_alias(cli, alias="folder", canonical="reveal")

--- a/src/bookery/cli/commands/reveal_cmd.py
+++ b/src/bookery/cli/commands/reveal_cmd.py
@@ -1,4 +1,4 @@
-# ABOUTME: The `bookery folder` command for opening a book's folder on disk.
+# ABOUTME: The `bookery reveal` command for opening a book's folder on disk.
 # ABOUTME: Resolves an ID or title to a BookRecord and opens the folder in the OS file manager.
 
 from pathlib import Path
@@ -26,7 +26,7 @@ from bookery.util.file_manager import (
 console = Console()  # TODO: move Console() inside command for testability
 
 
-@click.command("folder")
+@click.command("reveal")
 @click.argument("query")
 @click.option(
     "--print",
@@ -36,7 +36,7 @@ console = Console()  # TODO: move Console() inside command for testability
     help="Print the folder path instead of opening the file manager.",
 )
 @db_option
-def folder(query: str, print_only: bool, db_path: Path | None) -> None:
+def reveal(query: str, print_only: bool, db_path: Path | None) -> None:
     """Open the on-disk folder for a book by ID or title."""
     conn = open_library(resolve_db_path(db_path))
     try:

--- a/src/bookery/cli/commands/vault_export_cmd.py
+++ b/src/bookery/cli/commands/vault_export_cmd.py
@@ -19,6 +19,7 @@ from rich.progress import (
 )
 
 from bookery.cli._match_helpers import build_progress_fn
+from bookery.cli.deprecation import deprecated_option
 from bookery.cli.options import db_option, resolve_db_path
 from bookery.core.config import get_library_root, load_config
 from bookery.core.importer import import_books
@@ -42,7 +43,8 @@ console = Console()
 @click.command("vault-export")
 @click.option("--vault", "vault_opt", type=click.Path(path_type=Path), default=None,
               help="Path to the Obsidian vault.")
-@click.option("--folder", "folders_opt", multiple=True,
+@deprecated_option(["--folder"], canonical="--include-folder", multiple=True)
+@click.option("--include-folder", "include_folder", multiple=True,
               help="Top-level folder to include (repeatable). Defaults to the whole vault.")
 @click.option("-o", "--output", "output_path", type=click.Path(path_type=Path),
               default=None,
@@ -70,7 +72,7 @@ console = Console()
 @db_option
 def vault_export(
     vault_opt: Path | None,
-    folders_opt: tuple[str, ...],
+    include_folder: tuple[str, ...],
     output_path: Path | None,
     index_opt: bool | None,
     index_exclude_opt: tuple[str, ...],
@@ -98,7 +100,7 @@ def vault_export(
     if not vault_path.is_dir():
         raise click.UsageError(f"vault path does not exist: {vault_path}")
 
-    folders = list(folders_opt) if folders_opt else cfg.folders
+    folders = list(include_folder) if include_folder else cfg.folders
     include_index = cfg.include_index if index_opt is None else index_opt
     exclude_prefixes = list(index_exclude_opt) if index_exclude_opt else cfg.index_exclude_prefixes
     min_count = index_min_count_opt if index_min_count_opt is not None else cfg.index_min_count

--- a/src/bookery/cli/deprecation.py
+++ b/src/bookery/cli/deprecation.py
@@ -179,8 +179,11 @@ def _build_callback(
     def callback(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
         # `value is None` means the user did not supply the deprecated option;
         # leave the canonical value untouched. For flags whose default is
-        # False, treat False the same way so unused flags stay quiet.
-        if value is None or value is False:
+        # False, treat False the same way so unused flags stay quiet. For
+        # repeatable options (`multiple=True`), Click delivers an empty tuple
+        # when nothing was supplied — also skip those so the canonical-only
+        # path stays warning-free.
+        if value is None or value is False or value == ():
             return value
         _emit_warning(primary_old, canonical)
         mapping = (

--- a/tests/e2e/test_reveal_cli.py
+++ b/tests/e2e/test_reveal_cli.py
@@ -1,14 +1,21 @@
-# ABOUTME: End-to-end tests for the `bookery folder` CLI command.
+# ABOUTME: End-to-end tests for the `bookery reveal` CLI command (and `folder` alias).
 # ABOUTME: Drives the full CLI through Click against a real on-disk DB and folder.
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from bookery.cli import cli
+from bookery.cli.deprecation import reset_deprecation_state
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedupe() -> None:
+    reset_deprecation_state()
 
 
 def _seed_book(db_path: Path, title: str, folder: Path) -> int:
@@ -26,8 +33,8 @@ def _seed_book(db_path: Path, title: str, folder: Path) -> int:
         conn.close()
 
 
-class TestFolderCliE2E:
-    """E2E tests covering the full folder command flow against a real DB."""
+class TestRevealCliE2E:
+    """E2E tests covering the full reveal command flow against a real DB."""
 
     def test_print_folder_by_id(self, tmp_path: Path) -> None:
         db_path = tmp_path / "e2e.db"
@@ -35,7 +42,7 @@ class TestFolderCliE2E:
         book_id = _seed_book(db_path, "The Hobbit", folder)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", str(book_id), "--print", "--db", str(db_path)])
         assert result.exit_code == 0, result.output
 
         printed = result.output.strip().splitlines()[-1]
@@ -50,6 +57,27 @@ class TestFolderCliE2E:
         _seed_book(db_path, "The Hobbit", folder)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", "Hobbit", "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", "Hobbit", "--print", "--db", str(db_path)])
         assert result.exit_code == 0, result.output
         assert str(folder) in result.output
+
+    def test_folder_alias_still_prints_path(self, tmp_path: Path) -> None:
+        """`folder` is the deprecated alias for `reveal` and must still work."""
+        db_path = tmp_path / "e2e.db"
+        folder = tmp_path / "library" / "Aliased"
+        book_id = _seed_book(db_path, "Aliased", folder)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
+        assert result.exit_code == 0, result.output
+        assert str(folder) in result.output
+
+    def test_folder_alias_warns_to_stderr(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "e2e.db"
+        folder = tmp_path / "library" / "Warned"
+        book_id = _seed_book(db_path, "Warned", folder)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
+        assert result.exit_code == 0, result.output
+        assert "warning: 'folder' is deprecated; use 'reveal' instead." in result.stderr

--- a/tests/e2e/test_vault_export_cli.py
+++ b/tests/e2e/test_vault_export_cli.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from ebooklib import epub
 
 from bookery.cli import cli
+from bookery.cli.deprecation import reset_deprecation_state
 
 pytestmark = pytest.mark.skipif(
     shutil.which("pandoc") is None, reason="pandoc not installed"
@@ -339,3 +340,87 @@ def test_vault_export_default_output_lands_in_library_root_with_catalog(
     # Default filename is derived from --title so the EPUB lands at a
     # stable, predictable path under the library root.
     assert (_isolate_library_root / "Test Vault.epub").exists()
+
+
+def test_vault_export_include_folder_filters_to_subset(tmp_path: Path) -> None:
+    """`--include-folder` is the canonical name for selecting subfolders; it is
+    repeatable and additive. Restricting to `3_Permanent Notes` should still
+    surface that folder's notes in the TOC while excluding others.
+    """
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    result = runner.invoke(
+        cli,
+        [
+            "vault-export", "--vault", str(FIXTURE),
+            "-o", str(out),
+            "--include-folder", "3_Permanent Notes",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Canonical invocation must not warn.
+    assert "deprecated" not in result.stderr
+    assert out.exists()
+
+
+def test_vault_export_folder_alias_still_works(tmp_path: Path) -> None:
+    """The deprecated `--folder` alias should still forward to `--include-folder`."""
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    result = runner.invoke(
+        cli,
+        [
+            "vault-export", "--vault", str(FIXTURE),
+            "-o", str(out),
+            "--folder", "3_Permanent Notes",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert (
+        "warning: '--folder' is deprecated; use '--include-folder' instead."
+        in result.stderr
+    )
+
+
+def test_vault_export_folder_alias_warns_once_when_repeated(tmp_path: Path) -> None:
+    """Even with multiple `--folder` flags, the warning fires exactly once."""
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    result = runner.invoke(
+        cli,
+        [
+            "vault-export", "--vault", str(FIXTURE),
+            "-o", str(out),
+            "--folder", "3_Permanent Notes",
+            "--folder", "2_Literature Notes",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert result.stderr.count("warning: '--folder' is deprecated") == 1
+
+
+def test_vault_export_include_folder_repeatable(tmp_path: Path) -> None:
+    """`--include-folder` is repeatable; multiple flags accumulate."""
+    reset_deprecation_state()
+    runner = CliRunner()
+    out = tmp_path / "vault.epub"
+    result = runner.invoke(
+        cli,
+        [
+            "vault-export", "--vault", str(FIXTURE),
+            "-o", str(out),
+            "--include-folder", "3_Permanent Notes",
+            "--include-folder", "2_Literature Notes",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "deprecated" not in result.stderr
+    assert out.exists()

--- a/tests/integration/test_reveal_cmd.py
+++ b/tests/integration/test_reveal_cmd.py
@@ -1,4 +1,4 @@
-# ABOUTME: Integration tests for the `bookery folder` CLI command.
+# ABOUTME: Integration tests for the `bookery reveal` CLI command (and `folder` alias).
 # ABOUTME: Uses a real tmp SQLite database with the file-manager opener mocked.
 
 from pathlib import Path
@@ -8,10 +8,17 @@ import pytest
 from click.testing import CliRunner
 
 from bookery.cli import cli
+from bookery.cli.deprecation import reset_deprecation_state
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 from bookery.metadata.types import BookMetadata
 from bookery.util.file_manager import Headless, Opened, OpenerFailed
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedupe() -> None:
+    """Each test starts with a clean deprecation-warning dedupe set."""
+    reset_deprecation_state()
 
 
 @pytest.fixture()
@@ -43,7 +50,7 @@ def db_with_books(tmp_path: Path) -> tuple[Path, dict[str, int]]:
     return db_path, ids
 
 
-class TestFolderCommandPrint:
+class TestRevealCommandPrint:
     def test_print_by_id_prints_path_and_exits_zero(
         self, db_with_books: tuple[Path, dict[str, int]]
     ) -> None:
@@ -51,23 +58,23 @@ class TestFolderCommandPrint:
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["folder", str(ids["The Hobbit"]), "--print", "--db", str(db_path)],
+            ["reveal", str(ids["The Hobbit"]), "--print", "--db", str(db_path)],
         )
         assert result.exit_code == 0, result.output
         assert "The_Hobbit" in result.output
 
 
-class TestFolderCommandOpen:
+class TestRevealCommandOpen:
     def test_open_by_id_invokes_opener(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, ids = db_with_books
         runner = CliRunner()
         with patch(
-            "bookery.cli.commands.folder_cmd.open_in_file_manager",
+            "bookery.cli.commands.reveal_cmd.open_in_file_manager",
             return_value=Opened(),
         ) as mock_open:
             result = runner.invoke(
                 cli,
-                ["folder", str(ids["The Hobbit"]), "--db", str(db_path)],
+                ["reveal", str(ids["The Hobbit"]), "--db", str(db_path)],
             )
         assert result.exit_code == 0, result.output
         mock_open.assert_called_once()
@@ -78,12 +85,12 @@ class TestFolderCommandOpen:
         db_path, ids = db_with_books
         runner = CliRunner()
         with patch(
-            "bookery.cli.commands.folder_cmd.open_in_file_manager",
+            "bookery.cli.commands.reveal_cmd.open_in_file_manager",
             return_value=Headless(),
         ):
             result = runner.invoke(
                 cli,
-                ["folder", str(ids["The Hobbit"]), "--db", str(db_path)],
+                ["reveal", str(ids["The Hobbit"]), "--db", str(db_path)],
             )
         assert result.exit_code == 0, result.output
         assert "headless" in result.output.lower() or "no graphical" in result.output.lower()
@@ -94,29 +101,29 @@ class TestFolderCommandOpen:
         db_path, ids = db_with_books
         runner = CliRunner()
         with patch(
-            "bookery.cli.commands.folder_cmd.open_in_file_manager",
+            "bookery.cli.commands.reveal_cmd.open_in_file_manager",
             return_value=OpenerFailed("nope"),
         ):
             result = runner.invoke(
                 cli,
-                ["folder", str(ids["The Hobbit"]), "--db", str(db_path)],
+                ["reveal", str(ids["The Hobbit"]), "--db", str(db_path)],
             )
         assert result.exit_code == 1
         assert "nope" in result.output
 
 
-class TestFolderCommandLookupErrors:
+class TestRevealCommandLookupErrors:
     def test_unknown_id_exits_one(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, _ = db_with_books
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", "9999", "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", "9999", "--print", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "not found" in result.output.lower()
 
     def test_ambiguous_title_exits_two(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, _ = db_with_books
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", "Dune", "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", "Dune", "--print", "--db", str(db_path)])
         assert result.exit_code == 2
         assert "Dune" in result.output
         assert "Dune Messiah" in result.output
@@ -124,13 +131,13 @@ class TestFolderCommandLookupErrors:
     def test_typo_returns_suggestions(self, db_with_books: tuple[Path, dict[str, int]]) -> None:
         db_path, _ = db_with_books
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", "Hobit", "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", "Hobit", "--print", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "did you mean" in result.output.lower()
         assert "Hobbit" in result.output
 
 
-class TestFolderCommandFilesystemErrors:
+class TestRevealCommandFilesystemErrors:
     def test_missing_folder_on_disk_exits_one(self, tmp_path: Path) -> None:
         db_path = tmp_path / "lib.db"
         conn = open_library(db_path)
@@ -144,14 +151,14 @@ class TestFolderCommandFilesystemErrors:
         conn.close()
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", str(book_id), "--print", "--db", str(db_path)])
         assert result.exit_code == 1
         assert "out of sync" in result.output.lower() or "does not exist" in result.output.lower()
 
     def test_no_output_path_falls_back_to_source_parent(self, tmp_path: Path) -> None:
         """When output_path is None, fall back to the parent of source_path.
 
-        Books imported without --match never get an output_path. The folder
+        Books imported without --match never get an output_path. The reveal
         command should still be useful by opening the directory containing
         the original EPUB.
         """
@@ -171,6 +178,37 @@ class TestFolderCommandFilesystemErrors:
         conn.close()
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["folder", str(book_id), "--print", "--db", str(db_path)])
+        result = runner.invoke(cli, ["reveal", str(book_id), "--print", "--db", str(db_path)])
         assert result.exit_code == 0, result.output
         assert str(source_dir) in result.output
+
+
+class TestFolderAliasDeprecated:
+    """`folder` is the deprecated alias for `reveal`. It must still work and warn."""
+
+    def test_folder_alias_still_works(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, ids = db_with_books
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["folder", str(ids["The Hobbit"]), "--print", "--db", str(db_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "The_Hobbit" in result.output
+
+    def test_folder_alias_prints_deprecation_warning(
+        self, db_with_books: tuple[Path, dict[str, int]]
+    ) -> None:
+        db_path, ids = db_with_books
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["folder", str(ids["The Hobbit"]), "--print", "--db", str(db_path)],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert (
+            "warning: 'folder' is deprecated; use 'reveal' instead."
+            in result.stderr
+        )

--- a/tests/unit/test_cli_deprecation.py
+++ b/tests/unit/test_cli_deprecation.py
@@ -185,6 +185,65 @@ def test_flag_alias_simple_passthrough_without_transform() -> None:
     assert "warning: '--old-name' is deprecated" in result.stderr
 
 
+# --- multiple=True repeatable option --------------------------------------
+
+
+def _make_multiple_cmd() -> click.Command:
+    """Build a command with a deprecated repeatable option."""
+
+    @click.command()
+    @deprecated_option(["--folder"], canonical="--include-folder", multiple=True)
+    @click.option("--include-folder", multiple=True, default=())
+    def cmd(include_folder: tuple[str, ...]) -> None:
+        click.echo(f"include_folder={include_folder!r}")
+
+    return cmd
+
+
+def test_flag_alias_multiple_canonical_only_is_silent() -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    result = runner.invoke(
+        _make_multiple_cmd(),
+        ["--include-folder", "a", "--include-folder", "b"],
+    )
+    assert result.exit_code == 0
+    assert "include_folder=('a', 'b')" in result.stdout
+    assert "deprecated" not in result.stderr
+
+
+def test_flag_alias_multiple_neither_is_silent() -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    result = runner.invoke(_make_multiple_cmd(), [])
+    assert result.exit_code == 0
+    assert "include_folder=()" in result.stdout
+    assert "deprecated" not in result.stderr
+
+
+def test_flag_alias_multiple_deprecated_forwards_values() -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    result = runner.invoke(
+        _make_multiple_cmd(),
+        ["--folder", "a", "--folder", "b"],
+    )
+    assert result.exit_code == 0
+    assert "include_folder=('a', 'b')" in result.stdout
+    assert "warning: '--folder' is deprecated; use '--include-folder' instead." in result.stderr
+
+
+def test_flag_alias_multiple_warns_only_once_for_repeats() -> None:
+    reset_deprecation_state()
+    runner = CliRunner()
+    result = runner.invoke(
+        _make_multiple_cmd(),
+        ["--folder", "a", "--folder", "b", "--folder", "c"],
+    )
+    assert result.exit_code == 0
+    assert result.stderr.count("warning: '--folder' is deprecated") == 1
+
+
 # --- dedupe ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #214.

The top-level `folder` command and `vault-export --folder` flag used the same word for two unrelated concepts — opening a book's on-disk directory vs. selecting vault subfolders to include in an export. This PR renames both for clarity while keeping the old names working as deprecated aliases for one release.

- `bookery folder <book>` -> `bookery reveal <book>` (`folder` retained as a hidden, deprecated alias)
- `bookery vault-export --folder X` -> `bookery vault-export --include-folder X` (`--folder` retained as a hidden, deprecated alias; option is repeatable)

Both aliases print a one-line deprecation warning to stderr exactly once per invocation, courtesy of the shared dedupe in `cli/deprecation.py`. Depends on the `@deprecated_alias` helper from #222 (merged on May 27).

### Bug fix in the deprecation helper

The existing `deprecated_option` callback short-circuited only on `None` or `False`, but Click delivers an empty tuple `()` (not `None`) when a `multiple=True` option is unset. That meant a repeatable deprecated flag would fire its warning on every invocation — even when the user only supplied the canonical name. Extended the filter to also skip `()`, with new unit tests pinning the canonical-only-is-silent and warn-once-when-repeated behaviors.

### Example invocations

```bash
# Canonical (no warnings):
bookery reveal "The Hobbit" --print
bookery vault-export --vault ~/vault --include-folder "Permanent" --include-folder "Literature"

# Deprecated aliases (still work, warn once to stderr):
bookery folder "The Hobbit" --print
# stderr: warning: 'folder' is deprecated; use 'reveal' instead. ...

bookery vault-export --vault ~/vault --folder "Permanent" --folder "Literature"
# stderr: warning: '--folder' is deprecated; use '--include-folder' instead. ...
```

## Test plan

- [x] `uv run pytest` — 1958 tests pass (added 4 unit tests for `multiple=True` deprecation, 2 integration + 2 e2e tests for the `folder` alias, 4 e2e tests for the vault-export rename)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright src/` — clean (pre-commit hook ran on commit)
- [x] Canonical `bookery reveal <id> --print` works without warnings
- [x] Deprecated `bookery folder <id> --print` still works and warns once
- [x] Canonical `vault-export --include-folder X --include-folder Y` works without warnings
- [x] Deprecated `vault-export --folder X --folder Y` still works and warns exactly once
- [x] README updated (command table + vault-export workflow example)

## Files touched

- `src/bookery/cli/__init__.py` — register `reveal`, alias `folder` -> `reveal`
- `src/bookery/cli/commands/reveal_cmd.py` — renamed from `folder_cmd.py`
- `src/bookery/cli/commands/vault_export_cmd.py` — `--folder` -> `--include-folder`, deprecated alias
- `src/bookery/cli/deprecation.py` — short-circuit empty tuple from `multiple=True`
- `tests/unit/test_cli_deprecation.py` — coverage for `multiple=True` behavior
- `tests/integration/test_reveal_cmd.py` — renamed; switched primary invocations to `reveal`; added alias tests
- `tests/e2e/test_reveal_cli.py` — renamed; added alias tests
- `tests/e2e/test_vault_export_cli.py` — added `--include-folder` + `--folder` alias tests
- `README.md` — updated command table and vault-export workflow example