### PR TITLE
Chore: untrack .opencode/ per-user editor config

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": [
-    "@mrgray17/opentoken"
-  ]
-}

--- a/.opencode/tui.json
+++ b/.opencode/tui.json
@@ -1,5 +1,0 @@
-{
-  "plugin": [
-    "@mrgray17/opentoken"
-  ]
-}


### PR DESCRIPTION
## Summary
Two OpenCode editor config files (`.opencode/opencode.json`, `.opencode/tui.json`) were accidentally committed in #247 — swept in by a broad `git add -A` during the #245 commit. They are per-user local tooling and don't belong in version control.

## Changes
- Remove `.opencode/opencode.json` and `.opencode/tui.json` from tracking (`git rm --cached` — files stay on disk locally).
- Add `.opencode/` to `.gitignore`, alongside the existing `.claude/` and `.serena/` per-user tooling entries, so it can't reaccumulate.

## Testing
- [x] `git check-ignore` confirms both files are now ignored
- [x] pre-commit (ruff check + pyright) green
- [x] No source or test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)