### PR TITLE
Fix #237: Push static collections to Kobo as shelves

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 - **MOBI-to-EPUB conversion** — converts MOBI/KF8 files to EPUB, preserving metadata, images, cover art, and chapter structure (via NCX TOC)
 - **PDF-to-EPUB conversion** — `bookery add` detects text-based PDFs, extracts their structure with pdfplumber + a local LLM (LM Studio), and produces a reflowable EPUB. Scanned PDFs are refused (OCR not yet supported).
 - **Kobo sync** — `bookery sync kobo` walks the catalog, converts each EPUB to `.kepub.epub` via `kepubify`, and copies the result to a mounted Kobo. The library itself stays format-canonical (EPUB only); kepub is generated on demand at sync time and cached so re-syncs are free when nothing has changed.
+- **Collection shelves on device** — the same `bookery sync kobo` mirrors each collection to a Kobo shelf (`Shelf`/`ShelfContent`). Bookery owns only shelves whose `InternalName` is `bookery-<collection_id>`; a user-created shelf that shares a name is skipped, never overwritten. Unchanged shelves are skipped on re-sync (membership hash), and a shelf is removed once its collection is deleted. `bookery collections show <id> --sync-status` reports per-device shelf state.
 - **Multi-provider metadata matching** — Open Library and Google Books in a consensus merger that prefers values agreed on by ≥2 providers and falls back to a priority order otherwise. ISBN-10/13 lookups are normalized and provider responses are cached.
 - **Per-field provenance & locking** — every cataloged field records which provider supplied it and when. User edits are stamped as `user` and locked against `rematch`; individual fields can be locked/unlocked explicitly with `bookery info --lock` / `--unlock`.
 - **Interactive review** — presents candidates in a Rich table, lets you accept, compare details, look up by URL, or skip
@@ -186,9 +187,10 @@ The web UI provides paginated and sortable browsing, filter chips, cover thumbna
 
 | Command | Description |
 |---------|-------------|
-| `sync kobo` | Convert library EPUBs to `.kepub.epub` and copy to a mounted Kobo |
+| `sync kobo` | Convert library EPUBs to `.kepub.epub`, copy to a mounted Kobo, and mirror collections to device shelves |
 | `sync kobo --target <path>` | Override auto-detection with an explicit mount point |
 | `sync kobo --dry-run` | Show what would be copied without touching the device |
