### PR TITLE
Add #240: Query-based collections (simple rules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 - **MOBI-to-EPUB conversion** — converts MOBI/KF8 files to EPUB, preserving metadata, images, cover art, and chapter structure (via NCX TOC)
 - **PDF-to-EPUB conversion** — `bookery add` detects text-based PDFs, extracts their structure with pdfplumber + a local LLM (LM Studio), and produces a reflowable EPUB. Scanned PDFs are refused (OCR not yet supported).
 - **Kobo sync** — `bookery sync kobo` walks the catalog, converts each EPUB to `.kepub.epub` via `kepubify`, and copies the result to a mounted Kobo. The library itself stays format-canonical (EPUB only); kepub is generated on demand at sync time and cached so re-syncs are free when nothing has changed.
+- **Collections** — group books into named lists, either static (hand-picked) or rule-based (membership derived live from a query like `genre:"Science Fiction"` or `series:Dune`, so it stays current as the library grows). See `bookery collections`.
 - **Collection shelves on device** — the same `bookery sync kobo` mirrors each collection to a Kobo shelf (`Shelf`/`ShelfContent`). Bookery owns only shelves whose `InternalName` is `bookery-<collection_id>`; a user-created shelf that shares a name is skipped, never overwritten. Unchanged shelves are skipped on re-sync (membership hash), and a shelf is removed once its collection is deleted. `bookery collections show <id> --sync-status` reports per-device shelf state.
 - **Multi-provider metadata matching** — Open Library and Google Books in a consensus merger that prefers values agreed on by ≥2 providers and falls back to a priority order otherwise. ISBN-10/13 lookups are normalized and provider responses are cached.
 - **Per-field provenance & locking** — every cataloged field records which provider supplied it and when. User edits are stamped as `user` and locked against `rematch`; individual fields can be locked/unlocked explicitly with `bookery info --lock` / `--unlock`.
@@ -174,6 +175,34 @@ bookery info 42
 | `genre unmatched` | Show books with subjects but no genre assigned |
 | `mark finished <id>` | Mark a book as finished (also `mark reading <id>`, `mark unread <id>`; supports `--bulk-from FILE`) |
 | `verify` | Check for missing or changed files (supports `--check-hash`) |
+
+### Collections
+
+Collections group books into named lists. A collection is either **static**
+(hand-picked membership) or **rule-based** (membership derived live from a
+query). The two are mutually exclusive — a rule-based collection holds no
+hand-picked rows, and its members are recomputed on every read, so it stays
+current automatically as the library changes.
+
+| Command | Description |
+|---------|-------------|
+| `collections create <name>` | Create a static collection (`-d/--description` optional) |
+| `collections create <name> --query '<rule>'` | Create a rule-based collection, e.g. `--query 'genre:"Science Fiction"'` |
+| `collections ls` | List collections with live book counts |
+| `collections show <id>` | Show a collection's books; rule-based collections also show the rule and live match count (`--sync-status` for per-device shelf state) |
+| `collections add-books <id> <book_id>...` | Add books to a static collection |
+| `collections remove-books <id> <book_id>...` | Remove books from a static collection |
+| `collections edit <id> --query '<rule>'` | Convert a static collection to rule-based |
+| `collections edit <id> --clear-query` | Convert a rule-based collection to static, snapshotting current members |
+| `collections preview --query '<rule>'` | Show which books a rule matches, without saving |
+| `collections rename <id> <new_name>` | Rename a collection |
+| `collections rm <id>` | Delete a collection (books are not deleted) |
+
+Rule queries are a deliberately small subset: exactly one `field:value` or
+`field:"phrase"` term over a whitelisted field. Slice 3 supports `series`
+(exact match) and `genre` (canonical genre). `author` is coming in a later
+slice; multi-term, boolean (`AND`/`OR`/`NOT`), wildcards, and ranges are
+rejected with a message naming the valid fields.
 
 ### Web UI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "ebooklib>=0.18",
     "flask>=3.0",
     "httpx>=0.27",
+    "luqum>=0.13",
     "mobi>=0.4",
     "openai>=1.0",
     "pdfplumber>=0.11",

--- a/src/bookery/cli/commands/collection_cmd.py
+++ b/src/bookery/cli/commands/collection_cmd.py
@@ -1,5 +1,5 @@
 # ABOUTME: The `bookery collections` command group for managing book collections.
-# ABOUTME: Provides create, add-books, remove-books, ls, show, rm, rename subcommands.
+# ABOUTME: Static (create/add-books/remove-books) and rule-based (--query/edit/preview) curation.
 
 from pathlib import Path
 from typing import cast
@@ -9,6 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from bookery.cli.options import db_option, resolve_db_path
+from bookery.collections import CollectionQueryError, parse_collection_query
 from bookery.db.catalog import LibraryCatalog
 from bookery.db.connection import open_library
 
@@ -17,26 +18,54 @@ console = Console()
 
 @click.group("collections")
 def collections() -> None:
-    """Manage book collections (manual curation)."""
+    """Manage book collections (static curation or rule-based queries)."""
 
 
 @collections.command("create")
 @click.argument("name")
 @click.option("--description", "-d", help="Optional description for the collection.")
+@click.option(
+    "--query",
+    "-q",
+    "query",
+    default=None,
+    help='Rule for a rule-based collection, e.g. \'genre:"Science Fiction"\' or series:Dune.',
+)
 @db_option
-def collections_create(name: str, description: str | None, db_path: Path | None) -> None:
-    """Create a new collection."""
+def collections_create(
+    name: str, description: str | None, query: str | None, db_path: Path | None
+) -> None:
+    """Create a new collection.
+
+    Pass --query to create a rule-based collection whose membership is derived
+    live from the rule (e.g. --query 'genre:"Science Fiction"'); omit it for a
+    static, hand-curated collection.
+    """
+    # Validate the rule before touching the database so a bad query never
+    # creates an empty collection.
+    if query is not None:
+        try:
+            parse_collection_query(query)
+        except CollectionQueryError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise SystemExit(1) from exc
+
     conn = open_library(resolve_db_path(db_path))
     catalog = LibraryCatalog(conn)
 
     try:
-        collection_id = catalog.create_collection(name, description)
+        collection_id = catalog.create_collection(name, description, query)
     except Exception as exc:
         console.print(f"[red]Failed to create collection: {exc}[/red]")
         conn.close()
         raise SystemExit(1) from exc
 
-    console.print(f"Created collection [bold]{name}[/bold] (ID: {collection_id}).")
+    if query:
+        console.print(
+            f"Created rule-based collection [bold]{name}[/bold] (ID: {collection_id})."
+        )
+    else:
+        console.print(f"Created collection [bold]{name}[/bold] (ID: {collection_id}).")
     conn.close()
 
 
