### PR TITLE
Fix #243: stub get_collections_for_book in web detail test mocks

### DIFF
--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -59,6 +59,7 @@ def mock_catalog():
     catalog.get_by_id.return_value = None
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
+    catalog.get_collections_for_book.return_value = []
     catalog.get_book_statuses.return_value = {}
     catalog.get_book_status.return_value = None
     catalog.get_device_read_state_for_book.return_value = None

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -122,6 +122,7 @@ def mock_catalog():
     catalog.get_by_id.return_value = None
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
+    catalog.get_collections_for_book.return_value = []
     catalog.get_book_statuses.return_value = {}
     catalog.get_book_status.return_value = None
     catalog.get_device_read_state_for_book.return_value = None


### PR DESCRIPTION
## Summary
- Fixes the 55 detail-page test failures present on `main` (51 in `tests/web`, 4 in `tests/unit/test_web_app.py`).
- Root cause: the static-collections feature (#241, #244) added a collections section to the detail template and a `catalog.get_collections_for_book()` call in the `book_detail` route, but the two web-test catalog mocks were never updated. The unstubbed `Mock` was non-iterable, so the template's `{% for collection in collections %}` raised `TypeError: 'Mock' object is not iterable` on every detail-page render.
- Diagnosis matches the issue: tests went stale, the template did not regress.

## Changes
- **tests/web/conftest.py**: stub `get_collections_for_book` → `[]` in `mock_catalog`, mirroring the existing `get_tags_for_book` / `get_genres_for_book` stubs.
- **tests/unit/test_web_app.py**: same stub in that file's separate `mock_catalog` fixture.

## Testing
- [x] `uv run pytest tests/web` — 345 passed (was ~51 failing)
- [x] `uv run pytest tests/web tests/unit/test_web_app.py` — 372 passed
- [x] Full suite — 2132 passed; only the 7 pre-existing DB schema/migration failures remain (unrelated, filed as #245)
- [x] ruff + pyright clean

## Note
The 7 remaining full-suite failures are a pre-existing schema-version staleness on `main` (schema at v13, tests assert v10/v7), verified by stashing this change and checking out `main`. Out of scope here — filed separately as #245.

## Related Issues
Fixes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)