+| `collections show <id> --sync-status` | Show per-device shelf sync state for a collection |
 
 Requires the [`kepubify`](https://pgaskin.net/kepubify/) binary on `PATH`
 (`brew install kepubify` on macOS). Files are written to

--- a/src/bookery/cli/commands/collection_cmd.py
+++ b/src/bookery/cli/commands/collection_cmd.py
@@ -2,6 +2,7 @@
 # ABOUTME: Provides create, add-books, remove-books, ls, show, rm, rename subcommands.
 
 from pathlib import Path
+from typing import cast
 
 import click
 from rich.console import Console
@@ -142,8 +143,14 @@ def collections_ls(db_path: Path | None) -> None:
 
 @collections.command("show")
 @click.argument("collection_id", type=int)
+@click.option(
+    "--sync-status",
+    "show_sync_status",
+    is_flag=True,
+    help="Show shelf sync status per device.",
+)
 @db_option
-def collections_show(collection_id: int, db_path: Path | None) -> None:
+def collections_show(collection_id: int, show_sync_status: bool, db_path: Path | None) -> None:
     """Show collection details and list books in it."""
     conn = open_library(resolve_db_path(db_path))
     catalog = LibraryCatalog(conn)
@@ -177,7 +184,52 @@ def collections_show(collection_id: int, db_path: Path | None) -> None:
 
     console.print(f"[bold]{len(books)} book(s):[/bold]")
     console.print(table)
+
+    # Show sync status if requested
+    if show_sync_status:
+        console.print()
+        _show_collection_sync_status(conn, catalog, collection_id)
+
     conn.close()
+
+
+def _show_collection_sync_status(conn, catalog: LibraryCatalog, collection_id: int) -> None:
+    """Display shelf sync status for a collection across devices."""
+    # Get all devices
+    devices = catalog.list_devices()
+    if not devices:
+        console.print("[dim]No devices configured.[/dim]")
+        return
+
+    table = Table(title="Shelf Sync Status")
+    table.add_column("Device", style="cyan")
+    table.add_column("Serial")
+    table.add_column("Last Pushed", style="dim")
+    table.add_column("Books on Device")
+    table.add_column("Status", style="green")
+
+    for device in devices:
+        device_id = cast(int, device["id"])
+        shelf_state = catalog.get_collection_shelf_state(device_id, collection_id)
+
+        if shelf_state:
+            table.add_row(
+                str(device["label"] or device["kind"]),
+                str(device["serial"]),
+                str(shelf_state["last_pushed_at"]),
+                str(shelf_state["book_count_on_device"] or "0"),
+                "[green]Synced[/green]",
+            )
+        else:
+            table.add_row(
+                str(device["label"] or device["kind"]),
+                str(device["serial"]),
+                "Never",
+                "—",
+                "[dim]Not synced[/dim]",
+            )
+
+    console.print(table)
 
 
 @collections.command("rm")

--- a/src/bookery/cli/commands/sync_cmd.py
+++ b/src/bookery/cli/commands/sync_cmd.py
@@ -37,8 +37,7 @@ def _print_status_summary(report) -> None:  # type: ignore[no-untyped-def]
     """
     if report.device_files_discovered:
         console.print(
-            f"[dim]Discovered {report.device_files_discovered} existing "
-            f"book(s) on device[/dim]"
+            f"[dim]Discovered {report.device_files_discovered} existing book(s) on device[/dim]"
         )
     if report.read_states_pulled or report.read_states_skipped:
         console.print(
@@ -55,6 +54,15 @@ def _print_status_summary(report) -> None:  # type: ignore[no-untyped-def]
                 else ""
             )
         )
+    if report.shelves_pushed:
+        console.print(
+            f"[green]Pushed {report.shelves_pushed} collection shelf(s) to device[/green]"
+        )
+    if report.shelves_deleted:
+        console.print(
+            f"[dim]Removed {len(report.shelves_deleted)} orphaned shelf(s): "
+            f"{', '.join(report.shelves_deleted)}[/dim]"
+        )
     if report.backup_path is not None:
         console.print(f"[dim]Backup: {report.backup_path}[/dim]")
     if report.read_status_push_failed:
@@ -64,6 +72,13 @@ def _print_status_summary(report) -> None:  # type: ignore[no-untyped-def]
         )
         for content_id, reason in report.read_status_push_failed:
             console.print(f"  [yellow]- {content_id}: {reason}[/yellow]")
+    if report.shelves_skipped:
+        console.print(
+            f"[yellow]Skipped {len(report.shelves_skipped)} shelf(s) "
+            f"(name conflicts with existing shelves):[/yellow]"
+        )
+        for name, reason in report.shelves_skipped:
+            console.print(f"  [yellow]- {name}: {reason}[/yellow]")
 
 
 @click.group("sync")
@@ -112,9 +127,7 @@ def sync_kobo(
     resolved_target = target
     if resolved_target is None:
         if not sync_cfg.kobo.auto_detect:
-            console.print(
-                "[red]No --target given and auto_detect is disabled.[/red]"
-            )
+            console.print("[red]No --target given and auto_detect is disabled.[/red]")
             raise SystemExit(1)
         detected = detect_mounted_kobo()
         if detected is None:
@@ -125,9 +138,7 @@ def sync_kobo(
         console.print(f"[dim]Detected Kobo at {resolved_target}[/dim]")
 
     if not (resolved_target / ".kobo").exists() and not dry_run:
-        console.print(
-            f"[yellow]Warning:[/yellow] {resolved_target} has no .kobo/ marker."
-        )
+        console.print(f"[yellow]Warning:[/yellow] {resolved_target} has no .kobo/ marker.")
 
     data_dir = data_dir_override or get_data_dir()
     cache = KepubCache(data_dir / "kepub_cache.db")

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -903,6 +903,26 @@ class LibraryCatalog:
         ).fetchone()
         return int(row["book_id"]) if row is not None else None
 
+    def list_devices(self) -> list[dict[str, object]]:
+        """Return all registered devices ordered by last seen."""
+        cursor = self._conn.execute(
+            """
+            SELECT id, kind, serial, label, last_seen_at
+            FROM devices
+            ORDER BY last_seen_at DESC
+            """
+        )
+        return [
+            {
+                "id": int(row["id"]),
+                "kind": str(row["kind"]),
+                "serial": str(row["serial"]),
+                "label": row["label"],
+                "last_seen_at": str(row["last_seen_at"]),
+            }
+            for row in cursor.fetchall()
+        ]
+
     def upsert_device_read_state(
         self,
         *,
@@ -1171,8 +1191,7 @@ class LibraryCatalog:
             return False
         catalog_ts = str(catalog_row["updated_at"])
         device_row = self._conn.execute(
-            "SELECT MAX(status_updated_at) AS latest "
-            "FROM device_read_state WHERE book_id = ?",
+            "SELECT MAX(status_updated_at) AS latest FROM device_read_state WHERE book_id = ?",
             (book_id,),
         ).fetchone()
         if device_row is None or device_row["latest"] is None:
@@ -1509,3 +1528,144 @@ class LibraryCatalog:
             }
             for row in cursor.fetchall()
         ]
+
+    # --- Device shelf state (SCHEMA_V12) -------------------------------
+
+    def upsert_device_shelf_state(
+        self,
+        *,
+        device_id: int,
+        collection_id: int,
+        shelf_id: str,
+        shelf_name: str,
+        last_pushed_at: str,
+        book_count_on_device: int | None = None,
+        member_hash: str | None = None,
+    ) -> None:
+        """Persist what we last pushed for a collection shelf.
+
+        Mirrors device_read_state but for collection→shelf mappings.
+        ``member_hash`` is a digest of the pushed membership so a later sync
+        with no changes can skip the device write entirely.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO device_shelf_state (
+                device_id, collection_id, shelf_id, shelf_name,
+                last_pushed_at, book_count_on_device, member_hash
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(device_id, collection_id) DO UPDATE SET
+                shelf_id = excluded.shelf_id,
+                shelf_name = excluded.shelf_name,
+                last_pushed_at = excluded.last_pushed_at,
+                book_count_on_device = excluded.book_count_on_device,
+                member_hash = excluded.member_hash
+            """,
+            (
+                device_id,
+                collection_id,
+                shelf_id,
+                shelf_name,
+                last_pushed_at,
+                book_count_on_device,
+                member_hash,
+            ),
+        )
+        self._conn.commit()
+
+    def get_collection_shelf_state(
+        self, device_id: int, collection_id: int
+    ) -> dict[str, object] | None:
+        """Return the last-pushed shelf state for a collection on a device."""
+        row = self._conn.execute(
+            """
+            SELECT device_id, collection_id, shelf_id, shelf_name,
+                   last_pushed_at, book_count_on_device, member_hash
+            FROM device_shelf_state
+            WHERE device_id = ? AND collection_id = ?
+            """,
+            (device_id, collection_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "device_id": int(row["device_id"]),
+            "collection_id": int(row["collection_id"]),
+            "shelf_id": str(row["shelf_id"]),
+            "shelf_name": str(row["shelf_name"]),
+            "last_pushed_at": str(row["last_pushed_at"]),
+            "book_count_on_device": row["book_count_on_device"],
+            "member_hash": row["member_hash"],
+        }
+
+    def delete_collection_shelf_state(self, device_id: int, collection_id: int) -> None:
+        """Remove the shelf state record for a collection on a device."""
+        self._conn.execute(
+            "DELETE FROM device_shelf_state WHERE device_id = ? AND collection_id = ?",
+            (device_id, collection_id),
+        )
+        self._conn.commit()
+
+    def list_collection_shelf_candidates(self, *, device_id: int) -> list[dict[str, object]]:
+        """Return collections that can be pushed as shelves to a device.
+
+        Returns collections that:
+        - Have at least one book synced to this device
+        - Have a shelf state record (were previously synced)
+        - Or are new collections that need initial sync
+
+        Each candidate includes collection info plus current book count on device.
+        """
+        cursor = self._conn.execute(
+            """
+            SELECT
+                c.id AS collection_id,
+                c.name,
+                c.updated_at,
+                COALESCE(dss.shelf_id, NULL) AS shelf_id,
+                COALESCE(dss.last_pushed_at, NULL) AS last_pushed_at,
+                COUNT(DISTINCT df.book_id) AS books_on_device,
+                COUNT(DISTINCT cb.book_id) AS books_in_collection
+            FROM collections c
+            JOIN collection_books cb ON c.id = cb.collection_id
+            JOIN device_files df ON cb.book_id = df.book_id AND df.device_id = ?
+            LEFT JOIN device_shelf_state dss
+                ON dss.collection_id = c.id AND dss.device_id = ?
+            GROUP BY c.id
+            ORDER BY c.name COLLATE NOCASE
+            """,
+            (device_id, device_id),
+        )
+        return [
+            {
+                "collection_id": int(row["collection_id"]),
+                "name": str(row["name"]),
+                "updated_at": str(row["updated_at"]),
+                "shelf_id": row["shelf_id"],
+                "last_pushed_at": row["last_pushed_at"],
+                "books_on_device": int(row["books_on_device"]),
+                "books_in_collection": int(row["books_in_collection"]),
+            }
+            for row in cursor.fetchall()
+        ]
+
+    def list_collection_device_paths(self, *, collection_id: int, device_id: int) -> list[str]:
+        """Return device remote paths for books in a collection that are on a device.
+
+        Only books that are both members of the collection and present on the
+        device (via device_files) are returned, ordered deterministically. The
+        caller turns these into Kobo ContentIDs by prefixing ``file://``.
+        """
+        cursor = self._conn.execute(
+            """
+            SELECT df.remote_path
+            FROM collection_books cb
+            JOIN device_files df
+                ON cb.book_id = df.book_id AND df.device_id = ?
+            WHERE cb.collection_id = ?
+            ORDER BY df.remote_path
+            """,
+            (device_id, collection_id),
+        )
+        return [str(row["remote_path"]) for row in cursor.fetchall()]

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -297,6 +297,33 @@ CREATE INDEX idx_collection_books_book_id ON collection_books(book_id);
 INSERT INTO schema_version (version) VALUES (11);
 """
 
+# V12: Device shelf state for collections sync to Kobo ContentList table
+# Mirrors what we last pushed for each collection->shelf mapping.
+SCHEMA_V12 = """
+CREATE TABLE device_shelf_state (
+    device_id          INTEGER NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    collection_id      INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    shelf_id           TEXT NOT NULL,
+    shelf_name         TEXT NOT NULL,
+    last_pushed_at     TEXT NOT NULL,
+    book_count_on_device INTEGER,
+    PRIMARY KEY (device_id, collection_id)
+);
+CREATE INDEX idx_device_shelf_state_device_id ON device_shelf_state(device_id);
+CREATE INDEX idx_device_shelf_state_shelf_id ON device_shelf_state(device_id, shelf_id);
+
+INSERT INTO schema_version (version) VALUES (12);
+"""
+
+# V13: member_hash on device_shelf_state. Records a digest of the shelf's pushed
+# membership so a re-sync with no changes can skip the device write entirely
+# (idempotent no-op). Forward-only ALTER on the V12 table.
+SCHEMA_V13 = """
+ALTER TABLE device_shelf_state ADD COLUMN member_hash TEXT;
+
+INSERT INTO schema_version (version) VALUES (13);
+"""
+
 MIGRATIONS = [
     (2, SCHEMA_V2),
     (3, SCHEMA_V3),
@@ -308,4 +335,6 @@ MIGRATIONS = [
     (9, SCHEMA_V9),
     (10, SCHEMA_V10),
     (11, SCHEMA_V11),
+    (12, SCHEMA_V12),
+    (13, SCHEMA_V13),
 ]

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -4,9 +4,11 @@
 import contextlib
 import datetime as _dt
 import getpass
+import hashlib
 import logging
 import platform
 import shutil
+import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,7 +20,13 @@ from bookery.db.mapping import BookRecord
 from bookery.db.status import PushCandidate
 from bookery.device.kobo_backup import backup_kobo_db
 from bookery.device.kobo_reader import pull_read_state, read_kobo_serial
-from bookery.device.kobo_writer import ReadStatusUpdate, push_read_status
+from bookery.device.kobo_writer import (
+    CollectionShelfUpdate,
+    ReadStatusUpdate,
+    delete_orphan_shelves,
+    push_read_status,
+    write_collection_shelves,
+)
 
 KOBO_MARKER = ".kobo"
 
@@ -29,6 +37,13 @@ def _now_iso() -> str:
     # UTC to match SQLite's `strftime('%Y-%m-%dT%H:%M:%S', 'now')` used
     # elsewhere in the catalog — keeps merge timestamps comparable.
     return _dt.datetime.now(_dt.UTC).replace(microsecond=0, tzinfo=None).isoformat()
+
+
+def _now_kobo() -> str:
+    # Kobo's own Shelf/ShelfContent rows use ISO-8601 UTC with a trailing 'Z'
+    # (e.g. 2024-08-11T06:37:35Z). nickel expects that exact shape, so shelf
+    # writes use this rather than the bare-naive form `_now_iso` produces.
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0, tzinfo=None).isoformat() + "Z"
 
 
 # The Kobo mounts its internal storage at `/mnt/onboard` from its own
@@ -108,6 +123,15 @@ class SyncReport:
     read_statuses_pushed: int = 0
     read_status_pull_only: int = 0
     read_status_push_failed: list[tuple[str, str]] = field(default_factory=list)
+    # P2a: Collection shelf push stats (Slice 2). ``shelves_pushed`` is shelves
+    # written this sync; unchanged shelves are skipped via member_hash and not
+    # counted. ``shelves_skipped`` is (name, reason) pairs for shelves left alone
+    # (e.g. a name collision with a user-created shelf). ``shelves_deleted`` is
+    # the names of bookery-owned shelves removed because their collection is gone.
+    shelves_pushed: int = 0
+    shelf_push_failed: list[tuple[str, str]] = field(default_factory=list)
+    shelves_skipped: list[tuple[str, str]] = field(default_factory=list)
+    shelves_deleted: list[str] = field(default_factory=list)
     backup_path: Path | None = None
 
 
@@ -142,6 +166,27 @@ class _CatalogProto(Protocol):
     ) -> None: ...
 
     def list_push_candidates(self, *, device_id: int) -> list[PushCandidate]: ...
+
+    # Collection shelf methods (Slice 2)
+    def upsert_device_shelf_state(
+        self,
+        *,
+        device_id: int,
+        collection_id: int,
+        shelf_id: str,
+        shelf_name: str,
+        last_pushed_at: str,
+        book_count_on_device: int | None = None,
+        member_hash: str | None = None,
+    ) -> None: ...
+
+    def get_collection_shelf_state(
+        self, device_id: int, collection_id: int
+    ) -> dict[str, object] | None: ...
+
+    def list_collection_shelf_candidates(self, *, device_id: int) -> list[dict[str, object]]: ...
+
+    def list_collection_device_paths(self, *, collection_id: int, device_id: int) -> list[str]: ...
 
 
 class _CacheProto(Protocol):
@@ -338,9 +383,7 @@ def _build_push_updates(candidates: list[PushCandidate]) -> list[ReadStatusUpdat
         ):
             continue
         content_id = f"file://{cand.remote_path}"
-        updates.append(
-            ReadStatusUpdate(content_id=content_id, status=cand.catalog_status)
-        )
+        updates.append(ReadStatusUpdate(content_id=content_id, status=cand.catalog_status))
     return updates
 
 
@@ -373,9 +416,7 @@ def _push_read_state(
 
     db_path = target / ".kobo" / "KoboReader.sqlite"
     if not db_path.exists():
-        logger.warning(
-            "KoboReader.sqlite not found at %s; skipping read-status push", db_path
-        )
+        logger.warning("KoboReader.sqlite not found at %s; skipping read-status push", db_path)
         return
 
     if backup_root is not None:
@@ -394,9 +435,7 @@ def _push_read_state(
         )
     except Exception as exc:
         logger.warning("Read-status push failed: %s", exc)
-        report.read_status_push_failed = [
-            (upd.content_id, str(exc)) for upd in updates
-        ]
+        report.read_status_push_failed = [(upd.content_id, str(exc)) for upd in updates]
         return
     report.read_statuses_pushed = push.pushed_count
     report.read_status_pull_only = push.pull_only_count
@@ -441,8 +480,11 @@ def sync_library_to_kobo(
             source = record.output_path
             if source is None:
                 report.skipped.append(
-            (record.source_path or Path(f"book#{record.id}"), "no canonical EPUB in library")
-        )
+                    (
+                        record.source_path or Path(f"book#{record.id}"),
+                        "no canonical EPUB in library",
+                    )
+                )
                 continue
             if source.suffix.lower() != ".epub":
                 report.skipped.append((source, "output is not an EPUB"))
@@ -485,9 +527,7 @@ def sync_library_to_kobo(
                 now=now,
             )
         except Exception as exc:
-            logger.warning(
-                "device_files discovery failed; continuing with pull: %s", exc
-            )
+            logger.warning("device_files discovery failed; continuing with pull: %s", exc)
         try:
             pulled, skipped = pull_read_state(
                 catalog, device_id=device_id, mount_path=target, now=now
@@ -529,5 +569,154 @@ def sync_library_to_kobo(
             backup_root=backup_root,
             report=report,
         )
+        _push_collection_shelves(
+            catalog=catalog,
+            device_id=device_id,
+            target=target,
+            report=report,
+        )
 
     return report
+
+
+# Bump when the on-device shelf write format changes, to force a re-push that
+# overwrites shelves left by an older format. v1 = phantom ContentList table
+# (never rendered); v2 = real Shelf/ShelfContent, _IsSynced='true'; v3 =
+# ShelfContent keyed on InternalName so nickel actually renders membership.
+_SHELF_WRITE_FORMAT = "v3"
+
+
+def _shelf_member_hash(shelf_name: str, content_ids: list[str]) -> str:
+    """Digest of a shelf's pushed membership, for idempotent no-op detection.
+
+    Order-independent over content (sorted) and sensitive to the shelf name so a
+    rename also triggers a re-push. ``_SHELF_WRITE_FORMAT`` is mixed in so that
+    changing how shelves are written to the device (e.g. the v1 phantom
+    ``ContentList`` layout → v2 real ``Shelf``/``ShelfContent`` with
+    ``_IsSynced='true'``) invalidates every stored hash and forces a one-time
+    re-push that heals shelves written by an older, broken format.
+    """
+    payload = (
+        _SHELF_WRITE_FORMAT + "\x00" + "\n".join(sorted(content_ids)) + "\x00" + shelf_name
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _push_collection_shelves(
+    *,
+    catalog: _CatalogProto,
+    device_id: int,
+    target: Path,
+    report: SyncReport,
+) -> None:
+    """Push collection shelves to the device's Shelf/ShelfContent tables.
+
+    For each collection with books on this device, builds the shelf membership
+    from the catalog, skips the device write when the membership is unchanged
+    (member_hash match), and writes the rest. Afterwards, bookery-owned shelves
+    whose collection no longer maps here are removed. Persists shelf state
+    (including the member_hash) back to the catalog.
+    """
+    try:
+        candidates = catalog.list_collection_shelf_candidates(device_id=device_id)
+    except Exception as exc:
+        logger.warning("Could not list collection shelf candidates: %s", exc)
+        return
+
+    db_path = target / ".kobo" / "KoboReader.sqlite"
+    if not db_path.exists():
+        logger.warning(
+            "KoboReader.sqlite not found at %s; skipping collection shelf push", db_path
+        )
+        return
+
+    now = _now_iso()
+    valid_internal_names: set[str] = set()
+    updates: list[CollectionShelfUpdate] = []
+    # Carry (collection_id, internal_name, member_hash, count) for shelves we write.
+    pending_state: list[tuple[int, str, str, int]] = []
+
+    for cand in candidates:
+        collection_id: int = cand["collection_id"]  # type: ignore[assignment]
+        name: str = cand["name"]  # type: ignore[assignment]
+        internal_name = f"bookery-{collection_id}"
+        valid_internal_names.add(internal_name)
+
+        content_ids = _get_collection_content_ids(catalog, device_id, collection_id)
+        member_hash = _shelf_member_hash(name, content_ids)
+
+        existing_state = catalog.get_collection_shelf_state(device_id, collection_id)
+        if existing_state is not None and existing_state.get("member_hash") == member_hash:
+            # Unchanged since last push — skip the device write (idempotent no-op).
+            continue
+
+        shelf_id: str = (
+            existing_state["shelf_id"]  # type: ignore[assignment]
+            if existing_state is not None
+            else str(uuid.uuid4())
+        )
+        updates.append(
+            CollectionShelfUpdate(
+                shelf_id=shelf_id,
+                internal_name=internal_name,
+                shelf_name=name,
+                content_ids=content_ids,
+            )
+        )
+        pending_state.append((collection_id, internal_name, member_hash, len(content_ids)))
+
+    if updates:
+        try:
+            push_result = write_collection_shelves(
+                db_path=db_path,
+                updates=updates,
+                now=_now_kobo,
+            )
+        except Exception as exc:
+            logger.warning("Collection shelf push failed: %s", exc)
+            report.shelf_push_failed = [(upd.shelf_name, str(exc)) for upd in updates]
+            return
+
+        report.shelves_pushed = push_result.pushed_count
+        report.shelf_push_failed = list(push_result.failed)
+        report.shelves_skipped = list(push_result.skipped)
+
+        skipped_names = {name for name, _ in push_result.skipped}
+        for upd, (collection_id, _internal, member_hash, count) in zip(
+            updates, pending_state, strict=True
+        ):
+            if upd.shelf_name in skipped_names:
+                continue
+            catalog.upsert_device_shelf_state(
+                device_id=device_id,
+                collection_id=collection_id,
+                shelf_id=upd.shelf_id,
+                shelf_name=upd.shelf_name,
+                last_pushed_at=now,
+                book_count_on_device=count,
+                member_hash=member_hash,
+            )
+
+    # Remove shelves we own whose collection no longer maps to this device.
+    try:
+        report.shelves_deleted = delete_orphan_shelves(
+            db_path=db_path, valid_internal_names=valid_internal_names
+        )
+    except Exception as exc:
+        logger.warning("Orphan shelf cleanup failed: %s", exc)
+
+
+def _get_collection_content_ids(
+    catalog: _CatalogProto,
+    device_id: int,
+    collection_id: int,
+) -> list[str]:
+    """Return Kobo ContentIDs for books in a collection that are on this device.
+
+    Membership comes from the catalog (collection_books ∩ device_files), not the
+    device DB. Each on-device remote path is turned into the ``file://`` ContentID
+    the Kobo ``ShelfContent`` table uses, e.g.
+    ``file:///mnt/onboard/Bookery/Author/Title/Title.kepub.epub``.
+    """
+    paths = catalog.list_collection_device_paths(collection_id=collection_id, device_id=device_id)
+    return [f"file://{path}" for path in paths]

--- a/src/bookery/device/kobo_writer.py
+++ b/src/bookery/device/kobo_writer.py
@@ -53,6 +53,40 @@ class PushReport:
     failed: list[tuple[str, str]] = field(default_factory=list)
 
 
+@dataclass(frozen=True, slots=True)
+class CollectionShelfUpdate:
+    """One collection shelf to sync to the device.
+
+    ``shelf_id`` is a UUID-style string stored as ``Shelf.Id`` (stable across
+    syncs). ``internal_name`` is the ownership marker ``bookery-<collection_id>``
+    written to ``Shelf.InternalName`` and referenced by ``ShelfContent.ShelfName``
+    (nickel links membership on the InternalName). ``shelf_name`` is the
+    human-readable display name (``Shelf.Name``). ``content_ids`` are the Kobo
+    ContentIDs of the books on this shelf (``file://`` + remote path).
+    """
+
+    shelf_id: str
+    internal_name: str
+    shelf_name: str
+    content_ids: list[str]
+
+
+@dataclass
+class ShelfPushReport:
+    """Outcome of a ``write_collection_shelves`` batch.
+
+    ``pushed_count`` is shelves written. ``skipped`` is ``(name, reason)`` pairs
+    for shelves left alone (e.g. a name collision with a user-created shelf).
+    ``failed`` is ``(name, error)`` pairs from a rollback. ``deleted`` is the
+    names of orphaned shelves removed by ``delete_orphan_shelves``.
+    """
+
+    pushed_count: int = 0
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+
+
 def open_kobo_db_rw(kobo_sqlite_path: Path) -> sqlite3.Connection:
     """Open KoboReader.sqlite in read-write mode.
 
@@ -158,3 +192,157 @@ def push_read_status(
     finally:
         conn.close()
     return report
+
+
+def write_collection_shelves(
+    *,
+    db_path: Path,
+    updates: list[CollectionShelfUpdate],
+    now: Callable[[], str],
+) -> ShelfPushReport:
+    """Write collection shelves to the Kobo ``Shelf`` / ``ShelfContent`` tables.
+
+    Kobo stores shelves as a row in ``Shelf`` (``Type='UserTag'``, BOOL columns
+    held as the text ``'true'``/``'false'``) plus one ``ShelfContent`` row per
+    book. nickel joins a shelf to its books on ``InternalName`` (not the display
+    ``Name``), so ``ShelfContent.ShelfName`` holds the ``bookery-<id>`` internal
+    name while ``Shelf.Name`` carries the human-readable collection name. This
+    function owns only shelves whose ``InternalName`` is ``bookery-<id>``:
+
+    - **Collision guard:** if a shelf with the target ``Name`` already exists but
+      is not ours (a user-created shelf), it is left untouched and reported in
+      ``skipped`` — never overwritten.
+    - **Upsert:** our shelf row is replaced by ``InternalName`` (keeping ``Id``
+      stable), and membership is rewritten by deleting and re-inserting
+      ``ShelfContent`` so both additions and removals propagate. Because content
+      is keyed on the stable ``InternalName``, renaming a collection doesn't
+      strand its books.
+
+    The whole batch is one transaction: any SQLite error rolls everything back.
+    """
+    report = ShelfPushReport()
+    if not updates:
+        return report
+
+    timestamp = now()
+    conn = open_kobo_db_rw(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN")
+        try:
+            for upd in updates:
+                # Collision guard: a shelf with this Name that we don't own.
+                foreign = conn.execute(
+                    "SELECT 1 FROM Shelf WHERE Name = ? AND InternalName != ? LIMIT 1",
+                    (upd.shelf_name, upd.internal_name),
+                ).fetchone()
+                if foreign is not None:
+                    report.skipped.append((upd.shelf_name, "name belongs to a non-bookery shelf"))
+                    continue
+
+                # nickel joins a collection to its books on the shelf's
+                # InternalName, NOT its display Name — so ShelfContent.ShelfName
+                # must hold the InternalName ('bookery-<id>'). The display Name
+                # ('Favorites') lives only on the Shelf row. Clear our rows by
+                # InternalName, plus any stragglers an older format wrote under
+                # the display name, then re-insert (additions/removals propagate).
+                conn.execute("DELETE FROM Shelf WHERE InternalName = ?", (upd.internal_name,))
+                conn.executemany(
+                    "DELETE FROM ShelfContent WHERE ShelfName = ?",
+                    [(upd.internal_name,), (upd.shelf_name,)],
+                )
+
+                conn.execute(
+                    """
+                    INSERT INTO Shelf (
+                        CreationDate, Id, InternalName, LastModified, Name, Type,
+                        _IsDeleted, _IsVisible, _IsSynced, _SyncTime, LastAccessed
+                    )
+                    VALUES (?, ?, ?, ?, ?, 'UserTag',
+                            'false', 'true', 'true', ?, ?)
+                    """,
+                    (
+                        timestamp,
+                        upd.shelf_id,
+                        upd.internal_name,
+                        timestamp,
+                        upd.shelf_name,
+                        timestamp,
+                        timestamp,
+                    ),
+                )
+                conn.executemany(
+                    """
+                    INSERT INTO ShelfContent (
+                        ShelfName, ContentId, DateModified, _IsDeleted, _IsSynced
+                    )
+                    VALUES (?, ?, ?, 'false', 'true')
+                    """,
+                    [
+                        (upd.internal_name, content_id, timestamp)
+                        for content_id in upd.content_ids
+                    ],
+                )
+                report.pushed_count += 1
+
+        except sqlite3.Error as exc:
+            conn.execute("ROLLBACK")
+            logger.warning(
+                "Collection shelf push failed; rolling back batch of %d shelf(s): %s",
+                len(updates),
+                exc,
+            )
+            report.pushed_count = 0
+            report.skipped = []
+            report.failed = [(upd.shelf_name, str(exc)) for upd in updates]
+            return report
+
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+    return report
+
+
+def delete_orphan_shelves(
+    *,
+    db_path: Path,
+    valid_internal_names: set[str],
+) -> list[str]:
+    """Remove bookery-owned shelves that no longer map to a live collection.
+
+    Ownership is reconstructed purely from the device: every ``Shelf`` whose
+    ``InternalName`` starts with ``bookery-`` is ours. Any such shelf not in
+    ``valid_internal_names`` (its collection was deleted, or no longer has books
+    on this device) is hard-deleted along with its ``ShelfContent`` rows.
+    ``ShelfContent`` is keyed on the InternalName; the display Name is also
+    cleared to sweep up rows left by an older format. User-created shelves are
+    never touched. Returns the display names removed.
+    """
+    deleted: list[str] = []
+    conn = open_kobo_db_rw(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN")
+        try:
+            rows = conn.execute(
+                "SELECT InternalName, Name FROM Shelf WHERE InternalName LIKE 'bookery-%'"
+            ).fetchall()
+            for row in rows:
+                internal_name = str(row["InternalName"])
+                if internal_name in valid_internal_names:
+                    continue
+                name = str(row["Name"])
+                conn.execute("DELETE FROM Shelf WHERE InternalName = ?", (internal_name,))
+                conn.executemany(
+                    "DELETE FROM ShelfContent WHERE ShelfName = ?",
+                    [(internal_name,), (name,)],
+                )
+                deleted.append(name)
+        except sqlite3.Error as exc:
+            conn.execute("ROLLBACK")
+            logger.warning("Orphan shelf cleanup failed; rolling back: %s", exc)
+            return []
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+    return deleted

--- a/tests/fixtures/kobo_schema.py
+++ b/tests/fixtures/kobo_schema.py
@@ -1,0 +1,100 @@
+# ABOUTME: Real Kobo KoboReader.sqlite shelf DDL, snapshotted verbatim from a device.
+# ABOUTME: Shelf tests build their fake DB from this so they can't drift from hardware.
+
+import sqlite3
+from pathlib import Path
+
+# DDL captured read-only from a real Kobo (/Volumes/KOBOeReader/.kobo/KoboReader.sqlite)
+# on 2026-05-29. Kobo stores BOOL columns as the text values 'true'/'false', user shelves
+# carry Type='UserTag', and ShelfContent links to a shelf by its Name (not its Id).
+SHELF_DDL = """
+CREATE TABLE Shelf (
+    CreationDate TEXT,
+    Id           TEXT,
+    InternalName TEXT,
+    LastModified TEXT,
+    Name         TEXT,
+    Type         TEXT,
+    _IsDeleted   BOOL,
+    _IsVisible   BOOL,
+    _IsSynced    BOOL,
+    _SyncTime    TEXT,
+    LastAccessed TEXT,
+    PRIMARY KEY(Id)
+);
+CREATE INDEX shelf_id_index ON shelf (Id);
+CREATE INDEX shelf_name_index ON shelf (Name);
+CREATE INDEX shelf_creationdate_index ON shelf (CreationDate);
+
+CREATE TABLE ShelfContent (
+    ShelfName    TEXT,
+    ContentId    TEXT,
+    DateModified TEXT,
+    _IsDeleted   BOOL,
+    _IsSynced    BOOL,
+    PRIMARY KEY(ShelfName, ContentId)
+);
+CREATE INDEX shelfcontent_datemodified_index ON ShelfContent (DateModified);
+"""
+
+
+def make_fake_kobo_db(root: Path) -> Path:
+    """Create a fake Kobo DB with the real shelf schema under ``<root>/.kobo``.
+
+    Returns the path to KoboReader.sqlite. The layout mirrors a mounted device so
+    callers can pass ``root`` as the sync target. Uses the default (DELETE) journal
+    mode to match ``open_kobo_db_rw``, which never switches to WAL.
+    """
+    kobo_dir = root / ".kobo"
+    kobo_dir.mkdir(parents=True, exist_ok=True)
+    db_path = kobo_dir / "KoboReader.sqlite"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(SHELF_DDL)
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def seed_shelf(
+    db_path: Path,
+    *,
+    shelf_id: str,
+    name: str,
+    internal_name: str,
+    shelf_type: str = "UserTag",
+    is_deleted: str = "false",
+    is_visible: str = "true",
+) -> None:
+    """Insert a pre-existing Shelf row (e.g. a user-created shelf for collision tests)."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO Shelf (
+                CreationDate, Id, InternalName, LastModified, Name, Type,
+                _IsDeleted, _IsVisible, _IsSynced
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'false')
+            """,
+            (
+                "2024-01-01T00:00:00",
+                shelf_id,
+                internal_name,
+                "2024-01-01T00:00:00",
+                name,
+                shelf_type,
+                is_deleted,
+                is_visible,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def connect_ro(db_path: Path) -> sqlite3.Connection:
+    """Open the fake Kobo DB with a Row factory for test assertions."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn

--- a/tests/integration/test_sync_collection_shelves.py
+++ b/tests/integration/test_sync_collection_shelves.py
@@ -1,0 +1,227 @@
+# ABOUTME: Integration tests for collection shelf sync against the real Kobo schema.
+# ABOUTME: Exercises sync_library_to_kobo end-to-end: membership, idempotency, orphan delete.
+
+import sqlite3
+from pathlib import Path
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.device.kepub_cache import KepubCache
+from bookery.device.kobo import sync_library_to_kobo
+from bookery.metadata.types import BookMetadata
+from tests.fixtures.kobo_schema import make_fake_kobo_db
+
+
+class _StubKepubify:
+    def __init__(self) -> None:
+        self.version = "v4.4.0"
+
+    def run(self, epub: Path, *, out_dir: Path) -> Path:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        result = out_dir / f"{epub.stem}.kepub.epub"
+        result.write_bytes(b"FAKE-KEPUB")
+        return result
+
+    def get_version(self) -> str:
+        return self.version
+
+
+def _build_fake_kobo_mount(root: Path) -> Path:
+    """Build a mount with the real Shelf/ShelfContent schema and a version file."""
+    mount = root / "kobo"
+    kobo_dir = mount / ".kobo"
+    kobo_dir.mkdir(parents=True)
+    (kobo_dir / "version").write_text("N428440071799,4.45.23684\n")
+    make_fake_kobo_db(mount)
+    return mount
+
+
+def _add_library_book(library: Path, author: str, title: str) -> Path:
+    epub = library / author / title / f"{title}.epub"
+    epub.parent.mkdir(parents=True, exist_ok=True)
+    epub.write_bytes(b"EPUB")
+    return epub
+
+
+def _add_catalog_book(catalog: LibraryCatalog, epub: Path, title: str, author: str) -> int:
+    return catalog.add_book(
+        BookMetadata(title=title, authors=[author], source_path=epub),
+        file_hash=f"hash-{title}",
+        output_path=epub,
+    )
+
+
+def _run_sync(catalog, mount, tmp_path, backup_root=None, status_push_enabled=True):
+    return sync_library_to_kobo(
+        catalog=catalog,
+        target=mount,
+        cache=KepubCache(tmp_path / "kepub.db"),
+        run_kepubify=_StubKepubify().run,
+        kepubify_version=_StubKepubify().get_version,
+        workspace_dir=tmp_path / "workspace",
+        books_subdir="Books",
+        backup_root=backup_root,
+        status_push_enabled=status_push_enabled,
+    )
+
+
+def _shelf_db(mount: Path) -> Path:
+    return mount / ".kobo" / "KoboReader.sqlite"
+
+
+def _query(db_path: Path, sql: str, params: tuple = ()) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+
+def test_collection_shelf_synced_to_device(tmp_path: Path) -> None:
+    """A collection becomes a Shelf row + ShelfContent rows on the device."""
+    conn = open_library(tmp_path / "library.db")
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+
+    collection_id = catalog.create_collection("Favorites", "My favorite books")
+    catalog.add_books_to_collection(collection_id, [book_id])
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    report = _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+
+    assert report.shelves_pushed >= 1
+
+    shelves = _query(
+        _shelf_db(mount),
+        "SELECT * FROM Shelf WHERE InternalName = ?",
+        (f"bookery-{collection_id}",),
+    )
+    assert len(shelves) == 1
+    assert shelves[0]["Name"] == "Favorites"
+    assert shelves[0]["Type"] == "UserTag"
+
+    # ShelfContent links by InternalName (what nickel joins on), not display name.
+    content = _query(
+        _shelf_db(mount),
+        "SELECT ContentId FROM ShelfContent WHERE ShelfName = ?",
+        (f"bookery-{collection_id}",),
+    )
+    assert [row["ContentId"] for row in content] == [
+        "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub"
+    ]
+
+
+def test_shelf_state_persisted_with_member_hash(tmp_path: Path) -> None:
+    """Shelf state, including member_hash, is persisted back to the catalog."""
+    conn = open_library(tmp_path / "library.db")
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+    collection_id = catalog.create_collection("Favorites")
+    catalog.add_books_to_collection(collection_id, [book_id])
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+
+    state = catalog.get_collection_shelf_state(1, collection_id)
+    assert state is not None
+    assert state["shelf_name"] == "Favorites"
+    assert state["last_pushed_at"] is not None
+    assert state["member_hash"]  # non-empty digest stored
+
+
+def test_membership_is_per_collection(tmp_path: Path) -> None:
+    """Each shelf gets only its own collection's books, not every device book."""
+    conn = open_library(tmp_path / "library.db")
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    foundation = _add_catalog_book(
+        catalog, _add_library_book(library, "Asimov", "Foundation"), "Foundation", "Asimov"
+    )
+    dune = _add_catalog_book(
+        catalog, _add_library_book(library, "Herbert", "Dune"), "Dune", "Herbert"
+    )
+
+    sci_fi = catalog.create_collection("Sci-Fi")
+    classics = catalog.create_collection("Classics")
+    catalog.add_books_to_collection(sci_fi, [foundation])
+    catalog.add_books_to_collection(classics, [dune])
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+
+    sci_fi_content = _query(
+        _shelf_db(mount),
+        "SELECT ContentId FROM ShelfContent WHERE ShelfName = ?",
+        (f"bookery-{sci_fi}",),
+    )
+    classics_content = _query(
+        _shelf_db(mount),
+        "SELECT ContentId FROM ShelfContent WHERE ShelfName = ?",
+        (f"bookery-{classics}",),
+    )
+    assert [r["ContentId"] for r in sci_fi_content] == [
+        "file:///mnt/onboard/Books/Asimov/Foundation/Foundation.kepub.epub"
+    ]
+    assert [r["ContentId"] for r in classics_content] == [
+        "file:///mnt/onboard/Books/Herbert/Dune/Dune.kepub.epub"
+    ]
+
+
+def test_resync_with_no_changes_is_noop(tmp_path: Path) -> None:
+    """A second sync with no membership change skips the device write (member_hash)."""
+    conn = open_library(tmp_path / "library.db")
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+    collection_id = catalog.create_collection("Favorites")
+    catalog.add_books_to_collection(collection_id, [book_id])
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    first = _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    assert first.shelves_pushed >= 1
+
+    second = _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync2")
+    assert second.shelves_pushed == 0
+
+
+def test_deleting_collection_removes_shelf(tmp_path: Path) -> None:
+    """Deleting a collection removes its shelf from the device on the next sync."""
+    conn = open_library(tmp_path / "library.db")
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub = _add_library_book(library, "Asimov", "Foundation")
+    book_id = _add_catalog_book(catalog, epub, "Foundation", "Asimov")
+    collection_id = catalog.create_collection("Favorites")
+    catalog.add_books_to_collection(collection_id, [book_id])
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+    assert _query(
+        _shelf_db(mount),
+        "SELECT 1 FROM Shelf WHERE InternalName = ?",
+        (f"bookery-{collection_id}",),
+    )
+
+    catalog.delete_collection(collection_id)
+    report = _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync2")
+
+    assert "Favorites" in report.shelves_deleted
+    assert (
+        _query(
+            _shelf_db(mount),
+            "SELECT 1 FROM Shelf WHERE InternalName = ?",
+            (f"bookery-{collection_id}",),
+        )
+        == []
+    )

--- a/tests/unit/test_device_shelf_state.py
+++ b/tests/unit/test_device_shelf_state.py
@@ -1,0 +1,302 @@
+# ABOUTME: Unit tests for device shelf state methods in LibraryCatalog.
+# ABOUTME: Validates upsert, get, and list operations for collection shelf sync state.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> LibraryCatalog:
+    """Provide a LibraryCatalog backed by a temporary database."""
+    conn = open_library(tmp_path / "shelf_state_test.db")
+    return LibraryCatalog(conn)
+
+
+@pytest.fixture()
+def device_id(catalog: LibraryCatalog) -> int:
+    """Register a sample device and return its ID."""
+    return catalog.upsert_device(
+        kind="kobo",
+        serial="SN123456789",
+        label="My Kobo",
+        now="2024-01-15T10:00:00",
+    )
+
+
+@pytest.fixture()
+def collection_id(catalog: LibraryCatalog) -> int:
+    """Create a sample collection and return its ID."""
+    return catalog.create_collection("Favorites", "My favorite books")
+
+
+@pytest.fixture()
+def book_id(catalog: LibraryCatalog) -> int:
+    """Add a sample book and return its ID."""
+    return catalog.add_book(
+        BookMetadata(title="Test Book", source_path=Path("/books/test.epub")),
+        file_hash="test_hash",
+    )
+
+
+class TestDeviceShelfState:
+    """Tests for device_shelf_state CRUD operations."""
+
+    def test_upsert_device_shelf_state_creates_new(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """Creating a new shelf state record works."""
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-123",
+            shelf_name="Favorites",
+            last_pushed_at="2024-01-15T10:30:00",
+            book_count_on_device=5,
+        )
+
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is not None
+        assert state["shelf_id"] == "shelf-uuid-123"
+        assert state["shelf_name"] == "Favorites"
+        assert state["last_pushed_at"] == "2024-01-15T10:30:00"
+        assert state["book_count_on_device"] == 5
+
+    def test_upsert_updates_existing(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """Upsert updates existing record."""
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-123",
+            shelf_name="Favorites",
+            last_pushed_at="2024-01-15T10:30:00",
+            book_count_on_device=5,
+        )
+
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-456",
+            shelf_name="My Favorites",
+            last_pushed_at="2024-01-15T11:00:00",
+            book_count_on_device=3,
+        )
+
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is not None
+        assert state["shelf_id"] == "shelf-uuid-456"
+        assert state["shelf_name"] == "My Favorites"
+        assert state["last_pushed_at"] == "2024-01-15T11:00:00"
+        assert state["book_count_on_device"] == 3
+
+    def test_member_hash_round_trips(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """member_hash is persisted and returned for idempotency checks."""
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-123",
+            shelf_name="Favorites",
+            last_pushed_at="2024-01-15T10:30:00",
+            book_count_on_device=5,
+            member_hash="abc123",
+        )
+
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is not None
+        assert state["member_hash"] == "abc123"
+
+    def test_member_hash_defaults_to_none(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """member_hash is None when not supplied."""
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-123",
+            shelf_name="Favorites",
+            last_pushed_at="2024-01-15T10:30:00",
+        )
+
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is not None
+        assert state["member_hash"] is None
+
+    def test_get_collection_shelf_state_nonexistent_returns_none(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """Getting non-existent state returns None."""
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is None
+
+    def test_delete_collection_shelf_state(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """Deleting a shelf state record removes it."""
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-123",
+            shelf_name="Favorites",
+            last_pushed_at="2024-01-15T10:30:00",
+        )
+
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is not None
+
+        catalog.delete_collection_shelf_state(device_id, collection_id)
+
+        state = catalog.get_collection_shelf_state(device_id, collection_id)
+        assert state is None
+
+    def test_list_collection_shelf_candidates_empty(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+    ) -> None:
+        """No candidates when no books synced to device."""
+        candidates = catalog.list_collection_shelf_candidates(device_id=device_id)
+        assert candidates == []
+
+    def test_list_collection_shelf_candidates_with_books(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+        book_id: int,
+    ) -> None:
+        """Collections with synced books appear as candidates."""
+        catalog.add_books_to_collection(collection_id, [book_id])
+
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/mnt/onboard/Bookery/Test Book/Test Book.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+
+        candidates = catalog.list_collection_shelf_candidates(device_id=device_id)
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["collection_id"] == collection_id
+        assert cand["name"] == "Favorites"
+        assert cand["books_on_device"] == 1
+        assert cand["books_in_collection"] == 1
+        assert cand["shelf_id"] is None
+        assert cand["last_pushed_at"] is None
+
+    def test_list_collection_shelf_candidates_returns_existing_state(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+        book_id: int,
+    ) -> None:
+        """Candidates include existing shelf state when present."""
+        catalog.add_books_to_collection(collection_id, [book_id])
+
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=book_id,
+            remote_path="/mnt/onboard/Bookery/Test Book/Test Book.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+
+        catalog.upsert_device_shelf_state(
+            device_id=device_id,
+            collection_id=collection_id,
+            shelf_id="shelf-uuid-123",
+            shelf_name="Favorites",
+            last_pushed_at="2024-01-15T10:30:00",
+            book_count_on_device=1,
+        )
+
+        candidates = catalog.list_collection_shelf_candidates(device_id=device_id)
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["shelf_id"] == "shelf-uuid-123"
+        assert cand["last_pushed_at"] == "2024-01-15T10:30:00"
+
+
+class TestListCollectionDevicePaths:
+    """Tests for list_collection_device_paths (per-collection membership)."""
+
+    def test_returns_only_in_collection_and_on_device(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """Only books both in the collection and on the device are returned."""
+        in_both = catalog.add_book(
+            BookMetadata(title="In Both", source_path=Path("/books/a.epub")),
+            file_hash="hash_both",
+        )
+        in_collection_only = catalog.add_book(
+            BookMetadata(title="Collection Only", source_path=Path("/books/b.epub")),
+            file_hash="hash_coll",
+        )
+        on_device_only = catalog.add_book(
+            BookMetadata(title="Device Only", source_path=Path("/books/c.epub")),
+            file_hash="hash_dev",
+        )
+
+        catalog.add_books_to_collection(collection_id, [in_both, in_collection_only])
+
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=in_both,
+            remote_path="/mnt/onboard/Bookery/A/A.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=on_device_only,
+            remote_path="/mnt/onboard/Bookery/C/C.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+
+        paths = catalog.list_collection_device_paths(
+            collection_id=collection_id, device_id=device_id
+        )
+
+        assert paths == ["/mnt/onboard/Bookery/A/A.kepub.epub"]
+
+    def test_empty_when_no_overlap(
+        self,
+        catalog: LibraryCatalog,
+        device_id: int,
+        collection_id: int,
+    ) -> None:
+        """No paths when the collection has no books on the device."""
+        paths = catalog.list_collection_device_paths(
+            collection_id=collection_id, device_id=device_id
+        )
+        assert paths == []

--- a/tests/unit/test_kobo_writer_shelves.py
+++ b/tests/unit/test_kobo_writer_shelves.py
@@ -1,0 +1,275 @@
+# ABOUTME: Unit tests for kobo_writer Shelf/ShelfContent operations against the real schema.
+# ABOUTME: Validates write_collection_shelves and delete_orphan_shelves on a device-faithful DB.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.device.kobo_writer import (
+    CollectionShelfUpdate,
+    delete_orphan_shelves,
+    write_collection_shelves,
+)
+from tests.fixtures.kobo_schema import connect_ro, make_fake_kobo_db, seed_shelf
+
+NOW = "2024-01-15T10:30:00"
+
+
+@pytest.fixture()
+def kobo_db_path(tmp_path: Path) -> Path:
+    """A fake Kobo DB with the real Shelf/ShelfContent schema."""
+    return make_fake_kobo_db(tmp_path)
+
+
+def _content_ids_for(db_path: Path, shelf_key: str) -> list[str]:
+    """ContentIds linked to a shelf. ``shelf_key`` is the InternalName (the value
+    ShelfContent.ShelfName holds), not the display name."""
+    conn = connect_ro(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT ContentId FROM ShelfContent WHERE ShelfName = ? ORDER BY ContentId",
+            (shelf_key,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [row["ContentId"] for row in rows]
+
+
+class TestWriteCollectionShelves:
+    def test_creates_shelf_and_content(self, kobo_db_path: Path) -> None:
+        """A single update creates a Shelf row and its ShelfContent rows."""
+        updates = [
+            CollectionShelfUpdate(
+                shelf_id="shelf-uuid-1",
+                internal_name="bookery-7",
+                shelf_name="Sci-Fi",
+                content_ids=[
+                    "file:///mnt/onboard/Bookery/A/A.kepub.epub",
+                    "file:///mnt/onboard/Bookery/B/B.kepub.epub",
+                ],
+            )
+        ]
+
+        report = write_collection_shelves(db_path=kobo_db_path, updates=updates, now=lambda: NOW)
+
+        assert report.pushed_count == 1
+        assert report.failed == []
+        assert report.skipped == []
+
+        conn = connect_ro(kobo_db_path)
+        shelf = conn.execute(
+            "SELECT * FROM Shelf WHERE InternalName = ?", ("bookery-7",)
+        ).fetchone()
+        conn.close()
+
+        assert shelf is not None
+        assert shelf["Id"] == "shelf-uuid-1"
+        assert shelf["Name"] == "Sci-Fi"
+        assert shelf["Type"] == "UserTag"
+        # Booleans stored as the text values Kobo uses, not integers. nickel
+        # only renders shelves/content marked _IsSynced='true'; 'false' rows
+        # are treated as un-reconciled local edits and suppressed in the UI.
+        assert shelf["_IsDeleted"] == "false"
+        assert shelf["_IsVisible"] == "true"
+        assert shelf["_IsSynced"] == "true"
+
+        # ShelfContent links by InternalName (what nickel joins on), not the
+        # display name — so membership is keyed on "bookery-7", not "Sci-Fi".
+        assert _content_ids_for(kobo_db_path, "bookery-7") == [
+            "file:///mnt/onboard/Bookery/A/A.kepub.epub",
+            "file:///mnt/onboard/Bookery/B/B.kepub.epub",
+        ]
+        assert _content_ids_for(kobo_db_path, "Sci-Fi") == []
+
+    def test_rerun_replaces_membership(self, kobo_db_path: Path) -> None:
+        """Re-pushing the same shelf reflects added and removed books."""
+        first = [
+            CollectionShelfUpdate(
+                shelf_id="shelf-uuid-1",
+                internal_name="bookery-7",
+                shelf_name="Sci-Fi",
+                content_ids=["file:///mnt/onboard/Bookery/A/A.kepub.epub"],
+            )
+        ]
+        write_collection_shelves(db_path=kobo_db_path, updates=first, now=lambda: NOW)
+
+        second = [
+            CollectionShelfUpdate(
+                shelf_id="shelf-uuid-1",
+                internal_name="bookery-7",
+                shelf_name="Sci-Fi",
+                content_ids=[
+                    "file:///mnt/onboard/Bookery/B/B.kepub.epub",
+                    "file:///mnt/onboard/Bookery/C/C.kepub.epub",
+                ],
+            )
+        ]
+        write_collection_shelves(db_path=kobo_db_path, updates=second, now=lambda: NOW)
+
+        assert _content_ids_for(kobo_db_path, "bookery-7") == [
+            "file:///mnt/onboard/Bookery/B/B.kepub.epub",
+            "file:///mnt/onboard/Bookery/C/C.kepub.epub",
+        ]
+        # Exactly one Shelf row for our InternalName, not a duplicate.
+        conn = connect_ro(kobo_db_path)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM Shelf WHERE InternalName = ?", ("bookery-7",)
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1
+
+    def test_rename_keeps_membership_under_internal_name(self, kobo_db_path: Path) -> None:
+        """Renaming a collection updates the display Name but keeps membership.
+
+        Because ShelfContent is keyed on the stable InternalName, a rename never
+        strands content under an old name.
+        """
+        write_collection_shelves(
+            db_path=kobo_db_path,
+            updates=[
+                CollectionShelfUpdate(
+                    shelf_id="shelf-uuid-1",
+                    internal_name="bookery-7",
+                    shelf_name="Old Name",
+                    content_ids=["file:///mnt/onboard/Bookery/A/A.kepub.epub"],
+                )
+            ],
+            now=lambda: NOW,
+        )
+        write_collection_shelves(
+            db_path=kobo_db_path,
+            updates=[
+                CollectionShelfUpdate(
+                    shelf_id="shelf-uuid-1",
+                    internal_name="bookery-7",
+                    shelf_name="New Name",
+                    content_ids=["file:///mnt/onboard/Bookery/A/A.kepub.epub"],
+                )
+            ],
+            now=lambda: NOW,
+        )
+
+        # Membership stays under the InternalName; display name updates.
+        assert _content_ids_for(kobo_db_path, "bookery-7") == [
+            "file:///mnt/onboard/Bookery/A/A.kepub.epub"
+        ]
+        conn = connect_ro(kobo_db_path)
+        name = conn.execute(
+            "SELECT Name FROM Shelf WHERE InternalName = 'bookery-7'"
+        ).fetchone()["Name"]
+        conn.close()
+        assert name == "New Name"
+
+    def test_collision_guard_skips_foreign_shelf(self, kobo_db_path: Path) -> None:
+        """A user shelf sharing the target name is left untouched and reported."""
+        seed_shelf(
+            kobo_db_path,
+            shelf_id="user-xyz",
+            name="Sci-Fi",
+            internal_name="Sci-Fi",  # user shelf: InternalName == Name, not 'bookery-*'
+        )
+
+        report = write_collection_shelves(
+            db_path=kobo_db_path,
+            updates=[
+                CollectionShelfUpdate(
+                    shelf_id="shelf-uuid-1",
+                    internal_name="bookery-7",
+                    shelf_name="Sci-Fi",
+                    content_ids=["file:///mnt/onboard/Bookery/A/A.kepub.epub"],
+                )
+            ],
+            now=lambda: NOW,
+        )
+
+        assert report.pushed_count == 0
+        assert len(report.skipped) == 1
+        assert report.skipped[0][0] == "Sci-Fi"
+
+        conn = connect_ro(kobo_db_path)
+        # The user's shelf still exists; no bookery- shelf was created.
+        user = conn.execute("SELECT Id FROM Shelf WHERE Name = 'Sci-Fi'").fetchall()
+        ours = conn.execute("SELECT Id FROM Shelf WHERE InternalName = 'bookery-7'").fetchall()
+        conn.close()
+        assert len(user) == 1
+        assert user[0]["Id"] == "user-xyz"
+        assert ours == []
+
+    def test_does_not_touch_unrelated_user_shelves(self, kobo_db_path: Path) -> None:
+        """Pushing a bookery shelf leaves differently-named user shelves intact."""
+        seed_shelf(kobo_db_path, shelf_id="u1", name="Fiction", internal_name="Fiction")
+
+        write_collection_shelves(
+            db_path=kobo_db_path,
+            updates=[
+                CollectionShelfUpdate(
+                    shelf_id="shelf-uuid-1",
+                    internal_name="bookery-7",
+                    shelf_name="Sci-Fi",
+                    content_ids=["file:///mnt/onboard/Bookery/A/A.kepub.epub"],
+                )
+            ],
+            now=lambda: NOW,
+        )
+
+        conn = connect_ro(kobo_db_path)
+        fiction = conn.execute("SELECT Id FROM Shelf WHERE Name = 'Fiction'").fetchone()
+        conn.close()
+        assert fiction is not None
+        assert fiction["Id"] == "u1"
+
+    def test_empty_updates_returns_empty(self, kobo_db_path: Path) -> None:
+        report = write_collection_shelves(db_path=kobo_db_path, updates=[], now=lambda: NOW)
+        assert report.pushed_count == 0
+        assert report.failed == []
+        assert report.skipped == []
+
+
+class TestDeleteOrphanShelves:
+    def test_removes_orphaned_bookery_shelf(self, kobo_db_path: Path) -> None:
+        """A bookery- shelf no longer valid is removed with its content."""
+        write_collection_shelves(
+            db_path=kobo_db_path,
+            updates=[
+                CollectionShelfUpdate(
+                    shelf_id="s1",
+                    internal_name="bookery-1",
+                    shelf_name="Keep",
+                    content_ids=["file:///mnt/onboard/Bookery/A/A.kepub.epub"],
+                ),
+                CollectionShelfUpdate(
+                    shelf_id="s2",
+                    internal_name="bookery-2",
+                    shelf_name="Drop",
+                    content_ids=["file:///mnt/onboard/Bookery/B/B.kepub.epub"],
+                ),
+            ],
+            now=lambda: NOW,
+        )
+
+        deleted = delete_orphan_shelves(db_path=kobo_db_path, valid_internal_names={"bookery-1"})
+
+        assert deleted == ["Drop"]
+        conn = connect_ro(kobo_db_path)
+        remaining = {
+            row["InternalName"]
+            for row in conn.execute("SELECT InternalName FROM Shelf").fetchall()
+        }
+        drop_content = conn.execute(
+            "SELECT COUNT(*) FROM ShelfContent WHERE ShelfName = 'bookery-2'"
+        ).fetchone()[0]
+        conn.close()
+        assert remaining == {"bookery-1"}
+        assert drop_content == 0
+
+    def test_leaves_user_shelves_untouched(self, kobo_db_path: Path) -> None:
+        """Orphan cleanup never deletes non-bookery shelves."""
+        seed_shelf(kobo_db_path, shelf_id="u1", name="Fiction", internal_name="Fiction")
+
+        deleted = delete_orphan_shelves(db_path=kobo_db_path, valid_internal_names=set())
+
+        assert deleted == []
+        conn = connect_ro(kobo_db_path)
+        fiction = conn.execute("SELECT Id FROM Shelf WHERE Name = 'Fiction'").fetchone()
+        conn.close()
+        assert fiction is not None

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 11
+        assert version == 13
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -126,7 +126,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 11
+        assert version == 13
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")
@@ -205,6 +205,14 @@ class TestMigrations:
         cursor = conn.execute("SELECT COUNT(*) FROM collection_books")
         assert cursor.fetchone()[0] == 0
         conn.close()
+
+    def test_v13_adds_member_hash_column(self, db_path: Path) -> None:
+        """V13 migration adds the member_hash column to device_shelf_state."""
+        conn = open_library(db_path)
+        cursor = conn.execute("PRAGMA table_info(device_shelf_state)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        assert "member_hash" in columns
 
     def test_collection_books_cascade_on_book_delete(self, db_path: Path) -> None:
         """Deleting a book cascades to remove collection_books associations."""


### PR DESCRIPTION
## Summary

Vertical slice 2 of the collections epic (#179): `bookery sync kobo` now mirrors each curated collection to a **Kobo shelf**, so collections show up on the device. Built and verified against the real Kobo `Shelf`/`ShelfContent` schema.

> Context: an earlier draft of this slice wrote to a phantom `ContentList`/`ContentIDList` table that does not exist on real hardware (its tests passed against a self-defined fake table) and ignored collection membership. This PR is the corrected, device-verified implementation.

## Changes

- **`device/kobo_writer.py`** — `write_collection_shelves` writes `Shelf` (`Type='UserTag'`, BOOL columns as text) + one `ShelfContent` row per book; `delete_orphan_shelves` removes a shelf once its collection is gone.
- **`device/kobo.py`** — `_push_collection_shelves` builds per-collection membership, skips unchanged shelves via `member_hash`, and prunes orphans. `_SHELF_WRITE_FORMAT` is folded into the hash so a write-format change force-invalidates it.
- **`db/catalog.py`** — `list_collection_device_paths` (membership = collection_books ∩ device_files), `member_hash` round-trip on shelf state.
- **`db/schema.py`** — `device_shelf_state` (V12) + `member_hash` (V13).
- **`cli/commands/`** — `collections show <id> --sync-status`; `sync kobo` summary reports push/skip/delete counts.
- **`tests/fixtures/kobo_schema.py`** — real Kobo DDL snapshot so shelf tests can't drift from hardware.

## Ownership & safety

- Owns only shelves whose `InternalName` is `bookery-<collection_id>`.
- A same-named user shelf is **skipped, never overwritten** (collision guard).
- Verified on-device that the four pre-existing user shelves are untouched.

## Two hardware-only findings (verified on a Kobo Libra Colour, fw 4.45)

- `ShelfContent.ShelfName` must hold the shelf's **`InternalName`**, not the display `Name` — nickel joins a collection to its books on `InternalName`. Native/Calibre shelves hide this by keeping them equal.
- Shelf/`ShelfContent` rows need **`_IsSynced='true'`**; `'false'` rows appear but their membership is suppressed in the UI.

## Testing

- [x] Unit + integration tests (41 shelf/migration/catalog tests) — green
- [x] `ruff check` + `pyright` clean
- [x] **End-to-end on a real Kobo**: collection shelf shows its book on-device; user shelves intact
- [ ] Note: 62 pre-existing `tests/web/` failures are unrelated to this change and tracked in #243

## Related

Fixes #237 · Epic #179 · Pre-existing web test failures: #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)