@@ -164,6 +193,8 @@ def collections_show(collection_id: int, show_sync_status: bool, db_path: Path |
     console.print(f"[bold]{collection['name']}[/bold] (ID: {collection_id})")
     if collection.get("description"):
         console.print(f"[dim]{collection['description']}[/dim]")
+    if collection.get("query"):
+        console.print(f"[dim]Query:[/dim] {collection['query']} [dim](rule-based)[/dim]")
     console.print()
 
     books = catalog.get_collection_books(collection_id)
@@ -230,6 +261,107 @@ def _show_collection_sync_status(conn, catalog: LibraryCatalog, collection_id: i
             )
 
     console.print(table)
+
+
+@collections.command("edit")
+@click.argument("collection_id", type=int)
+@click.option(
+    "--query",
+    "query",
+    default=None,
+    help="Convert to a rule-based collection with this rule.",
+)
+@click.option(
+    "--clear-query",
+    "clear_query",
+    is_flag=True,
+    help="Convert a rule-based collection to static, snapshotting current members.",
+)
+@db_option
+def collections_edit(
+    collection_id: int, query: str | None, clear_query: bool, db_path: Path | None
+) -> None:
+    """Change a collection's rule (convert static <-> rule-based).
+
+    Pass exactly one of --query (static -> rule-based) or --clear-query
+    (rule-based -> static, snapshotting the current members).
+    """
+    if query is not None and clear_query:
+        console.print("[red]Use either --query or --clear-query, not both.[/red]")
+        raise SystemExit(1)
+    if query is None and not clear_query:
+        console.print("[red]Specify --query '<rule>' or --clear-query.[/red]")
+        raise SystemExit(1)
+
+    if query is not None:
+        try:
+            parse_collection_query(query)
+        except CollectionQueryError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise SystemExit(1) from exc
+
+    conn = open_library(resolve_db_path(db_path))
+    catalog = LibraryCatalog(conn)
+
+    collection = catalog.get_collection_by_id(collection_id)
+    if collection is None:
+        console.print(f"[red]Collection {collection_id} not found.[/red]")
+        conn.close()
+        raise SystemExit(1)
+
+    if clear_query:
+        if collection.get("query") is None:
+            console.print(f"[red]Collection {collection_id} is already static.[/red]")
+            conn.close()
+            raise SystemExit(1)
+        catalog.clear_collection_query(collection_id)
+        console.print(
+            f"Converted [bold]{collection['name']}[/bold] to a static collection "
+            "(members snapshotted)."
+        )
+    else:
+        catalog.set_collection_query(collection_id, query)  # type: ignore[arg-type]
+        console.print(f"Set rule for [bold]{collection['name']}[/bold]: {query}")
+
+    conn.close()
+
+
+@collections.command("preview")
+@click.option(
+    "--query",
+    "query",
+    required=True,
+    help='Rule to preview, e.g. \'genre:"Science Fiction"\' or series:Dune.',
+)
+@db_option
+def collections_preview(query: str, db_path: Path | None) -> None:
+    """Preview which books a rule matches, without saving a collection."""
+    conn = open_library(resolve_db_path(db_path))
+    catalog = LibraryCatalog(conn)
+
+    try:
+        books = catalog.preview_query(query)
+    except CollectionQueryError as exc:
+        console.print(f"[red]{exc}[/red]")
+        conn.close()
+        raise SystemExit(1) from exc
+
+    console.print(f"[bold]{len(books)} book(s) match[/bold] [cyan]{query}[/cyan]:")
+    if not books:
+        conn.close()
+        return
+
+    table = Table()
+    table.add_column("ID", style="dim", width=6)
+    table.add_column("Title", style="bold")
+    table.add_column("Author(s)")
+
+    for book in books:
+        authors = ", ".join(book.metadata.authors) if book.metadata.authors else "Unknown"
+        table.add_row(str(book.id), book.metadata.title, authors)
+
+    console.print(table)
+    conn.close()
 
 
 @collections.command("rm")

--- a/src/bookery/cli/commands/collection_cmd.py
+++ b/src/bookery/cli/commands/collection_cmd.py
@@ -29,7 +29,7 @@ def collections() -> None:
     "-q",
     "query",
     default=None,
-    help='Rule for a rule-based collection, e.g. \'genre:"Science Fiction"\' or series:Dune.',
+    help="Rule for a rule-based collection, e.g. 'genre:\"Science Fiction\"' or series:Dune.",
 )
 @db_option
 def collections_create(
@@ -61,9 +61,7 @@ def collections_create(
         raise SystemExit(1) from exc
 
     if query:
-        console.print(
-            f"Created rule-based collection [bold]{name}[/bold] (ID: {collection_id})."
-        )
+        console.print(f"Created rule-based collection [bold]{name}[/bold] (ID: {collection_id}).")
     else:
         console.print(f"Created collection [bold]{name}[/bold] (ID: {collection_id}).")
     conn.close()
@@ -331,7 +329,7 @@ def collections_edit(
     "--query",
     "query",
     required=True,
-    help='Rule to preview, e.g. \'genre:"Science Fiction"\' or series:Dune.',
+    help="Rule to preview, e.g. 'genre:\"Science Fiction\"' or series:Dune.",
 )
 @db_option
 def collections_preview(query: str, db_path: Path | None) -> None:

--- a/src/bookery/collections/__init__.py
+++ b/src/bookery/collections/__init__.py
@@ -1,0 +1,16 @@
+# ABOUTME: Pure collections query package — parses/validates rule-based collection queries.
+# ABOUTME: Quarantines the luqum dependency; has no database import.
+
+from bookery.collections.query import (
+    SLICE3_FIELD_NAMES,
+    CollectionQuery,
+    CollectionQueryError,
+    parse_collection_query,
+)
+
+__all__ = [
+    "SLICE3_FIELD_NAMES",
+    "CollectionQuery",
+    "CollectionQueryError",
+    "parse_collection_query",
+]

--- a/src/bookery/collections/query.py
+++ b/src/bookery/collections/query.py
@@ -1,0 +1,137 @@
+# ABOUTME: Parses and validates rule-based collection queries (slice-3 subset).
+# ABOUTME: Pure module — owns the luqum dependency, no DB import; SQL lives in the resolver.
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from luqum.exceptions import ParseError
+from luqum.parser import parser
+from luqum.tree import Phrase, SearchField, Word
+
+from bookery.metadata.genres import CANONICAL_GENRES, is_canonical_genre
+
+
+class CollectionQueryError(ValueError):
+    """A collection query string is invalid or outside the supported subset.
+
+    Carries a human-facing message; the CLI and web layers surface it verbatim.
+    Subclasses ``ValueError`` so existing ``except ValueError`` catch sites in the
+    catalog keep working.
+    """
+
+
+@dataclass(frozen=True)
+class CollectionQuery:
+    """A validated single-field equality query.
+
+    ``field`` is a canonical, lower-cased slice-3 field name (``series`` or
+    ``genre``); ``value`` is the raw user-supplied value (quotes stripped). The
+    resolver turns this into per-field SQL — this object holds no SQL itself.
+    """
+
+    field: str
+    value: str
+
+
+def _validate_genre_value(value: str) -> None:
+    """Reject non-canonical genres at parse time (mirrors ``get_books_by_genre``)."""
+    if not is_canonical_genre(value):
+        valid = ", ".join(CANONICAL_GENRES)
+        raise CollectionQueryError(
+            f"'{value}' is not a canonical genre. Valid genres: {valid}."
+        )
+
+
+# The slice-3 field whitelist. Maps each supported field to an optional value
+# validator. This registry drives both the compiler (in the db resolver, which
+# keys off these names) and the error messages below. Slice 4 (#236) grows this
+# map and relaxes the validator; the parse entry point does not change.
+SLICE3_FIELDS: dict[str, Callable[[str], None] | None] = {
+    "series": None,
+    "genre": _validate_genre_value,
+}
+SLICE3_FIELD_NAMES: tuple[str, ...] = tuple(SLICE3_FIELDS)
+
+# Fields deliberately deferred to a later slice, mapped to where they land. These
+# get a specific "coming later" message rather than the generic unknown-field error.
+_DEFERRED_FIELDS: dict[str, str] = {
+    "author": "slice 4 (#236)",
+}
+
+_FIELD_LIST = ", ".join(SLICE3_FIELD_NAMES)
+_SYNTAX_MSG = (
+    f"Invalid query syntax. Use a single term like 'genre:\"Science Fiction\"' "
+    f"or 'series:Dune' (valid fields: {_FIELD_LIST})."
+)
+_SINGLE_TERM_MSG = (
+    f"Only a single field:value term is supported in this release "
+    f"(e.g. 'genre:\"Science Fiction\"'). Valid fields: {_FIELD_LIST}."
+)
+_UNSUPPORTED_VALUE_MSG = (
+    "Wildcards, ranges, and comparisons are not supported in this release — "
+    "use an exact field:value, e.g. 'series:Dune'."
+)
+
+
+def parse_collection_query(raw: str) -> CollectionQuery:
+    """Parse and validate a rule-based collection query.
+
+    Parse-permissive, validate-restrictive: luqum parses the full Lucene grammar,
+    then the AST is walked and anything outside the slice-3 subset is rejected. A
+    valid query is exactly one ``field:value`` or ``field:"phrase"`` term over a
+    whitelisted field.
+
+    Raises:
+        CollectionQueryError: on syntax errors, multi-term/boolean queries,
+            unknown/deferred fields, unsupported value shapes (wildcards/ranges),
+            or non-canonical genre values.
+    """
+    text = raw.strip()
+    if not text:
+        raise CollectionQueryError(_SYNTAX_MSG)
+
+    try:
+        tree = parser.parse(text)
+    except ParseError as exc:
+        raise CollectionQueryError(_SYNTAX_MSG) from exc
+
+    # A single field:value term parses to a SearchField at the top level. Anything
+    # else — implicit multi-term (UnknownOperation), explicit AND/OR (And/OrOperation),
+    # NOT, a parenthesised Group, or a bare Word/Phrase with no field — is rejected.
+    if not isinstance(tree, SearchField):
+        raise CollectionQueryError(_SINGLE_TERM_MSG)
+
+    expr = tree.expr
+    if isinstance(expr, Phrase):
+        value = _strip_quotes(expr.value)
+    elif isinstance(expr, Word):
+        value = expr.value
+        if "*" in value or "?" in value:
+            raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
+    else:
+        # Range, Fuzzy, Proximity, etc. — not part of the slice-3 subset.
+        raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
+
+    field = tree.name.lower()
+
+    if field in _DEFERRED_FIELDS:
+        raise CollectionQueryError(
+            f"Field '{field}' is not yet supported — coming in {_DEFERRED_FIELDS[field]}."
+        )
+    if field not in SLICE3_FIELDS:
+        raise CollectionQueryError(
+            f"Unknown field '{tree.name}'. Valid fields: {_FIELD_LIST}."
+        )
+
+    validate_value = SLICE3_FIELDS[field]
+    if validate_value is not None:
+        validate_value(value)
+
+    return CollectionQuery(field=field, value=value)
+
+
+def _strip_quotes(phrase_value: str) -> str:
+    """Strip the surrounding double quotes luqum keeps on a Phrase's value."""
+    if len(phrase_value) >= 2 and phrase_value[0] == '"' and phrase_value[-1] == '"':
+        return phrase_value[1:-1]
+    return phrase_value

--- a/src/bookery/collections/query.py
+++ b/src/bookery/collections/query.py
@@ -37,9 +37,7 @@ def _validate_genre_value(value: str) -> None:
     """Reject non-canonical genres at parse time (mirrors ``get_books_by_genre``)."""
     if not is_canonical_genre(value):
         valid = ", ".join(CANONICAL_GENRES)
-        raise CollectionQueryError(
-            f"'{value}' is not a canonical genre. Valid genres: {valid}."
-        )
+        raise CollectionQueryError(f"'{value}' is not a canonical genre. Valid genres: {valid}.")
 
 
 # The slice-3 field whitelist. Maps each supported field to an optional value
@@ -119,9 +117,7 @@ def parse_collection_query(raw: str) -> CollectionQuery:
             f"Field '{field}' is not yet supported — coming in {_DEFERRED_FIELDS[field]}."
         )
     if field not in SLICE3_FIELDS:
-        raise CollectionQueryError(
-            f"Unknown field '{tree.name}'. Valid fields: {_FIELD_LIST}."
-        )
+        raise CollectionQueryError(f"Unknown field '{tree.name}'. Valid fields: {_FIELD_LIST}.")
 
     validate_value = SLICE3_FIELDS[field]
     if validate_value is not None:

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -1610,8 +1610,7 @@ class LibraryCatalog:
             return []
         placeholders = ",".join("?" * len(book_ids))
         cursor = self._conn.execute(
-            f"SELECT * FROM books WHERE id IN ({placeholders}) "
-            "ORDER BY title_sort COLLATE NOCASE",
+            f"SELECT * FROM books WHERE id IN ({placeholders}) ORDER BY title_sort COLLATE NOCASE",
             book_ids,
         )
         return [row_to_record(row) for row in cursor.fetchall()]

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -1766,62 +1766,67 @@ class LibraryCatalog:
     def list_collection_shelf_candidates(self, *, device_id: int) -> list[dict[str, object]]:
         """Return collections that can be pushed as shelves to a device.
 
-        Returns collections that:
-        - Have at least one book synced to this device
-        - Have a shelf state record (were previously synced)
-        - Or are new collections that need initial sync
-
-        Each candidate includes collection info plus current book count on device.
+        A collection is a candidate when at least one of its members (resolved via
+        the single membership resolver, so rule-based collections are included even
+        though they hold no ``collection_books`` rows) is present on the device.
+        Each candidate carries its current on-device count, total member count, and
+        any existing shelf state.
         """
-        cursor = self._conn.execute(
-            """
-            SELECT
-                c.id AS collection_id,
-                c.name,
-                c.updated_at,
-                COALESCE(dss.shelf_id, NULL) AS shelf_id,
-                COALESCE(dss.last_pushed_at, NULL) AS last_pushed_at,
-                COUNT(DISTINCT df.book_id) AS books_on_device,
-                COUNT(DISTINCT cb.book_id) AS books_in_collection
-            FROM collections c
-            JOIN collection_books cb ON c.id = cb.collection_id
-            JOIN device_files df ON cb.book_id = df.book_id AND df.device_id = ?
-            LEFT JOIN device_shelf_state dss
-                ON dss.collection_id = c.id AND dss.device_id = ?
-            GROUP BY c.id
-            ORDER BY c.name COLLATE NOCASE
-            """,
-            (device_id, device_id),
-        )
-        return [
-            {
-                "collection_id": int(row["collection_id"]),
-                "name": str(row["name"]),
-                "updated_at": str(row["updated_at"]),
-                "shelf_id": row["shelf_id"],
-                "last_pushed_at": row["last_pushed_at"],
-                "books_on_device": int(row["books_on_device"]),
-                "books_in_collection": int(row["books_in_collection"]),
-            }
-            for row in cursor.fetchall()
-        ]
+        device_book_ids = {
+            int(row["book_id"])
+            for row in self._conn.execute(
+                "SELECT book_id FROM device_files WHERE device_id = ?",
+                (device_id,),
+            )
+        }
+        if not device_book_ids:
+            return []
+
+        candidates: list[dict[str, object]] = []
+        collection_rows = self._conn.execute(
+            "SELECT id, name, updated_at FROM collections ORDER BY name COLLATE NOCASE"
+        ).fetchall()
+        for coll in collection_rows:
+            collection_id = int(coll["id"])
+            member_ids = self.resolve_collection_member_ids(collection_id)
+            books_on_device = sum(1 for book_id in member_ids if book_id in device_book_ids)
+            if books_on_device == 0:
+                continue
+
+            state = self._conn.execute(
+                "SELECT shelf_id, last_pushed_at FROM device_shelf_state "
+                "WHERE collection_id = ? AND device_id = ?",
+                (collection_id, device_id),
+            ).fetchone()
+            candidates.append(
+                {
+                    "collection_id": collection_id,
+                    "name": str(coll["name"]),
+                    "updated_at": str(coll["updated_at"]),
+                    "shelf_id": state["shelf_id"] if state is not None else None,
+                    "last_pushed_at": state["last_pushed_at"] if state is not None else None,
+                    "books_on_device": books_on_device,
+                    "books_in_collection": len(member_ids),
+                }
+            )
+        return candidates
 
     def list_collection_device_paths(self, *, collection_id: int, device_id: int) -> list[str]:
         """Return device remote paths for books in a collection that are on a device.
 
-        Only books that are both members of the collection and present on the
-        device (via device_files) are returned, ordered deterministically. The
-        caller turns these into Kobo ContentIDs by prefixing ``file://``.
+        Membership comes from the resolver (so it is correct for both static and
+        rule-based collections); only members also present on the device (via
+        ``device_files``) are returned, ordered deterministically. The caller
+        turns these into Kobo ContentIDs by prefixing ``file://``.
         """
+        member_ids = self.resolve_collection_member_ids(collection_id)
+        if not member_ids:
+            return []
+        placeholders = ",".join("?" * len(member_ids))
         cursor = self._conn.execute(
-            """
-            SELECT df.remote_path
-            FROM collection_books cb
-            JOIN device_files df
-                ON cb.book_id = df.book_id AND df.device_id = ?
-            WHERE cb.collection_id = ?
-            ORDER BY df.remote_path
-            """,
-            (device_id, collection_id),
+            f"SELECT df.remote_path FROM device_files df "
+            f"WHERE df.device_id = ? AND df.book_id IN ({placeholders}) "
+            f"ORDER BY df.remote_path",
+            [device_id, *member_ids],
         )
         return [str(row["remote_path"]) for row in cursor.fetchall()]

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -5,6 +5,7 @@ import json
 import sqlite3
 from pathlib import Path
 
+from bookery.collections import CollectionQuery, parse_collection_query
 from bookery.core.dedup import (
     normalize_author_for_dedup,
     normalize_for_dedup,
@@ -1282,12 +1283,18 @@ class LibraryCatalog:
 
     # --- Collection operations (SCHEMA_V11) ----------------------------
 
-    def create_collection(self, name: str, description: str | None = None) -> int:
+    def create_collection(
+        self, name: str, description: str | None = None, query: str | None = None
+    ) -> int:
         """Create a new collection.
 
         Args:
             name: The collection name (unique, case-insensitive).
             description: Optional description of the collection.
+            query: Optional rule query. When non-None the collection is
+                rule-based (membership derived live from the query); when None
+                it is static (explicit membership via ``collection_books``). The
+                two kinds are mutually exclusive.
 
         Returns:
             The row ID of the inserted collection.
@@ -1296,8 +1303,8 @@ class LibraryCatalog:
             sqlite3.IntegrityError: If a collection with this name already exists.
         """
         cursor = self._conn.execute(
-            "INSERT INTO collections (name, description) VALUES (?, ?)",
-            (name, description),
+            "INSERT INTO collections (name, description, query) VALUES (?, ?, ?)",
+            (name, description, query),
         )
         self._conn.commit()
         assert cursor.lastrowid is not None
@@ -1307,10 +1314,12 @@ class LibraryCatalog:
         """Retrieve a collection by its ID.
 
         Returns:
-            Dict with collection fields, or None if not found.
+            Dict with collection fields (including ``query``), or None if not found.
+            ``query`` is None for static collections, the rule string otherwise.
         """
         row = self._conn.execute(
-            "SELECT id, name, description, created_at, updated_at FROM collections WHERE id = ?",
+            "SELECT id, name, description, query, created_at, updated_at "
+            "FROM collections WHERE id = ?",
             (collection_id,),
         ).fetchone()
         if row is None:
@@ -1319,6 +1328,7 @@ class LibraryCatalog:
             "id": row["id"],
             "name": row["name"],
             "description": row["description"],
+            "query": row["query"],
             "created_at": row["created_at"],
             "updated_at": row["updated_at"],
         }
@@ -1327,10 +1337,10 @@ class LibraryCatalog:
         """Retrieve a collection by its name (case-insensitive).
 
         Returns:
-            Dict with collection fields, or None if not found.
+            Dict with collection fields (including ``query``), or None if not found.
         """
         row = self._conn.execute(
-            "SELECT id, name, description, created_at, updated_at "
+            "SELECT id, name, description, query, created_at, updated_at "
             "FROM collections WHERE name = ? COLLATE NOCASE",
             (name,),
         ).fetchone()
@@ -1340,6 +1350,7 @@ class LibraryCatalog:
             "id": row["id"],
             "name": row["name"],
             "description": row["description"],
+            "query": row["query"],
             "created_at": row["created_at"],
             "updated_at": row["updated_at"],
         }
