### PR TITLE
Fix #234: carry chosen enrich candidate forward into Apply

### DIFF
--- a/src/bookery/web/candidate_payload.py
+++ b/src/bookery/web/candidate_payload.py
@@ -1,0 +1,63 @@
+# ABOUTME: Serialize an enrich MetadataCandidate to/from a hidden Apply-form field.
+# ABOUTME: Lets Apply write exactly what View previewed without re-querying the provider (#234).
+
+import json
+from dataclasses import asdict
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+
+# BookMetadata fields that can't survive a JSON round-trip and aren't needed to
+# reconstruct the candidate at apply time: cover_image is re-fetched from
+# cover_url, and source_path is a Path describing the original (irrelevant here).
+_NON_SERIALIZABLE_FIELDS = ("cover_image", "source_path")
+
+
+def serialize_candidate(candidate: MetadataCandidate) -> str:
+    """Render a candidate as a compact JSON string for a hidden form field.
+
+    The metadata is taken verbatim from the candidate (minus byte/Path fields)
+    so the value Apply writes is exactly the one the diff previewed.
+    """
+    metadata = asdict(candidate.metadata)
+    for field_name in _NON_SERIALIZABLE_FIELDS:
+        metadata.pop(field_name, None)
+    return json.dumps(
+        {
+            "confidence": candidate.confidence,
+            "source": candidate.source,
+            "source_id": candidate.source_id,
+            "metadata": metadata,
+        }
+    )
+
+
+def deserialize_candidate(payload: str) -> MetadataCandidate | None:
+    """Rebuild a candidate from a form payload, or ``None`` on any bad input.
+
+    Apply must never 500 on a missing, malformed, or tampered payload — it
+    falls back to the re-fetch path instead. Every failure mode (invalid JSON,
+    wrong shape, missing required ``title``, unknown metadata keys, out-of-range
+    confidence) is funneled to ``None``.
+    """
+    if not payload:
+        return None
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    metadata_dict = data.get("metadata")
+    if not isinstance(metadata_dict, dict):
+        return None
+    try:
+        metadata = BookMetadata(**metadata_dict)
+        return MetadataCandidate(
+            metadata=metadata,
+            confidence=data["confidence"],
+            source=data["source"],
+            source_id=data["source_id"],
+        )
+    except (TypeError, ValueError, KeyError):
+        return None

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -798,9 +798,7 @@ def enrich_candidate(book_id):
     provider = _find_provider_by_name(provider_name)
     candidate = None
     if provider is not None:
-        candidates = _refetch_candidate(
-            provider, isbn=isbn, url=url, title=title, author=author
-        )
+        candidates = _refetch_candidate(provider, isbn=isbn, url=url, title=title, author=author)
         candidate = _find_candidate(candidates, candidate_id)
 
     if candidate is None:
@@ -914,8 +912,7 @@ def enrich_apply(book_id):
         # selection. Don't 404 a confirmed Apply — flash and bounce back to the
         # detail page so the user can retry from a clean state (#234).
         flash(
-            "Could not apply: the selected candidate is no longer available — "
-            "search again.",
+            "Could not apply: the selected candidate is no longer available — search again.",
             "error",
         )
         response = make_response("", 200)

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -29,6 +29,7 @@ from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.provider import MetadataProvider
 from bookery.util.text import strip_html
 from bookery.web.browse import BrowsePage, from_request_args
+from bookery.web.candidate_payload import deserialize_candidate, serialize_candidate
 from bookery.web.covers import get_or_extract_cover, invalidate_cover
 from bookery.web.diff import metadata_diff
 
@@ -768,13 +769,18 @@ def enrich_candidate(book_id):
     """Render the field-by-field diff panel for a chosen candidate.
 
     Re-fetches the candidate from its provider using the original query so
-    no per-session state is required. The diff panel includes an Apply form
-    that POSTs back to ``enrich_apply`` with the same dispatch params.
+    no per-session state is required. The chosen candidate is serialized into
+    the Apply form (issue #234) so Apply writes exactly what was previewed
+    without re-querying the provider.
 
     htmx GET (``HX-Request`` header set) returns the bare partial for an
     in-place swap into ``#book-content``. A plain GET — direct nav, browser
     refresh, shared link — returns the full styled page so the user lands
     on a real URL rather than an unstyled fragment.
+
+    If the provider is unreachable or the candidate has drifted out of its
+    result set, render a recoverable inline message rather than a bare 404 so
+    the user's other results remain reachable (issue #234).
     """
     catalog = current_app.config["CATALOG"]
     book = catalog.get_by_id(book_id)
