### PR TITLE
Chore: gitignore .opencode/ per-user tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ uv.lock
 # Serena (per-user tooling)
 .serena/
 
+# OpenCode (per-user tooling)
+.opencode/
+
 # Bookery runtime
 *.db
 bookery-output/


### PR DESCRIPTION
## Summary
Follow-up to #248. That PR removed the accidentally-committed `.opencode/` config files but missed the `.gitignore` entry itself — the edit was left unstaged, so the files aren't durably ignored yet.

## Changes
- Add `.opencode/` to `.gitignore`, alongside the existing `.claude/` and `.serena/` per-user tooling entries.

## Testing
- [x] `git check-ignore -v` confirms both `.opencode/*.json` files resolve to the new rule
- [x] No source or test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)