@@ -1407,14 +1418,17 @@ class LibraryCatalog:
         self._conn.commit()
 
     def list_collections(self) -> list[dict[str, object]]:
-        """List all collections with their book counts.
+        """List all collections with their (live) book counts.
 
         Returns:
-            List of dicts with collection fields plus 'book_count'.
+            List of dicts with collection fields plus 'book_count'. For static
+            collections the count is the number of ``collection_books`` rows; for
+            rule-based collections (``query`` set) it is the live-resolved member
+            count, since those hold no ``collection_books`` rows.
         """
         cursor = self._conn.execute(
             """
-            SELECT c.id, c.name, c.description, c.created_at, c.updated_at,
+            SELECT c.id, c.name, c.description, c.query, c.created_at, c.updated_at,
                    COUNT(cb.book_id) AS book_count
             FROM collections c
             LEFT JOIN collection_books cb ON c.id = cb.collection_id
@@ -1422,20 +1436,36 @@ class LibraryCatalog:
             ORDER BY c.name COLLATE NOCASE
             """
         )
-        return [
-            {
-                "id": row["id"],
-                "name": row["name"],
-                "description": row["description"],
-                "created_at": row["created_at"],
-                "updated_at": row["updated_at"],
-                "book_count": row["book_count"],
-            }
-            for row in cursor.fetchall()
-        ]
+        collections: list[dict[str, object]] = []
+        for row in cursor.fetchall():
+            query = row["query"]
+            # Rule-based collections keep zero collection_books rows, so the JOIN
+            # count is always 0 — resolve their membership live instead.
+            book_count = (
+                len(self.resolve_collection_member_ids(int(row["id"])))
+                if query is not None
+                else row["book_count"]
+            )
+            collections.append(
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "description": row["description"],
+                    "query": query,
+                    "created_at": row["created_at"],
+                    "updated_at": row["updated_at"],
+                    "book_count": book_count,
+                }
+            )
+        return collections
 
     def get_collection_books(self, collection_id: int) -> list[BookRecord]:
         """Get all books in a collection, ordered by title_sort.