@@ -787,20 +793,29 @@ def enrich_candidate(book_id):
     title = request.args.get("title", "")
     author = request.args.get("author", "")
     candidate_id = request.args.get("candidate_id", "")
+    return_to = _safe_return_to(request.args.get("return_to"))
 
     provider = _find_provider_by_name(provider_name)
-    if provider is None:
-        abort(404)
+    candidate = None
+    if provider is not None:
+        candidates = _refetch_candidate(
+            provider, isbn=isbn, url=url, title=title, author=author
+        )
+        candidate = _find_candidate(candidates, candidate_id)
 
-    candidates = _refetch_candidate(
-        provider, isbn=isbn, url=url, title=title, author=author
-    )
-    candidate = _find_candidate(candidates, candidate_id)
     if candidate is None:
-        abort(404)
+        return _render_enrich_candidate_error(
+            book,
+            provider_name=provider_name,
+            isbn=isbn,
+            url=url,
+            title=title,
+            author=author,
+            candidate_id=candidate_id,
+            return_to=return_to,
+        )
 
     diffs = metadata_diff(book.metadata, candidate.metadata)
-    return_to = _safe_return_to(request.args.get("return_to"))
 
     template = (
         "_enrich_diff.html" if request.headers.get("HX-Request") else "enrich_candidate.html"
@@ -816,8 +831,41 @@ def enrich_candidate(book_id):
         dispatch_title=title,
         dispatch_author=author,
         candidate_id=candidate_id,
+        candidate_payload=serialize_candidate(candidate),
         return_to=return_to,
     )
+
+
+def _render_enrich_candidate_error(
+    book,
+    *,
+    provider_name: str,
+    isbn: str,
+    url: str,
+    title: str,
+    author: str,
+    candidate_id: str,
+    return_to: str | None,
+):
+    """Render a recoverable "couldn't load this candidate" panel (issue #234).
+
+    htmx requests get the bare fragment for an in-place swap; a plain GET gets
+    the full styled page so direct nav/refresh lands on a real URL. Both offer
+    Try again / Back to results so the selection is never a dead end.
+    """
+    context = {
+        "book": book,
+        "provider_name": provider_name,
+        "dispatch_isbn": isbn,
+        "dispatch_url": url,
+        "dispatch_title": title,
+        "dispatch_author": author,
+        "candidate_id": candidate_id,
+        "return_to": return_to,
+    }
+    if request.headers.get("HX-Request"):
+        return render_template("_enrich_candidate_error.html", **context)
+    return render_template("enrich_candidate.html", load_error=True, **context)
 
 
 @bp.route("/books/<int:book_id>/enrich/apply", methods=["POST"])
@@ -839,6 +887,8 @@ def enrich_apply(book_id):
     if book is None:
         abort(404)
 
+    detail_url = url_for("web.book_detail", book_id=book_id)
+
     provider_name = request.form.get("provider", "")
     isbn = request.form.get("isbn", "")
     url = request.form.get("url", "")
@@ -846,18 +896,31 @@ def enrich_apply(book_id):
     author = request.form.get("author", "")
     candidate_id = request.form.get("candidate_id", "")
 
-    provider = _find_provider_by_name(provider_name)
-    if provider is None:
-        abort(404)
-
-    candidates = _refetch_candidate(
-        provider, isbn=isbn, url=url, title=title, author=author
-    )
-    candidate = _find_candidate(candidates, candidate_id)
+    # Prefer the candidate the user previewed, carried verbatim in the form, so
+    # Apply writes exactly what the diff showed without a provider round-trip
+    # (#234). A missing/malformed/tampered payload falls back to re-fetching by
+    # dispatch slot — the original stateless path — so older clients still work.
+    candidate = deserialize_candidate(request.form.get("candidate_payload", ""))
     if candidate is None:
-        abort(404)
+        provider = _find_provider_by_name(provider_name)
+        if provider is not None:
+            candidates = _refetch_candidate(
+                provider, isbn=isbn, url=url, title=title, author=author
+            )
+            candidate = _find_candidate(candidates, candidate_id)
 
