### PR TITLE
Add #200: fetch and embed candidate cover on enrich-apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ bookery info 42
 |---------|-------------|
 | `serve` | Launch the local web UI (`--host`, `--port`; default `127.0.0.1:5000`) |
 
-The web UI provides paginated and sortable browsing, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail and edit pages, a "search active providers" flow that lets you apply candidate metadata with a side-by-side diff, and inline delete.
+The web UI provides paginated and sortable browsing, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail and edit pages, a "search active providers" flow that lets you apply candidate metadata with a side-by-side diff, and inline delete. When you apply a candidate, its cover image (if the provider offers one) is fetched and embedded into the non-destructive EPUB copy alongside the text fields; a cover-fetch failure is non-fatal — the text metadata still applies and the result message notes the cover was skipped.
 
 ### Device sync
 

--- a/src/bookery/core/coverfetch.py
+++ b/src/bookery/core/coverfetch.py
@@ -1,0 +1,66 @@
+# ABOUTME: HTTP fetch for cover images referenced by a candidate's cover_url.
+# ABOUTME: Best-effort and non-fatal — any failure returns None so text apply still proceeds.
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Cover fetches are interactive (they run inline on the enrich-apply request),
+# so keep the timeout short — a slow CDN should not hold up the text apply.
+_COVER_FETCH_TIMEOUT = 10.0
+
+
+def fetch_cover_image(
+    url: str,
+    *,
+    transport: httpx.BaseTransport | None = None,
+) -> bytes | None:
+    """Download a cover image and return its bytes, or ``None`` on any failure.
+
+    Failure is deliberately non-fatal: a blank URL, network error, non-200
+    response, non-image content-type, or empty body all return ``None`` with a
+    logged warning. The caller (enrich-apply) treats ``None`` as "no cover this
+    time" and still applies the candidate's text metadata.
+
+    Args:
+        url: The candidate's ``cover_url``. Empty/whitespace short-circuits.
+        transport: Optional httpx transport for test injection.
+
+    Returns:
+        The downloaded image bytes, or ``None`` if the cover could not be fetched.
+    """
+    if not url or not url.strip():
+        return None
+
+    client_kwargs: dict[str, object] = {
+        "headers": {"User-Agent": "bookery/0.1.0"},
+        "timeout": _COVER_FETCH_TIMEOUT,
+        "follow_redirects": True,
+    }
+    if transport is not None:
+        client_kwargs["transport"] = transport
+
+    try:
+        with httpx.Client(**client_kwargs) as client:  # type: ignore[arg-type]
+            response = client.get(url)
+    except httpx.HTTPError as exc:
+        logger.warning("Cover fetch failed for %s: %s", url, exc)
+        return None
+
+    if response.status_code != 200:
+        logger.warning("Cover fetch got HTTP %d for %s", response.status_code, url)
+        return None
+
+    content_type = response.headers.get("Content-Type", "")
+    if not content_type.lower().startswith("image/"):
+        logger.warning("Cover fetch got non-image content-type %r for %s", content_type, url)
+        return None
+
+    data = response.content
+    if not data:
+        logger.warning("Cover fetch returned empty body for %s", url)
+        return None
+
+    return data