+
+        Works for both kinds: static collections read ``collection_books``,
+        rule-based collections resolve their membership live from the query. This
+        is a thin alias for :meth:`resolve_collection_members`, kept for existing
+        callers (web detail, CLI ``show``).
 
         Args:
             collection_id: The ID of the collection.
@@ -1446,17 +1476,143 @@ class LibraryCatalog:
         Raises:
             ValueError: If the collection doesn't exist.
         """
+        return self.resolve_collection_members(collection_id)
+
+    # --- Rule-based collection resolution (SCHEMA_V14, issue #240) -----
+
+    def resolve_collection_member_ids(self, collection_id: int) -> list[int]:
+        """Return the book IDs that belong to a collection.
+
+        The sole membership entry point for both kinds. Static collections
+        (``query IS NULL``) read explicit ``collection_books`` rows; rule-based
+        collections (``query`` set) derive membership live by parsing and
+        compiling the query. No caching — rule-based membership is recomputed on
+        each call so it is never stale.
+
+        Raises:
+            ValueError: If the collection doesn't exist.
+            CollectionQueryError: If a stored rule query is invalid.
+        """
+        collection = self.get_collection_by_id(collection_id)
+        if collection is None:
+            raise ValueError(f"Collection {collection_id} not found")
+
+        query = collection["query"]
+        if query is None:
+            cursor = self._conn.execute(
+                "SELECT book_id FROM collection_books WHERE collection_id = ?",
+                (collection_id,),
+            )
+            return [int(row["book_id"]) for row in cursor.fetchall()]
+
+        compiled = parse_collection_query(str(query))
+        return self._compile_query_member_ids(compiled)
+
+    def resolve_collection_members(self, collection_id: int) -> list[BookRecord]:
+        """Return the books in a collection as records, ordered by title_sort.
+
+        Raises:
+            ValueError: If the collection doesn't exist.
+            CollectionQueryError: If a stored rule query is invalid.
+        """
+        member_ids = self.resolve_collection_member_ids(collection_id)
+        return self._fetch_books_ordered(member_ids)
+
+    def preview_query(self, query: str) -> list[BookRecord]:
+        """Resolve a one-shot rule query to its matching books without saving.
+
+        Raises:
+            CollectionQueryError: If the query is invalid or unsupported.
+        """
+        compiled = parse_collection_query(query)
+        member_ids = self._compile_query_member_ids(compiled)
+        return self._fetch_books_ordered(member_ids)
+
+    def set_collection_query(self, collection_id: int, query: str) -> None:
+        """Convert a collection to rule-based with the given query.
+
+        Validates the query first (so an invalid query never mutates state), then
+        drops any existing ``collection_books`` rows — a rule-based collection is
+        mutually exclusive with static membership and holds none.
+
+        Raises:
+            ValueError: If the collection doesn't exist.
+            CollectionQueryError: If the query is invalid or unsupported.
+        """
+        parse_collection_query(query)  # validate before any write
         if self.get_collection_by_id(collection_id) is None:
             raise ValueError(f"Collection {collection_id} not found")
 
-        cursor = self._conn.execute(
-            """
-            SELECT b.* FROM books b
-            JOIN collection_books cb ON b.id = cb.book_id
-            WHERE cb.collection_id = ?
-            ORDER BY b.title_sort COLLATE NOCASE
-            """,
+        self._conn.execute(
+            "DELETE FROM collection_books WHERE collection_id = ?",
             (collection_id,),
+        )
+        self._conn.execute(
+            "UPDATE collections SET query = ?, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%S', 'now') WHERE id = ?",
+            (query, collection_id),
+        )
+        self._conn.commit()
+
+    def clear_collection_query(self, collection_id: int) -> None:
+        """Convert a rule-based collection to static, snapshotting current members.
+
+        The live-resolved members are written into ``collection_books`` before the
+        query is cleared, so the collection keeps exactly the books it matched at
+        conversion time.
+
+        Raises:
+            ValueError: If the collection doesn't exist.
+        """
+        collection = self.get_collection_by_id(collection_id)
+        if collection is None:
+            raise ValueError(f"Collection {collection_id} not found")
+
+        # Resolve while still rule-based, then snapshot before clearing the query.
+        member_ids = self.resolve_collection_member_ids(collection_id)
+        self._conn.executemany(
+            "INSERT OR IGNORE INTO collection_books (collection_id, book_id) VALUES (?, ?)",
+            [(collection_id, book_id) for book_id in member_ids],
+        )
+        self._conn.execute(
+            "UPDATE collections SET query = NULL, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%S', 'now') WHERE id = ?",
+            (collection_id,),
+        )
+        self._conn.commit()
+
+    def _compile_query_member_ids(self, query: CollectionQuery) -> list[int]:
+        """Compile a validated query into the matching book IDs (per-field SQL).
+
+        The query module guarantees ``field`` is a whitelisted slice-3 field and
+        ``value`` passed its per-field validation, so this only constructs SQL.
+        """
+        if query.field == "series":
+            cursor = self._conn.execute(
+                "SELECT id FROM books WHERE series = ? COLLATE NOCASE",
+                (query.value,),
+            )
+        elif query.field == "genre":
+            cursor = self._conn.execute(
+                "SELECT b.id FROM books b "
+                "JOIN book_genres bg ON b.id = bg.book_id "
+                "JOIN genres g ON bg.genre_id = g.id "
+                "WHERE g.name = ?",
+                (query.value,),
+            )
+        else:  # pragma: no cover - guarded by the query validator
+            raise ValueError(f"Unsupported query field: {query.field}")
+        return [int(row[0]) for row in cursor.fetchall()]
+
+    def _fetch_books_ordered(self, book_ids: list[int]) -> list[BookRecord]:
+        """Fetch the given books as records, ordered by title_sort."""
+        if not book_ids:
+            return []
+        placeholders = ",".join("?" * len(book_ids))
+        cursor = self._conn.execute(
+            f"SELECT * FROM books WHERE id IN ({placeholders}) "
+            "ORDER BY title_sort COLLATE NOCASE",
+            book_ids,
         )
         return [row_to_record(row) for row in cursor.fetchall()]
 

--- a/src/bookery/db/schema.py
+++ b/src/bookery/db/schema.py
@@ -324,6 +324,16 @@ ALTER TABLE device_shelf_state ADD COLUMN member_hash TEXT;
 INSERT INTO schema_version (version) VALUES (13);
 """
 