-    detail_url = url_for("web.book_detail", book_id=book_id)
+    if candidate is None:
+        # Neither the carried payload nor a re-fetch could recover the
+        # selection. Don't 404 a confirmed Apply — flash and bounce back to the
+        # detail page so the user can retry from a clean state (#234).
+        flash(
+            "Could not apply: the selected candidate is no longer available — "
+            "search again.",
+            "error",
+        )
+        response = make_response("", 200)
+        response.headers["HX-Redirect"] = detail_url
+        return response
 
     # The library copy is the canonical file post-import. The original
     # source_path may no longer exist (e.g. user emptied Calibre's trash
@@ -942,11 +1005,12 @@ def enrich_apply(book_id):
     if _should_write_scalar(current.series_index, proposed.series_index):
         update_fields["series_index"] = proposed.series_index
 
-    # Always credit provenance to the matched provider's canonical name
-    # rather than echoing the user-supplied form value verbatim.
+    # Credit provenance to the candidate's source — the provider's canonical
+    # name captured when the candidate was built at View time, carried in the
+    # payload (or recovered via the fallback re-fetch).
     catalog.update_book(
         book_id,
-        source=provider.name,
+        source=candidate.source,
         confidence=candidate.confidence,
         **update_fields,
     )
@@ -958,7 +1022,7 @@ def enrich_apply(book_id):
     # the next GET /books/<id>/cover re-extracts from the new file.
     invalidate_cover(get_library_root(), book_id)
 