--- a/src/bookery/core/pipeline.py
+++ b/src/bookery/core/pipeline.py
@@ -2,7 +2,7 @@
 # ABOUTME: Copies EPUB to output directory then writes updated metadata to the copy.
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from bookery.core.filecopy import copy_file
@@ -105,7 +105,11 @@ def _cleanup_dest(dest: Path) -> None:
 
 
 def apply_metadata_safely(
-    source: Path, metadata: BookMetadata, output_dir: Path
+    source: Path,
+    metadata: BookMetadata,
+    output_dir: Path,
+    *,
+    cover_image: bytes | None = None,
 ) -> WriteResult:
     """Copy an EPUB to output_dir and write updated metadata to the copy.
 
@@ -118,6 +122,10 @@ def apply_metadata_safely(
         source: Path to the original EPUB file.
         metadata: BookMetadata to write to the copy.
         output_dir: Directory to place the modified copy.
+        cover_image: Optional cover image bytes to embed in the same write.
+            When supplied, it overrides any ``metadata.cover_image`` so callers
+            can fetch a candidate cover lazily and pass it through without
+            mutating the candidate's metadata. ``None`` leaves the cover as-is.
 
     Returns:
         WriteResult with path, success flag, and verification details.
@@ -128,6 +136,10 @@ def apply_metadata_safely(
 
     logger.debug("apply_metadata_safely: copying %s -> %s", source.name, dest)
     copy_file(source, dest)
+
+    # Embed the supplied cover (if any) in the same write as the text fields.
+    if cover_image is not None:
+        metadata = replace(metadata, cover_image=cover_image)
 
     # Write metadata to the copy
     try:

--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -1,6 +1,7 @@
 # ABOUTME: EPUB metadata extraction and writing using ebooklib.
 # ABOUTME: Defensive wrapper that handles malformed files gracefully.
 
+import contextlib
 import logging
 from pathlib import Path
 
@@ -287,6 +288,62 @@ def _set_dc_metadata(book: epub.EpubBook, name: str, value: str) -> None:
     book.add_metadata("DC", name, value)
 
 
+_COVER_EXTENSION_FOR_CONTENT_TYPE: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+
+
+def _remove_existing_cover(book: epub.EpubBook) -> None:
+    """Drop any existing cover image item and the ``<meta name="cover">`` tags.
+
+    ``EpubBook.set_cover`` is single-use: calling it on a book that already has
+    a cover would leave a duplicate image item and a second cover meta entry.
+    Clearing the prior cover first keeps the write idempotent so re-enrichment
+    swaps the cover cleanly rather than stacking items.
+    """
+    cover_item = _find_cover_item(book)
+    if cover_item is not None:
+        with contextlib.suppress(ValueError, KeyError):
+            book.items.remove(cover_item)
+
+    # OPF cover meta tags live under the OPF namespace as ("meta", ...) or as a
+    # "cover" name depending on how ebooklib parsed them. Strip both shapes.
+    for ns in list(book.metadata):
+        ns_entries = book.metadata.get(ns, {})
+        for name in list(ns_entries):
+            entries = ns_entries[name]
+            kept = [
+                (value, attrs)
+                for value, attrs in entries
+                if not (isinstance(attrs, dict) and attrs.get("name") == "cover")
+            ]
+            if name == "cover":
+                kept = []
+            if len(kept) != len(entries):
+                ns_entries[name] = kept
+
+
+def _write_cover_image(book: epub.EpubBook, cover_image: bytes) -> None:
+    """Embed ``cover_image`` as the EPUB cover, replacing any existing cover.
+
+    The image bytes are sniffed for a content type so the cover item carries a
+    sensible filename extension; ebooklib's ``set_cover`` then registers the
+    image, a cover page, and the ``<meta name="cover">`` pointer.
+    """
+    _remove_existing_cover(book)
+    content_type = _guess_image_content_type(cover_image)
+    ext = _COVER_EXTENSION_FOR_CONTENT_TYPE.get(content_type, "jpg")
+    # create_page=False skips the generated cover XHTML page. That page relies
+    # on ebooklib's "cover" template, which is absent when the book was read
+    # from an existing EPUB rather than freshly constructed — generating it then
+    # serializes an empty document and ebooklib raises. The image item plus the
+    # ``<meta name="cover">`` pointer are all readers (and _find_cover_item) need.
+    book.set_cover(f"cover.{ext}", cover_image, create_page=False)
+
+
 def write_epub_metadata(path: Path, metadata: BookMetadata) -> None:
     """Write metadata fields into an existing EPUB file.
 
@@ -323,6 +380,9 @@ def write_epub_metadata(path: Path, metadata: BookMetadata) -> None:
 
     if metadata.description is not None:
         _set_dc_metadata(book, "description", metadata.description)
+
+    if metadata.cover_image:
+        _write_cover_image(book, metadata.cover_image)
 
     _fix_toc_uids(book)
     _scrub_none_metadata(book)