+# V14: Rule-based collections (issue #240). A nullable `query` column makes a
+# collection's kind a function of the column: NULL = static (explicit rows in
+# collection_books), non-NULL = rule-based (membership derived live from the
+# query). The two are mutually exclusive. Forward-only ALTER on the V11 table.
+SCHEMA_V14 = """
+ALTER TABLE collections ADD COLUMN query TEXT;
+
+INSERT INTO schema_version (version) VALUES (14);
+"""
+
 MIGRATIONS = [
     (2, SCHEMA_V2),
     (3, SCHEMA_V3),
@@ -337,6 +347,7 @@ MIGRATIONS = [
     (11, SCHEMA_V11),
     (12, SCHEMA_V12),
     (13, SCHEMA_V13),
+    (14, SCHEMA_V14),
 ]
 
 # The schema version a freshly-opened library converges to. Derived from the

--- a/src/bookery/web/templates/_collection_detail.html
+++ b/src/bookery/web/templates/_collection_detail.html
@@ -4,11 +4,18 @@
     {% if collection.description %}
     <p class="description">{{ collection.description }}</p>
     {% endif %}
+    {% if collection.query %}
+    <p class="collection-query">
+        <span class="query-label">Rule:</span> <code>{{ collection.query }}</code>
+    </p>
+    {% endif %}
 </header>
 
 {% if books %}
 <section class="books-in-collection" aria-labelledby="books-heading">
-    <h2 id="books-heading">{{ books|length }} book{% if books|length != 1 %}s{% endif %}</h2>
+    <h2 id="books-heading">
+        {% if collection.query %}Matches: {% endif %}{{ books|length }} book{% if books|length != 1 %}s{% endif %}
+    </h2>
     <ul class="book-list">
         {% for book in books %}
         <li>
@@ -18,13 +25,18 @@
             {% if book.metadata.authors %}
             <span class="authors">by {{ book.metadata.authors|join(", ") }}</span>
             {% endif %}
+            {# Manual removal only applies to static collections; rule-based membership is derived. #}
+            {% if not collection.query %}
             <form method="POST" action="{{ url_for('web.collection_remove_book', collection_id=collection.id, book_id=book.id) }}" class="inline-form">
                 <button type="submit" class="btn-small">Remove</button>
             </form>
+            {% endif %}
         </li>
         {% endfor %}
     </ul>
 </section>
 {% else %}
-<p class="empty">No books in this collection yet.</p>
+<p class="empty">
+    {% if collection.query %}No books match this rule yet.{% else %}No books in this collection yet.{% endif %}
+</p>
 {% endif %}

--- a/tests/e2e/test_collection_cli.py
+++ b/tests/e2e/test_collection_cli.py
@@ -182,3 +182,142 @@ class TestCollectionsWorkflow:
         assert "Book 1" not in result.output
         assert "Book 2" in result.output
         assert "1 book(s)" in result.output
+
+
+def _seed_sci_fi(db_path: Path) -> int:
+    """Add a Science Fiction book to the library and return its ID."""
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    book_id = catalog.add_book(
+        BookMetadata(title="Foundation", series="Foundation", source_path=Path("/books/f.epub")),
+        file_hash="sf_hash",
+    )
+    catalog.add_genre(book_id, "Science Fiction", is_primary=True)
+    conn.close()
+    return book_id
+
+
+class TestQueryBasedCollectionsCLI:
+    """E2E tests for slice-3 rule-based collection commands."""
+
+    def test_create_with_query_is_rule_based(self, runner: CliRunner, db_path: Path) -> None:
+        _seed_sci_fi(db_path)
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Sci-Fi",
+             "--query", 'genre:"Science Fiction"'],
+        )
+        assert result.exit_code == 0
+
+        show = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
+        assert 'genre:"Science Fiction"' in show.output
+        assert "Foundation" in show.output
+
+    def test_create_with_invalid_query_fails(self, runner: CliRunner, db_path: Path) -> None:
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Bad", "--query", "publisher:Tor"],
+        )
+        assert result.exit_code != 0
+        assert "series" in result.output and "genre" in result.output
+
+    def test_preview_counts_without_saving(self, runner: CliRunner, db_path: Path) -> None:
+        _seed_sci_fi(db_path)
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "preview", "--query",
+             'genre:"Science Fiction"'],
+        )
+        assert result.exit_code == 0
+        assert "Foundation" in result.output
+
+        # Nothing persisted.
+        ls = runner.invoke(cli, ["--db", str(db_path), "collections", "ls"])
+        assert "No collections" in ls.output
+
+    def test_show_displays_query_and_live_count(self, runner: CliRunner, db_path: Path) -> None:
+        _seed_sci_fi(db_path)
+        runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Sci-Fi",
+             "--query", 'genre:"Science Fiction"'],
+        )
+        result = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
+        assert 'genre:"Science Fiction"' in result.output
+        assert "1 book(s)" in result.output
+
+    def test_edit_query_converts_static_to_rule(self, runner: CliRunner, db_path: Path) -> None:
+        _seed_sci_fi(db_path)
+        runner.invoke(cli, ["--db", str(db_path), "collections", "create", "Sci-Fi"])
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "edit", "1", "--query",
+             'genre:"Science Fiction"'],
+        )
+        assert result.exit_code == 0
+
+        show = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
+        assert 'genre:"Science Fiction"' in show.output
+        assert "Foundation" in show.output
+
+    def test_edit_clear_query_snapshots_to_static(
+        self, runner: CliRunner, db_path: Path
+    ) -> None:
+        _seed_sci_fi(db_path)
+        runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Sci-Fi",
+             "--query", 'genre:"Science Fiction"'],
+        )
+        result = runner.invoke(
+            cli, ["--db", str(db_path), "collections", "edit", "1", "--clear-query"]
+        )
+        assert result.exit_code == 0
+
+        show = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
+        # Query no longer shown; the snapshotted member remains.
+        assert 'genre:"Science Fiction"' not in show.output
+        assert "Foundation" in show.output
+
+    def test_edit_requires_exactly_one_flag(self, runner: CliRunner, db_path: Path) -> None:
+        runner.invoke(cli, ["--db", str(db_path), "collections", "create", "Sci-Fi"])
+
+        neither = runner.invoke(cli, ["--db", str(db_path), "collections", "edit", "1"])
+        assert neither.exit_code != 0
+
+        both = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "edit", "1", "--query", "series:X",
+             "--clear-query"],
+        )
+        assert both.exit_code != 0
+
+    def test_author_query_returns_slice4_deferral(self, runner: CliRunner, db_path: Path) -> None:
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Auth", "--query",
+             'author:"Frank Herbert"'],
+        )
+        assert result.exit_code != 0
+        assert "#236" in result.output
+
+    def test_multi_term_query_is_rejected(self, runner: CliRunner, db_path: Path) -> None:
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Multi", "--query",
+             "genre:SF series:Dune"],
+        )
+        assert result.exit_code != 0
+        assert "single" in result.output.lower()
+
+    def test_non_canonical_genre_is_rejected(self, runner: CliRunner, db_path: Path) -> None:
+        result = runner.invoke(
+            cli,
+            ["--db", str(db_path), "collections", "create", "Borg", "--query",
+             'genre:"Borg Romance"'],
+        )
+        assert result.exit_code != 0
+        # Rich may wrap the long genre list across lines, so assert on stable
+        # fragments rather than a single (potentially wrapped) genre name.
+        assert "canonical genre" in result.output
+        assert "Valid genres" in result.output