-    message = f'Applied "{proposed.title}" from {provider.name}'
+    message = f'Applied "{proposed.title}" from {candidate.source}'
     if cover_skipped:
         message += " (cover could not be fetched and was skipped)"
     flash(message, "success")

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 
 from flask import (
     Blueprint,
+    Response,
     abort,
     current_app,
     flash,
@@ -764,6 +765,18 @@ def delete_book(book_id):
     return response
 
 
+def _hx_redirect(target_url: str) -> Response:
+    """Empty 200 carrying an ``HX-Redirect`` so the htmx client navigates the browser.
+
+    Several enrich-apply exits (success and the various recoverable failures)
+    all need the same "do nothing in-place, send the browser to ``target_url``"
+    shape; this keeps that response in one spot.
+    """
+    response = make_response("", 200)
+    response.headers["HX-Redirect"] = target_url
+    return response
+
+
 @bp.route("/books/<int:book_id>/enrich/candidate", methods=["GET"])
 def enrich_candidate(book_id):
     """Render the field-by-field diff panel for a chosen candidate.
@@ -915,9 +928,7 @@ def enrich_apply(book_id):
             "Could not apply: the selected candidate is no longer available — search again.",
             "error",
         )
-        response = make_response("", 200)
-        response.headers["HX-Redirect"] = detail_url
-        return response
+        return _hx_redirect(detail_url)
 
     # The library copy is the canonical file post-import. The original
     # source_path may no longer exist (e.g. user emptied Calibre's trash
@@ -933,9 +944,7 @@ def enrich_apply(book_id):
             f"(source={book.source_path}, library={book.output_path})",
             "error",
         )
-        response = make_response("", 200)
-        response.headers["HX-Redirect"] = detail_url
-        return response
+        return _hx_redirect(detail_url)
 
     # Prefer the existing library location of this book (its previous output
     # copy's parent) so multiple enrich passes don't scatter files across
@@ -967,9 +976,7 @@ def enrich_apply(book_id):
             f"Apply failed: {write_result.error or 'unknown error'}",
             "error",
         )
-        response = make_response("", 200)
-        response.headers["HX-Redirect"] = detail_url
-        return response
+        return _hx_redirect(detail_url)
 
     # Mirror the candidate's fields into the catalog with provenance credited
     # to the provider. We intentionally only write fields that the provider
@@ -1023,6 +1030,4 @@ def enrich_apply(book_id):
     if cover_skipped:
         message += " (cover could not be fetched and was skipped)"
     flash(message, "success")
-    response = make_response("", 200)
-    response.headers["HX-Redirect"] = detail_url
-    return response
+    return _hx_redirect(detail_url)

--- a/src/bookery/web/templates/_enrich_candidate_error.html
+++ b/src/bookery/web/templates/_enrich_candidate_error.html
@@ -1,0 +1,33 @@
+{# ABOUTME: Recoverable error panel for the apply-candidate flow when a candidate can't load. #}
+{# ABOUTME: Shown instead of a 404 when the provider is unreachable or the candidate drifted (#234). #}
+{% include "_book_subhead.html" %}
+<section class="enrich-candidate-error" aria-labelledby="enrich-candidate-error-heading">
+    <header class="enrich-diff-header">
+        <h3 id="enrich-candidate-error-heading">Couldn't load this candidate</h3>
+    </header>
+    <p class="enrich-candidate-error-message">
+        The provider may be temporarily unavailable, or this result changed since
+        you searched. Your other results are still here — try again or go back to
+        the list.
+    </p>
+
+    <div class="enrich-diff-actions" role="group" aria-label="Recovery actions">
+        <button type="button"
+                class="btn btn-secondary"
+                hx-get="{{ url_for('web.enrich_candidate', book_id=book.id, provider=provider_name, isbn=dispatch_isbn or none, url=dispatch_url or none, title=dispatch_title or none, author=dispatch_author or none, candidate_id=candidate_id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Try again</button>
+
+        <button type="button"
+                class="btn btn-secondary"
+                hx-get="{{ url_for('web.enrich_form', book_id=book.id, isbn=dispatch_isbn or none, title=dispatch_title or none, author=dispatch_author or none) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Back to results</button>
+
+        <button type="button"
+                class="btn btn-muted"
+                hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
+                hx-target="#book-content"
+                hx-swap="innerHTML">Cancel</button>
+    </div>
+</section>

--- a/src/bookery/web/templates/_enrich_diff.html
+++ b/src/bookery/web/templates/_enrich_diff.html
@@ -67,6 +67,10 @@
             <input type="hidden" name="title" value="{{ dispatch_title }}">
             <input type="hidden" name="author" value="{{ dispatch_author }}">
             <input type="hidden" name="candidate_id" value="{{ candidate_id }}">
+            {# Carry the previewed candidate so Apply writes exactly this without
+               re-querying the provider (#234); dispatch fields above back the
+               re-fetch fallback when this payload is absent. #}
+            <input type="hidden" name="candidate_payload" value="{{ candidate_payload }}">
             <button type="submit" class="btn btn-primary">
                 Apply{% if write_count %} ({{ write_count }} change{{ '' if write_count == 1 else 's' }}){% endif %}
             </button>

--- a/src/bookery/web/templates/enrich_candidate.html
+++ b/src/bookery/web/templates/enrich_candidate.html
@@ -11,7 +11,11 @@
     </nav>
 
     <div id="book-content" aria-live="polite">
-        {% include "_enrich_diff.html" %}
+        {% if load_error %}
+            {% include "_enrich_candidate_error.html" %}
+        {% else %}
+            {% include "_enrich_diff.html" %}
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/tests/web/test_candidate_payload.py
+++ b/tests/web/test_candidate_payload.py
@@ -82,15 +82,13 @@ class TestDeserializeFailsSafe:
 
     def test_missing_title_returns_none(self):
         payload = (
-            '{"confidence": 0.5, "source": "x", "source_id": "1", '
-            '"metadata": {"authors": ["A"]}}'
+            '{"confidence": 0.5, "source": "x", "source_id": "1", "metadata": {"authors": ["A"]}}'
         )
         assert deserialize_candidate(payload) is None
 
     def test_out_of_range_confidence_returns_none(self):
         payload = (
-            '{"confidence": 1.5, "source": "x", "source_id": "1", '
-            '"metadata": {"title": "T"}}'
+            '{"confidence": 1.5, "source": "x", "source_id": "1", "metadata": {"title": "T"}}'
         )
         assert deserialize_candidate(payload) is None
 

--- a/tests/web/test_candidate_payload.py
+++ b/tests/web/test_candidate_payload.py
@@ -1,0 +1,102 @@
+# ABOUTME: Unit tests for serializing an enrich candidate into/out of the Apply form.
+# ABOUTME: Covers round-trip fidelity, byte/Path field exclusion, and robust failure to None.
+
+from pathlib import Path
+
+from bookery.metadata.candidate import MetadataCandidate
+from bookery.metadata.types import BookMetadata
+from bookery.web.candidate_payload import deserialize_candidate, serialize_candidate
+
+
+def _candidate() -> MetadataCandidate:
+    return MetadataCandidate(
+        metadata=BookMetadata(
+            title="Dune",
+            authors=["Frank Herbert", "Brian Herbert"],
+            isbn="9780441172719",
+            publisher="Ace",
+            description="A desert planet epic.",
+            series="Dune",
+            series_index=1.0,
+            subjects=["Science Fiction", "Classic"],
+            identifiers={"google": "abc123", "isbn": "9780441172719"},
+            cover_url="https://example.test/cover.jpg",
+        ),
+        confidence=0.92,
+        source="Open Library",
+        source_id="OL:M/123",
+    )
+
+
+class TestRoundTrip:
+    def test_round_trip_preserves_fields(self):
+        restored = deserialize_candidate(serialize_candidate(_candidate()))
+
+        assert restored is not None
+        assert restored.confidence == 0.92
+        assert restored.source == "Open Library"
+        assert restored.source_id == "OL:M/123"
+        meta = restored.metadata
+        assert meta.title == "Dune"
+        assert meta.authors == ["Frank Herbert", "Brian Herbert"]
+        assert meta.isbn == "9780441172719"
+        assert meta.publisher == "Ace"
+        assert meta.description == "A desert planet epic."
+        assert meta.series == "Dune"
+        assert meta.series_index == 1.0
+        assert meta.subjects == ["Science Fiction", "Classic"]
+        assert meta.identifiers == {"google": "abc123", "isbn": "9780441172719"}
+        assert meta.cover_url == "https://example.test/cover.jpg"
+
+    def test_cover_image_bytes_are_dropped(self):
+        candidate = _candidate()
+        candidate.metadata.cover_image = b"\xff\xd8\xff binary jpeg bytes"
+
+        restored = deserialize_candidate(serialize_candidate(candidate))
+
+        assert restored is not None
+        # cover_image is re-fetched from cover_url at apply time, never carried.
+        assert restored.metadata.cover_image is None
+
+    def test_source_path_is_dropped(self):
+        candidate = _candidate()
+        candidate.metadata.source_path = Path("/library/dune.epub")
+
+        restored = deserialize_candidate(serialize_candidate(candidate))
+
+        assert restored is not None
+        assert restored.metadata.source_path is None
+
+
+class TestDeserializeFailsSafe:
+    def test_empty_string_returns_none(self):
+        assert deserialize_candidate("") is None
+
+    def test_non_json_returns_none(self):
+        assert deserialize_candidate("not json at all") is None
+
+    def test_wrong_shape_returns_none(self):
+        # Valid JSON but not the expected object shape.
+        assert deserialize_candidate("[1, 2, 3]") is None
+        assert deserialize_candidate('{"foo": "bar"}') is None
+
+    def test_missing_title_returns_none(self):
+        payload = (
+            '{"confidence": 0.5, "source": "x", "source_id": "1", '
+            '"metadata": {"authors": ["A"]}}'
+        )
+        assert deserialize_candidate(payload) is None
+
+    def test_out_of_range_confidence_returns_none(self):
+        payload = (
+            '{"confidence": 1.5, "source": "x", "source_id": "1", '
+            '"metadata": {"title": "T"}}'
+        )
+        assert deserialize_candidate(payload) is None
+
+    def test_unknown_metadata_key_returns_none(self):
+        payload = (
+            '{"confidence": 0.5, "source": "x", "source_id": "1", '
+            '"metadata": {"title": "T", "bogus_field": 1}}'
+        )
+        assert deserialize_candidate(payload) is None

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -17,9 +17,7 @@ from tests.web.conftest import FakeProvider, make_book, make_candidate
 
 def _extract_payload(html_text: str) -> str | None:
     """Pull the hidden candidate_payload value out of rendered Apply-form HTML."""
-    match = re.search(
-        r'name="candidate_payload"\s+value="([^"]*)"', html_text
-    )
+    match = re.search(r'name="candidate_payload"\s+value="([^"]*)"', html_text)
     return html.unescape(match.group(1)) if match else None
 
 

--- a/tests/web/test_enrich_apply.py
+++ b/tests/web/test_enrich_apply.py
@@ -1,6 +1,8 @@
 # ABOUTME: Tests for the apply-candidate enrichment flow — diff helper, GET, POST.
 # ABOUTME: Covers metadata_diff unit tests, candidate re-fetch, apply write + catalog updates.
 
+import html
+import re
 from unittest.mock import patch
 
 import pytest
@@ -8,8 +10,17 @@ import pytest
 from bookery.core.pipeline import WriteResult
 from bookery.metadata.candidate import MetadataCandidate
 from bookery.metadata.types import BookMetadata
+from bookery.web.candidate_payload import deserialize_candidate, serialize_candidate
 from bookery.web.diff import FieldDiff, metadata_diff
 from tests.web.conftest import FakeProvider, make_book, make_candidate
+
+
+def _extract_payload(html_text: str) -> str | None:
+    """Pull the hidden candidate_payload value out of rendered Apply-form HTML."""
+    match = re.search(
+        r'name="candidate_payload"\s+value="([^"]*)"', html_text
+    )
+    return html.unescape(match.group(1)) if match else None
 
 
 @pytest.fixture
@@ -200,6 +211,37 @@ class TestEnrichCandidateGet:
         # ISBN matches → "same" label rendered.
         assert "same" in html
 
+    def test_diff_embeds_carried_candidate_payload(self, mock_catalog, client, open_library):
+        mock_catalog.get_by_id.return_value = make_book(1, title="Dune Old")
+        candidate = make_candidate(
+            title="Dune",
+            authors=["Frank Herbert"],
+            isbn="9780441172719",
+            confidence=0.92,
+            source="Open Library",
+            source_id="OL:M/123",
+            cover_url="https://example.test/cover.jpg",
+        )
+        open_library.by_isbn = [candidate]
+
+        response = client.get(
+            "/books/1/enrich/candidate",
+            query_string={
+                "provider": "Open Library",
+                "isbn": "9780441172719",
+                "candidate_id": "OL:M/123",
+            },
+        )
+
+        html_text = response.data.decode()
+        payload = _extract_payload(html_text)
+        assert payload is not None, "Apply form must embed the candidate payload"
+        restored = deserialize_candidate(payload)
+        assert restored is not None
+        assert restored.metadata.title == "Dune"
+        assert restored.source_id == "OL:M/123"
+        assert restored.metadata.cover_url == "https://example.test/cover.jpg"
+
     def test_missing_book_returns_404(self, mock_catalog, client):
         mock_catalog.get_by_id.return_value = None
         response = client.get(
@@ -208,15 +250,20 @@ class TestEnrichCandidateGet:
         )
         assert response.status_code == 404
 
-    def test_unknown_provider_returns_404(self, mock_catalog, client):
+    def test_unknown_provider_renders_recovery(self, mock_catalog, client):
+        # An unknown/drifted provider must not 404 the selection — show a
+        # recoverable inline message instead (issue #234).
         mock_catalog.get_by_id.return_value = make_book(1)
         response = client.get(
             "/books/1/enrich/candidate",
             query_string={"provider": "Unknown", "title": "x", "candidate_id": "x"},
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        html_text = response.data.decode()
+        assert "Couldn't load this candidate" in html_text
+        assert "Back to results" in html_text
 
-    def test_candidate_id_not_found_returns_404(self, mock_catalog, client, open_library):
+    def test_candidate_id_not_found_renders_recovery(self, mock_catalog, client, open_library):
         mock_catalog.get_by_id.return_value = make_book(1)
         open_library.by_isbn = [
             make_candidate(source="Open Library", source_id="OL:1"),
@@ -230,7 +277,10 @@ class TestEnrichCandidateGet:
                 "candidate_id": "OL:does-not-exist",
             },
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        html_text = response.data.decode()
+        assert "Couldn't load this candidate" in html_text
+        assert "Back to results" in html_text
 
     def test_apply_button_carries_through_params(self, mock_catalog, client, open_library):
         mock_catalog.get_by_id.return_value = make_book(1)
@@ -639,32 +689,215 @@ class TestEnrichApplyPost:
         )
         assert response.status_code == 404
 
-    def test_unknown_provider_returns_404(self, mock_catalog, client, tmp_path):
+    def test_unknown_provider_recovers(self, mock_catalog, client, tmp_path):
+        # No carried payload + unknown provider → can't reconstruct the
+        # candidate. Recover gracefully (flash + redirect) instead of 404 (#234).
         source = tmp_path / "src.epub"
         source.write_bytes(b"epub")
         mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
-        response = client.post(
-            "/books/1/enrich/apply",
-            data={"provider": "Unknown", "title": "x", "candidate_id": "x"},
-        )
-        assert response.status_code == 404
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={"provider": "Unknown", "title": "x", "candidate_id": "x"},
+            )
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect") == "/books/1"
+        mock_apply.assert_not_called()
+        mock_catalog.update_book.assert_not_called()
 
-    def test_candidate_not_found_returns_404(self, mock_catalog, client, open_library, tmp_path):
+    def test_candidate_not_found_recovers(self, mock_catalog, client, open_library, tmp_path):
+        # No carried payload + provider result drifted → fallback finds nothing.
+        # Recover gracefully instead of 404 (#234).
         source = tmp_path / "src.epub"
         source.write_bytes(b"epub")
         mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
         open_library.by_isbn = [
             make_candidate(source="Open Library", source_id="OL:1"),
         ]
-        response = client.post(
-            "/books/1/enrich/apply",
-            data={
-                "provider": "Open Library",
-                "isbn": "9780441172719",
-                "candidate_id": "OL:missing",
-            },
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:missing",
+                },
+            )
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect") == "/books/1"
+        mock_apply.assert_not_called()
+        mock_catalog.update_book.assert_not_called()
+
+
+class TestEnrichApplyCarriedPayload:
+    """Apply writes the carried candidate without re-querying the provider (#234)."""
+
+    def test_carried_payload_skips_apply_time_provider_call(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        candidate = make_candidate(
+            title="Previewed Title",
+            authors=["Author"],
+            isbn="9780441172719",
+            source="Open Library",
+            source_id="OL:1",
         )
-        assert response.status_code == 404
+        # Provider returns nothing at apply time — the carried payload must not
+        # depend on it (this is the issue's observable success criterion).
+        open_library.by_isbn = []
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                    "candidate_payload": serialize_candidate(candidate),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_apply.assert_called_once()
+        args, _ = mock_apply.call_args
+        assert args[1].title == "Previewed Title"
+        # No provider round-trip of any kind happened.
+        assert open_library.isbn_calls == []
+        assert open_library.title_author_calls == []
+        assert open_library.url_calls == []
+
+    def test_carried_payload_credits_source_provenance(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        candidate = make_candidate(
+            title="New Title",
+            authors=["New Author"],
+            publisher="Acme",
+            source="Open Library",
+            source_id="OL:1",
+        )
+        open_library.by_isbn = []
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "candidate_payload": serialize_candidate(candidate),
+                },
+            )
+
+        mock_catalog.update_book.assert_called()
+        _, kwargs = mock_catalog.update_book.call_args
+        assert kwargs["title"] == "New Title"
+        assert kwargs["authors"] == ["New Author"]
+        assert kwargs["publisher"] == "Acme"
+        assert kwargs.get("source") == "Open Library"
+
+    def test_carried_payload_cover_fetched_without_provider(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        candidate = make_candidate(
+            title="Dune",
+            isbn="9780441172719",
+            source="Open Library",
+            source_id="OL:1",
+            cover_url="https://example.test/cover.jpg",
+        )
+        open_library.by_isbn = []  # provider fully unreachable at apply
+        dest = tmp_path / "out.epub"
+
+        with (
+            patch("bookery.web.routes.apply_metadata_safely") as mock_apply,
+            patch(
+                "bookery.web.routes.fetch_cover_image", return_value=_COVER_JPEG
+            ) as mock_fetch,
+            patch("bookery.web.routes.invalidate_cover"),
+        ):
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "candidate_payload": serialize_candidate(candidate),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_fetch.assert_called_once_with("https://example.test/cover.jpg")
+        _, kwargs = mock_apply.call_args
+        assert kwargs.get("cover_image") == _COVER_JPEG
+        assert open_library.isbn_calls == []
+
+    def test_malformed_payload_with_empty_provider_recovers(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        open_library.by_isbn = []  # fallback re-fetch yields nothing too
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                    "candidate_payload": "not-valid-json{",
+                },
+            )
+
+        # Malformed payload must not 500; it falls back, finds nothing, recovers.
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect") == "/books/1"
+        mock_apply.assert_not_called()
+        mock_catalog.update_book.assert_not_called()
+
+    def test_malformed_payload_falls_back_to_provider(
+        self, mock_catalog, client, open_library, tmp_path
+    ):
+        # A malformed payload with a still-reachable provider must recover the
+        # candidate via the fallback re-fetch path rather than failing.
+        source = tmp_path / "src.epub"
+        source.write_bytes(b"epub")
+        mock_catalog.get_by_id.return_value = make_book(1, source_path=source)
+        open_library.by_isbn = [
+            make_candidate(title="Recovered", source="Open Library", source_id="OL:1"),
+        ]
+        dest = tmp_path / "out.epub"
+
+        with patch("bookery.web.routes.apply_metadata_safely") as mock_apply:
+            mock_apply.return_value = WriteResult(path=dest, success=True)
+            response = client.post(
+                "/books/1/enrich/apply",
+                data={
+                    "provider": "Open Library",
+                    "isbn": "9780441172719",
+                    "candidate_id": "OL:1",
+                    "candidate_payload": "garbage",
+                },
+            )
+
+        assert response.status_code == 200
+        mock_apply.assert_called_once()
+        args, _ = mock_apply.call_args
+        assert args[1].title == "Recovered"
+        # Fallback path did query the provider.
+        assert open_library.isbn_calls == ["9780441172719"]
 
 
 # --- description HTML stripping on apply (issue #123) -----------------------

--- a/tests/web/test_navigation_state.py
+++ b/tests/web/test_navigation_state.py
@@ -390,7 +390,11 @@ class TestEnrichUrlIsReal:
         mock_catalog.get_by_id.return_value = None
         assert client.get(self._candidate_url()).status_code == 404
 
-    def test_candidate_missing_provider_returns_404(self, mock_catalog, client):
+    def test_candidate_missing_provider_renders_recovery(self, mock_catalog, client):
+        # A drifted/unknown provider renders a recoverable panel rather than a
+        # bare 404 so the selection is never a dead end (issue #234).
         mock_catalog.get_by_id.return_value = make_book(1)
         bad = "/books/1/enrich/candidate?provider=ghost&query=q&candidate_id=x"
-        assert client.get(bad).status_code == 404
+        response = client.get(bad)
+        assert response.status_code == 200
+        assert "Couldn't load this candidate" in response.data.decode()


### PR DESCRIPTION
## Summary
- The enrich flow was stateless across steps: both the diff **View** (`enrich_candidate`) and **Apply** (`enrich_apply`) re-ran the provider search and located the candidate by `source_id`. A provider that rate-limited, timed out, or drifted between View and Apply could `abort(404)` — the user's selection evaporated — and Apply could write something other than what was previewed.
- Apply now writes **exactly** the candidate the user previewed, carried in the form, with **no provider request at apply time**. View failures render a recoverable inline panel instead of a bare 404.

## Changes
- **`src/bookery/web/candidate_payload.py`** (new): `serialize_candidate` → compact JSON (`asdict` minus `cover_image` bytes / `source_path`); `deserialize_candidate` funnels every malformed/tampered/wrong-shape input to `None` so callers fall back safely (never raises, never 500s).
- **`src/bookery/web/routes.py` — `enrich_candidate`**: serializes the chosen candidate into the Apply form; provider/candidate failures render a recoverable panel (htmx fragment or full page) with Try again / Back to results instead of `abort(404)`. A genuinely missing book still 404s.
- **`src/bookery/web/routes.py` — `enrich_apply`**: reads the carried payload and writes it directly (skipping provider lookup + re-fetch); falls back to the original re-fetch path when the payload is absent/malformed; replaces the candidate-not-found `abort(404)` with a flash + `HX-Redirect`; credits provenance to `candidate.source`.
- **Templates**: hidden `candidate_payload` field in `_enrich_diff.html`; new `_enrich_candidate_error.html`; `enrich_candidate.html` branches on `load_error`.

## Invariants preserved
- Non-destructive copy writes via `apply_metadata_safely`.
- #125 empty-clobber guard (`_should_write_scalar` / `_should_write_authors`).
- #200 cover fetch at apply time from the carried `cover_url` (failure non-fatal).
- Backward compatible: older clients that POST without a payload exercise the unchanged re-fetch fallback.

## Testing
- [x] New unit suite for serialize/deserialize round-trip + fail-safe paths (`tests/web/test_candidate_payload.py`).
- [x] New apply suite incl. the issue's observable success criterion: provider mocked to return nothing at apply, yet the previewed metadata is still written and no provider call occurs (`TestEnrichApplyCarriedPayload`).
- [x] Updated View/Apply 404 tests (incl. `test_navigation_state.py`) to the graceful-recovery behavior.
- [x] Full suite: 2041 passing; `ruff check` clean.
- [ ] Manual browser pass of View→Apply not yet done.

## Notes
- Tamper/SSRF surface (apply-time cover fetch from a user-modifiable `cover_url`) is acceptable under the localhost single-user model and consistent with the prior security assessment; `fetch_cover_image` already enforces a timeout + image content-type + non-fatal failure.
- Pre-existing `ruff format` drift (#232) on untouched lines was intentionally left alone.

## Related Issues
Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)