--- a/src/bookery/web/covers.py
+++ b/src/bookery/web/covers.py
@@ -64,6 +64,25 @@ def _find_cached(library_root: Path, book_id: int) -> tuple[bytes, str] | None:
     return None
 
 
+def invalidate_cover(library_root: Path, book_id: int) -> None:
+    """Drop any on-disk cached cover for ``book_id``.
+
+    Covers are cached by book id under ``<library_root>/.covers/<id>.<ext>``.
+    After a write that changes the underlying cover (e.g. enrich-apply embeds a
+    new cover into a fresh EPUB copy), the stale cache entry would otherwise be
+    served on the next request. Removing it forces a re-extract from the new
+    file. Best-effort: a missing cache or unlinkable file is not an error.
+    """
+    cache = library_root / ".covers"
+    if not cache.exists():
+        return
+    for ext in _EXTENSION_FOR_CONTENT_TYPE.values():
+        path = cache / f"{book_id}{ext}"
+        with contextlib.suppress(OSError):
+            if path.exists():
+                path.unlink()
+
+
 def get_or_extract_cover(
     book_id: int,
     epub_path: Path | None,

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1,6 +1,7 @@
 # ABOUTME: Flask blueprint with route handlers for the Bookery web UI.
 # ABOUTME: Handles book listing, detail view, search, and inline editing with htmx support.
 
+import logging
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -19,6 +20,7 @@ from flask import (
 )
 
 from bookery.core.config import get_library_root
+from bookery.core.coverfetch import fetch_cover_image
 from bookery.core.enrichment import dispatch_from_form, multi_provider_search
 from bookery.core.pipeline import apply_metadata_safely
 from bookery.core.remove import remove_book
@@ -27,8 +29,10 @@ from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.provider import MetadataProvider
 from bookery.util.text import strip_html
 from bookery.web.browse import BrowsePage, from_request_args
-from bookery.web.covers import get_or_extract_cover
+from bookery.web.covers import get_or_extract_cover, invalidate_cover
 from bookery.web.diff import metadata_diff
+
+logger = logging.getLogger(__name__)
 
 _STATUS_FROM_FORM: dict[str, int] = {
     "unread": STATUS_UNREAD,
@@ -879,7 +883,25 @@ def enrich_apply(book_id):
     output_dir = book.output_path.parent if book.output_path is not None else source.parent
 
     proposed = candidate.metadata
-    write_result = apply_metadata_safely(source, proposed, output_dir)
+
+    # Fetch the candidate's cover (if any) so it lands in the same atomic write
+    # as the text fields. A cover fetch failure is non-fatal: the text metadata
+    # still applies, and we note the skipped cover in the success flash.
+    cover_image: bytes | None = None
+    cover_skipped = False
+    if proposed.cover_url:
+        cover_image = fetch_cover_image(proposed.cover_url)
+        if cover_image is None:
+            cover_skipped = True
+            logger.warning(
+                "enrich_apply: cover fetch failed for book %s from %s",
+                book_id,
+                proposed.cover_url,
+            )
+
+    write_result = apply_metadata_safely(
+        source, proposed, output_dir, cover_image=cover_image
+    )
     if not write_result.success or write_result.path is None:
         flash(
             f"Apply failed: {write_result.error or 'unknown error'}",
@@ -931,10 +953,15 @@ def enrich_apply(book_id):
     catalog.set_output_path(book_id, write_result.path)
     catalog.set_matched_at(book_id)
 
-    flash(
-        f'Applied "{proposed.title}" from {provider.name}',
-        "success",
-    )
+    # The rewritten copy is a new file (collision-resolved name) and, when a
+    # cover was embedded, different bytes. Drop the stale on-disk cover cache so
+    # the next GET /books/<id>/cover re-extracts from the new file.
+    invalidate_cover(get_library_root(), book_id)
+
+    message = f'Applied "{proposed.title}" from {provider.name}'
+    if cover_skipped:
+        message += " (cover could not be fetched and was skipped)"
+    flash(message, "success")
     response = make_response("", 200)
     response.headers["HX-Redirect"] = detail_url
     return response

--- a/tests/integration/test_enrich_cover_pipeline.py
+++ b/tests/integration/test_enrich_cover_pipeline.py
@@ -1,0 +1,59 @@
+# ABOUTME: Integration test for the enrich cover-apply path (issue #200).
+# ABOUTME: A candidate's fetched cover bytes end up embedded in the rewritten EPUB copy.
+
+from pathlib import Path
+
+from bookery.core.pipeline import apply_metadata_safely
+from bookery.formats.epub import extract_cover_bytes, read_epub_metadata
+from bookery.metadata.types import BookMetadata
+
+_FETCHED_JPEG = b"\xff\xd8\xff\xe0" + b"fetched-cover" * 16
+
+
+class TestApplyEmbedsCover:
+    """apply_metadata_safely writes the supplied cover into the non-destructive copy."""
+
+    def test_cover_bytes_land_in_rewritten_epub(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        original_bytes = sample_epub.read_bytes()
+        # The starting EPUB has no cover.
+        assert read_epub_metadata(sample_epub).cover_image is None
+
+        proposed = BookMetadata(title="Dune", authors=["Frank Herbert"])
+        output_dir = tmp_path / "output"
+
+        result = apply_metadata_safely(
+            sample_epub, proposed, output_dir, cover_image=_FETCHED_JPEG
+        )
+
+        assert result.success is True
+        assert result.path is not None
+
+        # The rewritten copy carries the cover bytes and re-reads cleanly.
+        re_read = read_epub_metadata(result.path)
+        assert re_read.title == "Dune"
+        assert re_read.cover_image == _FETCHED_JPEG
+
+        # The web cover route extracts via extract_cover_bytes — confirm it
+        # surfaces exactly the fetched bytes.
+        extracted = extract_cover_bytes(result.path)
+        assert extracted is not None
+        data, content_type = extracted
+        assert data == _FETCHED_JPEG
+        assert content_type == "image/jpeg"
+
+        # Non-destructive guarantee: the original source EPUB is untouched.
+        assert sample_epub.read_bytes() == original_bytes
+
+    def test_no_cover_bytes_leaves_copy_coverless(
+        self, sample_epub: Path, tmp_path: Path
+    ) -> None:
+        proposed = BookMetadata(title="Dune", authors=["Frank Herbert"])
+        output_dir = tmp_path / "output"
+
+        result = apply_metadata_safely(sample_epub, proposed, output_dir)
+
+        assert result.success is True
+        assert result.path is not None
+        assert read_epub_metadata(result.path).cover_image is None

--- a/tests/unit/test_cover_cache.py
+++ b/tests/unit/test_cover_cache.py
@@ -10,6 +10,7 @@ from bookery.web.covers import (
     PLACEHOLDER_CONTENT_TYPE,
     PLACEHOLDER_SVG,
     get_or_extract_cover,
+    invalidate_cover,
 )
 
 
@@ -148,3 +149,31 @@ class TestGetOrExtractCover:
         assert data.startswith(b"\x89PNG")
         # Cache extension matches the media type for browser-friendliness.
         assert (library_root / ".covers" / "99.png").exists()
+
+
+class TestInvalidateCover:
+    def test_removes_cached_entry(self, tmp_path: Path, epub_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        get_or_extract_cover(book_id=5, epub_path=epub_path, library_root=library_root)
+        cached = library_root / ".covers" / "5.jpg"
+        assert cached.exists()
+
+        invalidate_cover(library_root, 5)
+        assert not cached.exists()
+
+    def test_no_error_when_nothing_cached(self, tmp_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        # Should be a quiet no-op even with no .covers directory.
+        invalidate_cover(library_root, 123)
+
+    def test_only_removes_target_book(self, tmp_path: Path, epub_path: Path) -> None:
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        get_or_extract_cover(book_id=1, epub_path=epub_path, library_root=library_root)
+        get_or_extract_cover(book_id=2, epub_path=epub_path, library_root=library_root)
+
+        invalidate_cover(library_root, 1)
+        assert not (library_root / ".covers" / "1.jpg").exists()
+        assert (library_root / ".covers" / "2.jpg").exists()

--- a/tests/unit/test_cover_fetch.py
+++ b/tests/unit/test_cover_fetch.py
@@ -1,0 +1,68 @@
+# ABOUTME: Unit tests for the cover-image HTTP fetch helper used by enrich-apply.
+# ABOUTME: Verifies bytes are returned on success and None (non-fatal) on every failure mode.
+
+import httpx
+
+from bookery.core.coverfetch import fetch_cover_image
+
+
+class _Transport(httpx.BaseTransport):
+    """Canned-response transport for the cover fetch helper."""
+
+    def __init__(
+        self,
+        response: httpx.Response | None = None,
+        *,
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self._response = response
+        self._raise_exc = raise_exc
+        self.requested_urls: list[str] = []
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.requested_urls.append(str(request.url))
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        assert self._response is not None
+        return self._response
+
+
+_JPEG = b"\xff\xd8\xff\xe0" + b"jpeg-cover-bytes" * 4
+
+
+class TestFetchCoverImage:
+    def test_returns_bytes_on_200_image(self) -> None:
+        transport = _Transport(
+            httpx.Response(200, content=_JPEG, headers={"Content-Type": "image/jpeg"})
+        )
+        data = fetch_cover_image("https://example/cover.jpg", transport=transport)
+        assert data == _JPEG
+        assert transport.requested_urls == ["https://example/cover.jpg"]
+
+    def test_returns_none_on_non_200(self) -> None:
+        transport = _Transport(httpx.Response(404, content=b"missing"))
+        assert fetch_cover_image("https://example/cover.jpg", transport=transport) is None
+
+    def test_returns_none_on_non_image_content_type(self) -> None:
+        transport = _Transport(
+            httpx.Response(
+                200, content=b"<html>nope</html>", headers={"Content-Type": "text/html"}
+            )
+        )
+        assert fetch_cover_image("https://example/cover.jpg", transport=transport) is None
+
+    def test_returns_none_on_empty_body(self) -> None:
+        transport = _Transport(
+            httpx.Response(200, content=b"", headers={"Content-Type": "image/jpeg"})
+        )
+        assert fetch_cover_image("https://example/cover.jpg", transport=transport) is None
+
+    def test_returns_none_on_network_error(self) -> None:
+        transport = _Transport(raise_exc=httpx.ConnectError("boom"))
+        assert fetch_cover_image("https://example/cover.jpg", transport=transport) is None
+
+    def test_returns_none_on_blank_url(self) -> None:
+        # No network call should be attempted for an empty URL.
+        transport = _Transport()
+        assert fetch_cover_image("", transport=transport) is None
+        assert transport.requested_urls == []

--- a/tests/unit/test_epub_writer.py
+++ b/tests/unit/test_epub_writer.py
@@ -202,3 +202,48 @@ class TestWriteEpubMetadata:
         assert re_read.authors == ["Umberto Eco"]
         assert re_read.publisher == "Harcourt"
         assert re_read.description == "A mystery set in a medieval monastery."
+
+
+_JPEG_COVER = b"\xff\xd8\xff\xe0" + b"new-cover-bytes" * 8
+_PNG_COVER = b"\x89PNG\r\n\x1a\n" + b"png-cover-bytes" * 8
+
+
+class TestWriteEpubCover:
+    """Tests for embedding a cover image during the metadata write."""
+
+    def test_embeds_cover_when_book_has_none(self, sample_epub: Path) -> None:
+        """A book imported without a cover gets the candidate's cover embedded."""
+        # sample_epub has no cover image to start.
+        assert read_epub_metadata(sample_epub).cover_image is None
+
+        updated = BookMetadata(title="With Cover", cover_image=_JPEG_COVER)
+        write_epub_metadata(sample_epub, updated)
+
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.cover_image == _JPEG_COVER
+
+    def test_replaces_existing_cover(self, sample_epub: Path) -> None:
+        """Writing a cover onto a book that already has one swaps the bytes."""
+        write_epub_metadata(sample_epub, BookMetadata(title="First", cover_image=_JPEG_COVER))
+        assert read_epub_metadata(sample_epub).cover_image == _JPEG_COVER
+
+        write_epub_metadata(sample_epub, BookMetadata(title="Second", cover_image=_PNG_COVER))
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.cover_image == _PNG_COVER
+
+    def test_no_cover_bytes_leaves_book_coverless(self, sample_epub: Path) -> None:
+        """Omitting cover bytes preserves the prior (cover-less) state."""
+        updated = BookMetadata(title="No Cover", cover_image=None)
+        write_epub_metadata(sample_epub, updated)
+
+        re_read = read_epub_metadata(sample_epub)
+        assert re_read.cover_image is None
+
+    def test_rewritten_epub_opens_cleanly(self, sample_epub: Path) -> None:
+        """The cover-rewritten EPUB re-reads without error (opens in a reader)."""
+        write_epub_metadata(sample_epub, BookMetadata(title="Readable", cover_image=_JPEG_COVER))
+
+        # read_epub_metadata raises EpubReadError on a structurally broken file.
+        meta = read_epub_metadata(sample_epub)
+        assert meta.title == "Readable"
+        assert meta.cover_image == _JPEG_COVER

--- a/tests/web/test_book_cover.py
+++ b/tests/web/test_book_cover.py
@@ -123,6 +123,82 @@ class TestCoverRoute:
         assert response.content_type.startswith("image/jpeg")
 
 
+def _epub_without_cover(path: Path) -> Path:
+    book = epub.EpubBook()
+    book.set_identifier("no-cover-fixture")
+    book.set_title("No Cover Fixture")
+    book.set_language("en")
+    book.add_author("Test Author")
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap01.xhtml", lang="en")
+    chapter.content = b"<html><body><p>x</p></body></html>"
+    book.add_item(chapter)
+    book.toc = [epub.Link("chap01.xhtml", "Chapter 1", "chap01")]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+    epub.write_epub(str(path), book)
+    return path
+
+
+class TestEnrichAppliedCoverServedEndToEnd:
+    """End-to-end: applying a candidate cover makes /cover serve the new bytes.
+
+    Uses the real apply_metadata_safely write (only the network fetch is
+    mocked) so the cover route picks up the embedded cover from the rewritten
+    EPUB on the next request — verifying cache invalidation closes the loop.
+    """
+
+    def test_cover_route_serves_applied_cover(
+        self, mock_catalog, client, library_root: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        from tests.web.conftest import make_candidate
+
+        # A cover-less book living inside the library root.
+        epub_path = _epub_without_cover(library_root / "book.epub")
+        book = make_book(1, source_path=epub_path, output_path=epub_path)
+        mock_catalog.get_by_id.return_value = book
+
+        # Before apply: the cover route serves the placeholder SVG.
+        before = client.get("/books/1/cover")
+        assert before.content_type.startswith("image/svg+xml")
+
+        fetched_jpeg = b"\xff\xd8\xff\xe0" + b"applied-cover" * 16
+        candidate = make_candidate(
+            title="Dune", authors=["Frank Herbert"], source="Open Library", source_id="OL:1"
+        )
+        candidate.metadata.cover_url = "https://example/cover.jpg"
+
+        provider = type("P", (), {"name": "Open Library"})()
+        with (
+            patch("bookery.web.routes.fetch_cover_image", return_value=fetched_jpeg),
+            patch("bookery.web.routes._find_provider_by_name", return_value=provider),
+            patch("bookery.web.routes._refetch_candidate", return_value=[candidate]),
+        ):
+            apply_response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        assert apply_response.headers.get("HX-Redirect") == "/books/1"
+
+        # The real write produced a new file; point the catalog at it so the
+        # cover route reads the rewritten copy (mirrors set_output_path).
+        written_path = mock_catalog.set_output_path.call_args.args[1]
+        book.output_path = written_path
+        mock_catalog.get_by_id.return_value = book
+
+        after = client.get("/books/1/cover")
+        assert after.status_code == 200
+        assert after.content_type.startswith("image/jpeg")
+        assert after.data == fetched_jpeg
+
+
 class TestListThumbnail:
     def test_list_renders_lazy_loading_thumbnail_per_book(self, mock_catalog, client) -> None:
         mock_catalog.browse.return_value = (

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -974,3 +974,157 @@ class TestEnrichDiffSkipClearRendering:
         assert "diff-clear" in html
         # User-visible note explaining the skipped clear.
         assert "current kept" in html.lower()
+
+
+# --- cover fetch + embed on apply (issue #200) ------------------------------
+
+
+_COVER_JPEG = b"\xff\xd8\xff\xe0" + b"candidate-cover" * 8
+
+
+class TestEnrichApplyCover:
+    """Apply fetches the candidate cover and embeds it; failures are non-fatal."""
+
+    def _candidate_with_cover(self, cover_url: str | None) -> MetadataCandidate:
+        return MetadataCandidate(
+            metadata=BookMetadata(
+                title="Dune",
+                authors=["Frank Herbert"],
+                isbn="9780441172719",
+                cover_url=cover_url,
+            ),
+            confidence=0.9,
+            source="Open Library",
+            source_id="OL:1",
+        )
+
+    def test_fetched_cover_passed_to_write_helper(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        open_library.by_isbn = [self._candidate_with_cover("https://example/cover.jpg")]
+        dest = tmp_path / "out.epub"
+
+        with (
+            patch("bookery.web.routes.apply_metadata_safely") as mock_apply,
+            patch("bookery.web.routes.fetch_cover_image", return_value=_COVER_JPEG) as mock_fetch,
+            patch("bookery.web.routes.invalidate_cover") as mock_invalidate,
+        ):
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        mock_fetch.assert_called_once_with("https://example/cover.jpg")
+        # Cover bytes flow into apply_metadata_safely as the cover_image kwarg.
+        _, kwargs = mock_apply.call_args
+        assert kwargs.get("cover_image") == _COVER_JPEG
+        # Cache invalidated so the next /cover request re-extracts the new file.
+        mock_invalidate.assert_called_once()
+
+    def test_no_cover_url_skips_fetch(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        open_library.by_isbn = [self._candidate_with_cover(None)]
+        dest = tmp_path / "out.epub"
+
+        with (
+            patch("bookery.web.routes.apply_metadata_safely") as mock_apply,
+            patch("bookery.web.routes.fetch_cover_image") as mock_fetch,
+            patch("bookery.web.routes.invalidate_cover"),
+        ):
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # No cover_url → no network fetch, no cover_image passed through.
+        mock_fetch.assert_not_called()
+        _, kwargs = mock_apply.call_args
+        assert kwargs.get("cover_image") is None
+
+    def test_cover_fetch_failure_is_non_fatal_and_flashed(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", source_path=source)
+        open_library.by_isbn = [self._candidate_with_cover("https://example/cover.jpg")]
+        dest = tmp_path / "out.epub"
+
+        with (
+            patch("bookery.web.routes.apply_metadata_safely") as mock_apply,
+            patch("bookery.web.routes.fetch_cover_image", return_value=None),
+            patch("bookery.web.routes.invalidate_cover"),
+        ):
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        # Text apply still proceeds: write called with no cover, catalog updated.
+        mock_apply.assert_called_once()
+        _, kwargs = mock_apply.call_args
+        assert kwargs.get("cover_image") is None
+        mock_catalog.update_book.assert_called_once()
+        assert response.headers.get("HX-Redirect") == "/books/1"
+
+        # A flash surfaces the skipped cover non-fatally (success category).
+        with client.session_transaction() as session:
+            flashes = session.get("_flashes", [])
+        categories = [c for c, _ in flashes]
+        messages = [m for _, m in flashes]
+        assert "success" in categories
+        assert any("cover" in m.lower() for m in messages)
+        # The apply itself is not reported as a failure.
+        assert "error" not in categories
+
+    def test_successful_cover_flash_does_not_warn(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune", source_path=source)
+        open_library.by_isbn = [self._candidate_with_cover("https://example/cover.jpg")]
+        dest = tmp_path / "out.epub"
+
+        with (
+            patch("bookery.web.routes.apply_metadata_safely") as mock_apply,
+            patch("bookery.web.routes.fetch_cover_image", return_value=_COVER_JPEG),
+            patch("bookery.web.routes.invalidate_cover"),
+        ):
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                },
+            )
+
+        with client.session_transaction() as session:
+            flashes = session.get("_flashes", [])
+        messages = [m for _, m in flashes]
+        # Happy path flash should not mention a skipped cover.
+        assert not any("skip" in m.lower() for m in messages)


### PR DESCRIPTION
## Summary

Closes #200.

When a candidate is applied via the web Enrich flow, its cover image is now fetched and embedded into the non-destructive EPUB copy in the **same write** as the text fields. Previously the apply path mirrored text fields only, so a cover-less book stayed cover-less through enrichment.

- **`core/coverfetch.py`** (new) — `fetch_cover_image(url)` downloads cover bytes; returns `None` on any failure (blank URL, network error, non-200, non-image content-type, empty body). Network I/O is fully mockable via an injectable transport.
- **`formats/epub.py`** — `write_epub_metadata` now embeds `metadata.cover_image` when present. The cover write is idempotent: any existing cover item + `<meta name="cover">` tags are removed first, then `set_cover(..., create_page=False)`. `create_page=False` avoids an ebooklib crash where the generated cover XHTML page serializes an empty document for books read from disk (the `"cover"` template is absent).
- **`core/pipeline.apply_metadata_safely`** — gains an optional `cover_image` kwarg so callers can fetch a cover lazily and pass it through without mutating the candidate's metadata.
- **`web/covers.invalidate_cover`** (new) — drops the stale on-disk cover cache (`.covers/<id>.<ext>`) after a write so the next `GET /books/<id>/cover` re-extracts from the rewritten file.
- **`web/routes.enrich_apply`** — fetch cover → pass to write → invalidate cache → flash. A fetch failure is non-fatal: text metadata still applies, a warning is logged, and the success flash notes the cover was skipped.

The Google Books provider already populated `cover_url` (largest available `imageLinks` variant via `_pick_cover`); this PR closes the apply-side gap. Open Library cover population is out of scope per the issue.

The catalog stores the post-write file location via `set_output_path`; the cover route reads `output_path` directly, so the file-hash change after a cover write does not affect cover serving.

## Test plan

- [x] `uv run pytest` — full suite green (2024 passed)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright src/` — clean (also enforced by pre-commit hook)
- [x] **Unit:** `fetch_cover_image` returns bytes on a 200 image and `None` on every failure mode (`tests/unit/test_cover_fetch.py`)
- [x] **Unit:** `write_epub_metadata` embeds / replaces a cover and the rewritten EPUB re-reads cleanly (`tests/unit/test_epub_writer.py::TestWriteEpubCover`)
- [x] **Unit:** `invalidate_cover` drops only the target book's cache (`tests/unit/test_cover_cache.py::TestInvalidateCover`)
- [x] **Integration:** a candidate's fetched cover bytes land in the rewritten copy and surface via `extract_cover_bytes`; original source untouched (`tests/integration/test_enrich_cover_pipeline.py`)
- [x] **Web:** enrich-apply passes fetched bytes to the write helper, skips fetch when no `cover_url`, and flashes a non-fatal note on fetch failure while still applying text metadata (`tests/web/test_enrich_apply.py::TestEnrichApplyCover`)
- [x] **Web (end-to-end via test client):** apply a candidate with a cover (real write, only the network fetch mocked), then `GET /books/<id>/cover` serves the newly embedded JPEG — proving cache invalidation closes the loop (`tests/web/test_book_cover.py::TestEnrichAppliedCoverServedEndToEnd`)

> Note: the web behavior was verified through Flask's test client (rendered output, flash messages, the cover route bytes). A human should still eyeball the actual rendered cover in a browser.