--- a/tests/integration/test_sync_collection_shelves.py
+++ b/tests/integration/test_sync_collection_shelves.py
@@ -225,3 +225,40 @@ def test_deleting_collection_removes_shelf(tmp_path: Path) -> None:
         )
         == []
     )
+
+
+def test_rule_based_collection_auto_updates_on_next_sync(tmp_path: Path) -> None:
+    """A new matching book joins a rule-based shelf on the next sync, no manual edit."""
+    conn = open_library(tmp_path / "library.db")
+    catalog = LibraryCatalog(conn)
+
+    library = tmp_path / "library"
+    epub1 = _add_library_book(library, "Asimov", "Foundation")
+    book1 = _add_catalog_book(catalog, epub1, "Foundation", "Asimov")
+    catalog.add_genre(book1, "Science Fiction", is_primary=True)
+
+    collection_id = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+
+    mount = _build_fake_kobo_mount(tmp_path)
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync1")
+
+    first = _query(
+        _shelf_db(mount),
+        "SELECT ContentId FROM ShelfContent WHERE ShelfName = ?",
+        (f"bookery-{collection_id}",),
+    )
+    assert len(first) == 1
+
+    # Import a second matching book — membership is derived, so no add-books call.
+    epub2 = _add_library_book(library, "Gibson", "Neuromancer")
+    book2 = _add_catalog_book(catalog, epub2, "Neuromancer", "Gibson")
+    catalog.add_genre(book2, "Science Fiction", is_primary=True)
+
+    _run_sync(catalog=catalog, mount=mount, tmp_path=tmp_path / "sync2")
+
+    second = _query(
+        _shelf_db(mount),
+        "SELECT ContentId FROM ShelfContent WHERE ShelfName = ?",
+        (f"bookery-{collection_id}",),
+    )
+    assert len(second) == 2

--- a/tests/unit/test_collection_query.py
+++ b/tests/unit/test_collection_query.py
@@ -1,0 +1,104 @@
+# ABOUTME: Unit tests for the pure collections query parser/validator module.
+# ABOUTME: Covers the slice-3 single-field equality subset and its error UX.
+
+import pytest
+
+from bookery.collections import (
+    CollectionQuery,
+    CollectionQueryError,
+    parse_collection_query,
+)
+from bookery.metadata.genres import CANONICAL_GENRES
+
+
+class TestValidQueries:
+    def test_quoted_phrase_value(self) -> None:
+        cq = parse_collection_query('genre:"Science Fiction"')
+        assert cq == CollectionQuery(field="genre", value="Science Fiction")
+
+    def test_bare_word_value(self) -> None:
+        cq = parse_collection_query("series:Dune")
+        assert cq == CollectionQuery(field="series", value="Dune")
+
+    def test_series_quoted_multiword(self) -> None:
+        cq = parse_collection_query('series:"The Lord of the Rings"')
+        assert cq.field == "series"
+        assert cq.value == "The Lord of the Rings"
+
+    def test_field_name_is_case_insensitive(self) -> None:
+        cq = parse_collection_query('GENRE:"Science Fiction"')
+        assert cq.field == "genre"
+
+    def test_genre_value_is_case_insensitive(self) -> None:
+        # Canonical match is case-insensitive; the raw value is preserved.
+        cq = parse_collection_query('genre:"science fiction"')
+        assert cq.field == "genre"
+        assert cq.value == "science fiction"
+
+    def test_surrounding_whitespace_is_ignored(self) -> None:
+        cq = parse_collection_query("  series:Dune  ")
+        assert cq == CollectionQuery(field="series", value="Dune")
+
+
+class TestFieldValidation:
+    def test_unknown_field_lists_whitelist(self) -> None:
+        with pytest.raises(CollectionQueryError) as exc:
+            parse_collection_query("publisher:Tor")
+        msg = str(exc.value)
+        assert "publisher" in msg
+        assert "series" in msg and "genre" in msg
+
+    def test_author_returns_slice4_deferral(self) -> None:
+        with pytest.raises(CollectionQueryError) as exc:
+            parse_collection_query('author:"Frank Herbert"')
+        msg = str(exc.value)
+        assert "#236" in msg
+        # Must be the specific deferral, not the generic unknown-field error.
+        assert "Unknown field" not in msg
+
+    def test_non_canonical_genre_lists_valid_genres(self) -> None:
+        with pytest.raises(CollectionQueryError) as exc:
+            parse_collection_query('genre:"Borg Romance"')
+        msg = str(exc.value)
+        assert "Borg Romance" in msg
+        # A sampling of canonical genres should be named in the message.
+        assert "Science Fiction" in msg
+        assert all(g in msg for g in CANONICAL_GENRES)
+
+
+class TestRejectedShapes:
+    def test_multi_term_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("genre:SF series:Y")
+
+    def test_explicit_and_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query('genre:"Science Fiction" AND series:Dune')
+
+    def test_explicit_or_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query('genre:"Science Fiction" OR genre:Fantasy')
+
+    def test_explicit_not_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("NOT genre:Horror")
+
+    def test_bare_term_without_field_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("Dune")
+
+    def test_wildcard_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("series:Sci*")
+
+    def test_range_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("series:[a TO b]")
+
+    def test_empty_query_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("")
+
+    def test_garbage_syntax_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("genre:")

