### PR TITLE
Add #230: show cover comparison in enrich apply-candidate diff

### DIFF
--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -634,6 +634,16 @@ header .logo {
     background: #f0f0f0;
 }
 
+/* Cover thumbnails in the enrich apply-candidate diff (current vs proposed). */
+.enrich-diff-cover {
+    display: block;
+    width: 80px;
+    height: 120px;
+    object-fit: cover;
+    border: 1px solid var(--color-border);
+    background: #f0f0f0;
+}
+
 /* Hero cover floats to the left of the title block. The section-header
    selectors above target the title/byline siblings; the hero is a new
    sibling so the grid stays linear while the float pulls the image. */

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -22,11 +22,37 @@
             {% for diff in diffs %}
                 {% include "_field_diff_row.html" %}
             {% endfor %}
+            {# Cover is an image, not a text field, so it gets a dedicated row
+               rather than going through metadata_diff / _field_diff_row.html. #}
+            <tr class="diff-row {{ 'diff-changed' if candidate.metadata.cover_url else 'diff-unchanged' }}">
+                <th scope="row" class="diff-field">Cover</th>
+                <td class="diff-current{{ ' changed' if candidate.metadata.cover_url else '' }}">
+                    <img class="enrich-diff-cover"
+                         src="{{ url_for('web.book_cover', book_id=book.id) }}"
+                         alt="Current cover"
+                         width="80"
+                         height="120">
+                </td>
+                {% if candidate.metadata.cover_url %}
+                <td class="diff-proposed changed">
+                    <img class="enrich-diff-cover"
+                         src="{{ candidate.metadata.cover_url }}"
+                         alt="Proposed cover"
+                         width="80"
+                         height="120"
+                         loading="lazy">
+                </td>
+                {% else %}
+                <td class="diff-proposed muted"><span class="diff-same">same</span></td>
+                {% endif %}
+            </tr>
         </tbody>
     </table>
 
-    {# Apply only writes fields that actually change AND aren't a skipped clear. #}
-    {% set write_count = diffs|selectattr('changed')|rejectattr('skip_clear')|list|length %}
+    {# Apply only writes fields that actually change AND aren't a skipped clear.
+       The cover counts as one change whenever the candidate supplied one. #}
+    {% set write_count = (diffs|selectattr('changed')|rejectattr('skip_clear')|list|length)
+                         + (1 if candidate.metadata.cover_url else 0) %}
     {% set skip_clear_count = diffs|selectattr('skip_clear')|list|length %}
 
     <div class="enrich-diff-actions" role="group" aria-label="Diff actions">

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -53,6 +53,7 @@ def make_candidate(
     confidence: float = 0.5,
     source: str = "fake",
     source_id: str = "fake:1",
+    cover_url: str | None = None,
 ) -> MetadataCandidate:
     """Build a MetadataCandidate for web tests."""
     return MetadataCandidate(
@@ -62,6 +63,7 @@ def make_candidate(
             isbn=isbn,
             publisher=publisher,
             published_date=published_date,
+            cover_url=cover_url,
         ),
         confidence=confidence,
         source=source,

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -276,6 +276,66 @@ class TestEnrichCandidateGet:
         # Back-to-results re-runs the search panel.
         assert "Back to results" in html
 
+    def test_candidate_with_cover_url_shows_proposed_cover(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+        cover = "https://covers.example.com/dune-large.jpg"
+        open_library.by_isbn = [
+            make_candidate(
+                title="Dune",
+                source="Open Library",
+                source_id="OL:1",
+                cover_url=cover,
+            ),
+        ]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "isbn": "9780441172719",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        # Cover row exists and previews the candidate's proposed cover, alongside
+        # the current cover served by the existing /cover route.
+        assert "Cover" in html
+        assert cover in html
+        assert "/books/1/cover" in html
+        assert "Proposed cover" in html
+
+    def test_candidate_without_cover_shows_no_proposed_image(
+        self, mock_catalog, client, open_library
+    ):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune")
+        open_library.by_isbn = [
+            make_candidate(
+                title="Dune",
+                source="Open Library",
+                source_id="OL:1",
+                cover_url=None,
+            ),
+        ]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "isbn": "9780441172719",
+                "candidate_id": "OL:1",
+            },
+        )
+
+        html = response.data.decode()
+        # The Cover row still shows the current cover, but there is no proposed
+        # cover image when the candidate carries no cover_url.
+        assert "Cover" in html
+        assert "/books/1/cover" in html
+        assert "Proposed cover" not in html
+
 
 # --- POST /books/<id>/enrich/apply ------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to #200 (PR #229). After that PR, an enriched cover only became visible on the detail page *after* applying — the apply-candidate diff (`_enrich_diff.html`) compared text fields only, so you couldn't see the cover you were about to write.

This adds a **Cover** row to the Current-vs-Proposed diff table:

- **Current**: the book's current cover via the existing `GET /books/<id>/cover` route (placeholder when none).
- **Proposed**: the candidate's `cover_url` rendered as a thumbnail (already https-upgraded by the Google Books provider). When the candidate has no cover, the row shows the same "same" treatment as unchanged text fields — no broken `<img>`.
- The Apply button's "(N changes)" count now includes the cover when one is present.

Template-only change on the rendering side — `_enrich_diff.html` already receives both `book` and `candidate`, so no new route was needed. The proposed thumbnail loads directly from `cover_url` (browser → provider CDN); acceptable for a self-hosted preview and avoids a server-side fetch/proxy with SSRF surface.

Closes #230.

## Test plan

- [x] `uv run pytest` — 2026 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Web test: candidate with `cover_url` renders the proposed cover img + current cover route
- [x] Web test: candidate without `cover_url` renders no proposed img (no broken image)
- [ ] **Human visual check**: enrich a cover-less book, confirm the Cover row shows current placeholder + proposed thumbnail side by side, and that the proposed image actually loads (I verified the HTML via the Flask test client but could not eyeball the rendered thumbnails)