--- a/tests/unit/test_collection_query_resolver.py
+++ b/tests/unit/test_collection_query_resolver.py
@@ -1,0 +1,167 @@
+# ABOUTME: Unit tests for rule-based collection membership resolution on LibraryCatalog.
+# ABOUTME: Covers the V14 query column, the resolver, preview, and static<->rule conversion.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.collections import CollectionQueryError
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> LibraryCatalog:
+    conn = open_library(tmp_path / "resolver_test.db")
+    return LibraryCatalog(conn)
+
+
+def _add(
+    catalog: LibraryCatalog,
+    title: str,
+    *,
+    series: str | None = None,
+    genre: str | None = None,
+) -> int:
+    book_id = catalog.add_book(
+        BookMetadata(title=title, series=series, source_path=Path(f"/books/{title}.epub")),
+        file_hash=f"hash_{title}",
+    )
+    if genre is not None:
+        catalog.add_genre(book_id, genre, is_primary=True)
+    return book_id
+
+
+def _query_of(catalog: LibraryCatalog, collection_id: int) -> object:
+    collection = catalog.get_collection_by_id(collection_id)
+    assert collection is not None
+    return collection["query"]
+
+
+class TestMigrationV14:
+    def test_query_column_exists(self, tmp_path: Path) -> None:
+        conn = open_library(tmp_path / "v14.db")
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(collections)")}
+        assert "query" in cols
+        conn.close()
+
+
+class TestQueryStorage:
+    def test_create_without_query_is_static(self, catalog: LibraryCatalog) -> None:
+        cid = catalog.create_collection("Manual")
+        assert _query_of(catalog, cid) is None
+
+    def test_create_with_query_is_rule_based(self, catalog: LibraryCatalog) -> None:
+        cid = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+        assert _query_of(catalog, cid) == 'genre:"Science Fiction"'
+
+
+class TestResolveMembers:
+    def test_static_resolves_to_collection_books(self, catalog: LibraryCatalog) -> None:
+        a = _add(catalog, "A")
+        b = _add(catalog, "B")
+        cid = catalog.create_collection("Manual")
+        catalog.add_books_to_collection(cid, [a, b])
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([a, b])
+
+    def test_rule_series_equality_is_case_insensitive(self, catalog: LibraryCatalog) -> None:
+        d1 = _add(catalog, "Dune", series="Dune")
+        d2 = _add(catalog, "Dune Messiah", series="dune")
+        _add(catalog, "Neuromancer", series="Sprawl")
+        cid = catalog.create_collection("Dune books", query='series:"Dune"')
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([d1, d2])
+
+    def test_rule_genre_join(self, catalog: LibraryCatalog) -> None:
+        sf1 = _add(catalog, "SF One", genre="Science Fiction")
+        sf2 = _add(catalog, "SF Two", genre="Science Fiction")
+        _add(catalog, "A Fantasy", genre="Fantasy")
+        cid = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([sf1, sf2])
+
+    def test_resolve_members_returns_records_ordered_by_title_sort(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        _add(catalog, "The Border", series="Edge")  # title_sort "Border"
+        _add(catalog, "Apex", series="Edge")
+        cid = catalog.create_collection("Edge", query="series:Edge")
+        titles = [r.metadata.title for r in catalog.resolve_collection_members(cid)]
+        assert titles == ["Apex", "The Border"]
+
+    def test_unknown_collection_raises(self, catalog: LibraryCatalog) -> None:
+        with pytest.raises(ValueError):
+            catalog.resolve_collection_member_ids(999)
+
+    def test_get_collection_books_uses_resolver_for_rule_based(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        sf = _add(catalog, "SF One", genre="Science Fiction")
+        cid = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+        assert [r.id for r in catalog.get_collection_books(cid)] == [sf]
+
+
+class TestPreviewQuery:
+    def test_preview_returns_records_without_saving(self, catalog: LibraryCatalog) -> None:
+        _add(catalog, "SF One", genre="Science Fiction")
+        before = len(catalog.list_collections())
+        records = catalog.preview_query('genre:"Science Fiction"')
+        assert len(records) == 1
+        assert len(catalog.list_collections()) == before  # nothing persisted
+
+    def test_preview_invalid_query_raises(self, catalog: LibraryCatalog) -> None:
+        with pytest.raises(CollectionQueryError):
+            catalog.preview_query("publisher:Tor")
+
+
+class TestConversion:
+    def test_set_query_converts_static_to_rule_and_clears_rows(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        manual = _add(catalog, "Manual Pick")
+        sf = _add(catalog, "SF One", genre="Science Fiction")
+        cid = catalog.create_collection("Mixed")
+        catalog.add_books_to_collection(cid, [manual])
+
+        catalog.set_collection_query(cid, 'genre:"Science Fiction"')
+
+        assert _query_of(catalog, cid) == 'genre:"Science Fiction"'
+        # Static rows are dropped — a rule-based collection holds zero of them.
+        rows = catalog._conn.execute(
+            "SELECT book_id FROM collection_books WHERE collection_id = ?", (cid,)
+        ).fetchall()
+        assert rows == []
+        assert catalog.resolve_collection_member_ids(cid) == [sf]
+
+    def test_clear_query_snapshots_members_into_static(self, catalog: LibraryCatalog) -> None:
+        sf1 = _add(catalog, "SF One", genre="Science Fiction")
+        sf2 = _add(catalog, "SF Two", genre="Science Fiction")
+        cid = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+
+        catalog.clear_collection_query(cid)
+
+        assert _query_of(catalog, cid) is None
+        snapshot = {
+            row["book_id"]
+            for row in catalog._conn.execute(
+                "SELECT book_id FROM collection_books WHERE collection_id = ?", (cid,)
+            )
+        }
+        assert snapshot == {sf1, sf2}
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([sf1, sf2])
+
+    def test_set_invalid_query_raises_and_does_not_persist(
+        self, catalog: LibraryCatalog
+    ) -> None:
+        cid = catalog.create_collection("X")
+        with pytest.raises(CollectionQueryError):
+            catalog.set_collection_query(cid, "publisher:Tor")
+        assert _query_of(catalog, cid) is None
+
+
+class TestListCollectionsLiveCount:
+    def test_rule_based_count_is_live(self, catalog: LibraryCatalog) -> None:
+        _add(catalog, "SF One", genre="Science Fiction")
+        _add(catalog, "SF Two", genre="Science Fiction")
+        catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+        row = next(c for c in catalog.list_collections() if c["name"] == "Sci-Fi")
+        assert row["book_count"] == 2

--- a/tests/unit/test_device_shelf_state.py
+++ b/tests/unit/test_device_shelf_state.py
@@ -300,3 +300,73 @@ class TestListCollectionDevicePaths:
             collection_id=collection_id, device_id=device_id
         )
         assert paths == []
+
+
+class TestRuleBasedSyncMembership:
+    """Sync membership for rule-based collections (derived, no collection_books rows)."""
+
+    def _add_sf_and_fantasy(self, catalog: LibraryCatalog) -> tuple[int, int]:
+        sf = catalog.add_book(
+            BookMetadata(title="SF Book", source_path=Path("/books/sf.epub")),
+            file_hash="hash_sf",
+        )
+        catalog.add_genre(sf, "Science Fiction", is_primary=True)
+        fantasy = catalog.add_book(
+            BookMetadata(title="Fantasy Book", source_path=Path("/books/fan.epub")),
+            file_hash="hash_fan",
+        )
+        catalog.add_genre(fantasy, "Fantasy", is_primary=True)
+        return sf, fantasy
+
+    def test_device_paths_for_rule_based_collection(
+        self, catalog: LibraryCatalog, device_id: int
+    ) -> None:
+        """Device paths come from the derived membership, not collection_books."""
+        sf, fantasy = self._add_sf_and_fantasy(catalog)
+        cid = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=sf,
+            remote_path="/mnt/onboard/Bookery/SF/SF.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=fantasy,
+            remote_path="/mnt/onboard/Bookery/Fan/Fan.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+
+        paths = catalog.list_collection_device_paths(collection_id=cid, device_id=device_id)
+
+        assert paths == ["/mnt/onboard/Bookery/SF/SF.kepub.epub"]
+
+    def test_candidates_include_rule_based_with_on_device_member(
+        self, catalog: LibraryCatalog, device_id: int
+    ) -> None:
+        """A rule-based collection with a derived member on device is a candidate."""
+        sf, _fantasy = self._add_sf_and_fantasy(catalog)
+        cid = catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+        catalog.upsert_device_file(
+            device_id=device_id,
+            book_id=sf,
+            remote_path="/mnt/onboard/Bookery/SF/SF.kepub.epub",
+            now="2024-01-15T10:00:00",
+        )
+
+        candidates = catalog.list_collection_shelf_candidates(device_id=device_id)
+
+        by_id = {c["collection_id"]: c for c in candidates}
+        assert cid in by_id
+        assert by_id[cid]["name"] == "Sci-Fi"
+        assert by_id[cid]["books_on_device"] == 1
+        assert by_id[cid]["books_in_collection"] == 1
+
+    def test_rule_based_without_on_device_member_is_not_candidate(
+        self, catalog: LibraryCatalog, device_id: int
+    ) -> None:
+        """A rule-based collection whose members aren't on the device is excluded."""
+        self._add_sf_and_fantasy(catalog)  # books exist but none on the device
+        catalog.create_collection("Sci-Fi", query='genre:"Science Fiction"')
+
+        assert catalog.list_collection_shelf_candidates(device_id=device_id) == []

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from bookery.db.connection import _apply_migrations, _get_schema_version, open_library
-from bookery.db.schema import MIGRATIONS
+from bookery.db.schema import LATEST_SCHEMA_VERSION, MIGRATIONS
 
 
 @pytest.fixture()
@@ -24,7 +24,7 @@ class TestMigrations:
         conn = open_library(db_path)
         version = _get_schema_version(conn)
         conn.close()
-        assert version == 13
+        assert version == LATEST_SCHEMA_VERSION
 
     def test_migrations_list_is_ordered(self) -> None:
         """MIGRATIONS list has strictly increasing version numbers."""
@@ -126,7 +126,7 @@ class TestMigrations:
         # Now open with bookery — should auto-migrate
         conn = open_library(db_path)
         version = _get_schema_version(conn)
-        assert version == 13
+        assert version == LATEST_SCHEMA_VERSION
 
         # Tags table should exist
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'")

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -482,3 +482,53 @@ class TestUpdateBook:
         assert response.status_code == 200
         call_kwargs = mock_catalog.update_book.call_args[1]
         assert call_kwargs["series_index"] is None
+
+
+class TestCollectionDetail:
+    def _rule_based(self) -> dict:
+        return {
+            "id": 1,
+            "name": "Sci-Fi",
+            "description": None,
+            "query": 'genre:"Science Fiction"',
+            "created_at": "2026-01-01",
+            "updated_at": "2026-01-01",
+        }
+
+    def _static(self) -> dict:
+        return {
+            "id": 2,
+            "name": "Manual",
+            "description": None,
+            "query": None,
+            "created_at": "2026-01-01",
+            "updated_at": "2026-01-01",
+        }
+
+    def test_rule_based_shows_query_and_live_count(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = self._rule_based()
+        mock_catalog.get_collection_books.return_value = [_make_book(1, title="Foundation")]
+
+        response = client.get("/collections/1")
+        html = response.data.decode()
+
+        assert response.status_code == 200
+        assert "genre:" in html and "Science Fiction" in html
+        assert "Foundation" in html
+        assert "Matches:" in html
+
+    def test_rule_based_hides_manual_remove_controls(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = self._rule_based()
+        mock_catalog.get_collection_books.return_value = [_make_book(1, title="Foundation")]
+
+        html = client.get("/collections/1").data.decode()
+
+        assert "/remove-book/" not in html
+
+    def test_static_shows_manual_remove_controls(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = self._static()
+        mock_catalog.get_collection_books.return_value = [_make_book(1, title="Foundation")]
+
+        html = client.get("/collections/2").data.decode()
+
+        assert "/remove-book/" in html


### PR DESCRIPTION
## Summary

Slice 3 of the Collections epic (#179). Adds **rule-based** collections whose membership is derived live from a single-field equality query (`series:` or `genre:`), so a collection like "All my Sci-Fi books" stays current automatically as books are imported — no manual re-curation. Static (hand-picked) and rule-based collections are mutually exclusive, keyed off a new nullable `collections.query` column.

## Changes

- **`collections/` (new pure module)** — `parse_collection_query` validates the slice-3 subset (parse-permissive with luqum's full grammar, then validate-restrictive down to exactly one `field:value`/`field:"phrase"` term). Quarantines the new `luqum` dependency; no DB import. Specific error messages for unknown field, `author:` (slice-4 deferral), multi-term/boolean, wildcards/ranges, and non-canonical genre.
- **`db/schema.py`** — V14 migration adds the nullable `query` column.
- **`db/catalog.py`** — single membership resolver (`resolve_collection_member_ids` / `resolve_collection_members`) that all read paths funnel through; per-field SQL compiler (series equality `COLLATE NOCASE`, genre join); `preview_query` (one-shot, no save); `set_collection_query` (static→rule, drops `collection_books` rows); `clear_collection_query` (rule→static, snapshots members). `list_collections` reports live counts for rule-based collections; `get_collection_books` delegates to the resolver. Kobo sync (`list_collection_device_paths`, `list_collection_shelf_candidates`) made resolver-aware so rule-based collections sync as shelves.
- **`cli/commands/collection_cmd.py`** — `create --query`, new `edit` (`--query` | `--clear-query`), new `preview --query`, and `show` displaying the rule + live count.
- **`web/templates/_collection_detail.html`** — shows the rule and "Matches: N" live count; hides manual add/remove controls for rule-based collections.
- **`README.md`** — new Collections command section + feature bullet.

## Design notes

- **One resolver, no cache**: rule-based collections hold zero `collection_books` rows and membership is recomputed on every read — single source of truth, no staleness. Architecture per the design session captured ahead of implementation.
- **CLI identifier convention**: the issue text illustrated commands as `edit NAME`, but the new commands keep the existing **integer-ID** convention (`edit <id>`) that every other `collections` subcommand uses — no breaking/mixed surface.
- **luqum** added as a dependency, isolated to the pure `collections/` module.

## Testing

- [x] Full suite green — **2189 passed** (unit, integration, e2e)
- [x] New tests paired with each slice (TDD): pure parser/validator, resolver, resolver-aware sync (incl. an integration test proving a newly-imported matching book joins the shelf on the next sync), CLI e2e (incl. all error-UX paths), web detail
- [x] `ruff check` clean; `ruff format` applied; pyright 0 errors
- [x] Manual smoke verified every acceptance criterion (preview/create/show, auto-update count 2→3 with no manual edit, `--clear-query` snapshot, all four error messages)
- [x] Repaired 2 stale hardcoded schema-version assertions in `test_migration.py` (`== 13` → `LATEST_SCHEMA_VERSION`; same class as #245)

## Related Issues

Fixes #240
Part of #179 · feeds #236 (slice 4, full Lucene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)