### PR TITLE
Add #236: collections query engine — full Lucene support (slice 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,14 +195,46 @@ current automatically as the library changes.
 | `collections edit <id> --query '<rule>'` | Convert a static collection to rule-based |
 | `collections edit <id> --clear-query` | Convert a rule-based collection to static, snapshotting current members |
 | `collections preview --query '<rule>'` | Show which books a rule matches, without saving |
+| `collections query-help` | Print the full query reference (fields, operators, dates, examples) |
 | `collections rename <id> <new_name>` | Rename a collection |
 | `collections rm <id>` | Delete a collection (books are not deleted) |
 
-Rule queries are a deliberately small subset: exactly one `field:value` or
-`field:"phrase"` term over a whitelisted field. Slice 3 supports `series`
-(exact match) and `genre` (canonical genre). `author` is coming in a later
-slice; multi-term, boolean (`AND`/`OR`/`NOT`), wildcards, and ranges are
-rejected with a message naming the valid fields.
+#### Rule query language
+
+A rule query is a [Lucene](https://lucene.apache.org/)-style expression over a
+whitelisted set of fields, parsed permissively and validated restrictively — an
+unknown field, bad value, or unsupported shape is rejected with a message naming
+what's allowed. Run `bookery collections query-help` for the in-terminal
+reference.
+
+| Field | Matches |
+|-------|---------|
+| `id` | exact book id |
+| `title` | exact, phrase, or `prefix*` (left-anchored) |
+| `author` | substring (contains) |
+| `series` | exact |
+| `genre` | exact canonical genre |
+| `tag` | exact |
+| `language` | exact |
+| `publisher` | exact |
+| `subject` | substring (contains) |
+| `isbn` | exact |
+| `year` | publication year — `=`, range, or comparison |
+| `rating` | `=`, range, or comparison |
+| `added` | date added (ISO `YYYY-MM-DD`) — `=`, range, or comparison |
+
+Operators: `AND`, `OR`, `NOT`, grouping with `( )`, and `+`/`-` prefixes
+(require/exclude). The numeric/date fields (`year`, `rating`, `added`) also
+accept ranges `[a TO b]` (inclusive), `{a TO b}` (exclusive), open-ended `*`,
+and comparisons `>=` `<=` `>` `<`. Fuzzy (`~`) and boost (`^`) are not
+supported.
+
+```text
+series:Dune
+genre:"Science Fiction" AND year:[2020 TO *]
+rating:>=4
+author:"Ursula K. Le Guin" NOT tag:reread
+```
 
 ### Web UI
 

--- a/src/bookery/cli/commands/collection_cmd.py
+++ b/src/bookery/cli/commands/collection_cmd.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from bookery.cli.options import db_option, resolve_db_path
@@ -132,7 +133,7 @@ def collections_create(
         try:
             parse_collection_query(query)
         except CollectionQueryError as exc:
-            console.print(f"[red]{exc}[/red]")
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise SystemExit(1) from exc
 
     conn = open_library(resolve_db_path(db_path))
@@ -380,7 +381,7 @@ def collections_edit(
         try:
             parse_collection_query(query)
         except CollectionQueryError as exc:
-            console.print(f"[red]{exc}[/red]")
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise SystemExit(1) from exc
 
     conn = open_library(resolve_db_path(db_path))
@@ -425,7 +426,7 @@ def collections_preview(query: str, db_path: Path | None) -> None:
     try:
         books = catalog.preview_query(query)
     except CollectionQueryError as exc:
-        console.print(f"[red]{exc}[/red]")
+        console.print(f"[red]{escape(str(exc))}[/red]")
         conn.close()
         raise SystemExit(1) from exc
 

--- a/src/bookery/cli/commands/collection_cmd.py
+++ b/src/bookery/cli/commands/collection_cmd.py
@@ -15,13 +15,98 @@ from bookery.db.connection import open_library
 
 console = Console()
 
+# Shared cheat-sheet appended to the --help of every query-aware command
+# (create/edit/preview). The leading "\b" marks each block as no-rewrap so Click
+# keeps the example lines intact. Run `collections query-help` for the full page.
+_QUERY_EPILOG = (
+    "\b\n"
+    "Query syntax (rule-based collections):\n"
+    "  fields   id title author series genre tag language\n"
+    "           publisher subject isbn year rating added\n"
+    '  match    field:value, field:"a phrase", title:prefix*\n'
+    "  numeric  year/rating/added accept [a TO b], {a TO b}, >=, <=, >, <\n"
+    "  boolean  AND  OR  NOT  ( )   (+ require, - exclude)\n"
+    "\n"
+    "\b\n"
+    "Examples:\n"
+    "  series:Dune\n"
+    '  genre:"Science Fiction" AND year:[2020 TO *]\n'
+    "  rating:>=4\n"
+    '  author:"Ursula K. Le Guin" NOT tag:reread\n'
+    "\n"
+    "Run 'bookery collections query-help' for the full query reference."
+)
+
 
 @click.group("collections")
 def collections() -> None:
     """Manage book collections (static curation or rule-based queries)."""
 
 
-@collections.command("create")
+@collections.command("query-help")
+def collections_query_help() -> None:
+    """Show the full reference for rule-based collection query rules."""
+    console.print("[bold]Collection query reference[/bold]\n")
+
+    table = Table(title="Fields")
+    table.add_column("Field", style="cyan")
+    table.add_column("Matches")
+    table.add_column("Example")
+    # No '[' in the Example column — Rich would read it as markup. Bracketed range
+    # syntax lives in the Operators section below, printed with markup disabled.
+    field_rows = [
+        ("id", "exact, IN", "id:42"),
+        ("title", "exact, phrase, prefix*", "title:Dune*"),
+        ("author", "contains", "author:Tolkien"),
+        ("series", "exact", "series:Dune"),
+        ("genre", "exact (canonical)", 'genre:"Science Fiction"'),
+        ("tag", "exact", "tag:favorites"),
+        ("language", "exact", "language:en"),
+        ("publisher", "exact", "publisher:Tor"),
+        ("subject", "contains", "subject:dystopia"),
+        ("isbn", "exact", "isbn:9780441013593"),
+        ("year", "=, range, comparisons", "year:2020"),
+        ("rating", "=, range, comparisons", "rating:>=4"),
+        ("added", "=, range, comparisons", "added:2024-01-31"),
+    ]
+    for field, matches, example in field_rows:
+        table.add_row(field, matches, example)
+    console.print(table)
+
+    # markup=False keeps '[', ']' and '>' literal; soft_wrap keeps lines intact.
+    def line(text: str, *, style: str | None = None) -> None:
+        console.print(text, markup=False, soft_wrap=True, style=style)
+
+    console.print("\n[bold]Operators[/bold]")
+    line("  Boolean:  AND  OR  NOT  ( )    + require, - exclude")
+    line("  Ranges (year, rating, added):  [a TO b] inclusive, {a TO b} exclusive, * open-ended")
+    line("  Comparisons (year, rating, added):  >=  <=  >  <")
+    line("  Prefix (title only):  title:dune*")
+    line('  Phrase (any field):  author:"Ursula K. Le Guin"')
+
+    console.print("\n[bold]Dates[/bold]")
+    line("  'added' uses ISO 8601 calendar dates: YYYY-MM-DD (e.g. added:2024-01-31)")
+    line("  'year' matches the 4-digit publication year (e.g. year:2020)")
+
+    console.print("\n[bold]Examples[/bold]")
+    example_rows = [
+        ("series:Dune", "every book in the Dune series"),
+        ('genre:"Science Fiction" AND year:[2020 TO *]', "sci-fi published in 2020 or later"),
+        ("rating:>=4", "books rated 4 stars or higher"),
+        ('author:"Ursula K. Le Guin" NOT tag:reread', "Le Guin you have not reread"),
+    ]
+    for query, description in example_rows:
+        line(f"  {query}")
+        line(f"      {description}", style="dim")
+
+    console.print("\n[bold]Common pitfalls[/bold]")
+    line("  - genre values must be canonical; an unknown genre is rejected.")
+    line("  - ranges and comparisons work only on year, rating, and added.")
+    line('  - quote multi-word values: series:"The Lord of the Rings".')
+    line("  - author and subject match substrings; series and title match the whole value.")
+
+
+@collections.command("create", epilog=_QUERY_EPILOG)
 @click.argument("name")
 @click.option("--description", "-d", help="Optional description for the collection.")
 @click.option(
@@ -261,7 +346,7 @@ def _show_collection_sync_status(conn, catalog: LibraryCatalog, collection_id: i
     console.print(table)
 
 
-@collections.command("edit")
+@collections.command("edit", epilog=_QUERY_EPILOG)
 @click.argument("collection_id", type=int)
 @click.option(
     "--query",
@@ -324,7 +409,7 @@ def collections_edit(
     conn.close()
 
 
-@collections.command("preview")
+@collections.command("preview", epilog=_QUERY_EPILOG)
 @click.option(
     "--query",
     "query",

--- a/src/bookery/collections/__init__.py
+++ b/src/bookery/collections/__init__.py
@@ -2,15 +2,17 @@
 # ABOUTME: Quarantines the luqum dependency; has no database import.
 
 from bookery.collections.query import (
-    SLICE3_FIELD_NAMES,
-    CollectionQuery,
+    QUERY_FIELD_NAMES,
     CollectionQueryError,
+    Op,
+    QueryTerm,
     parse_collection_query,
 )
 
 __all__ = [
-    "SLICE3_FIELD_NAMES",
-    "CollectionQuery",
+    "QUERY_FIELD_NAMES",
     "CollectionQueryError",
+    "Op",
+    "QueryTerm",
     "parse_collection_query",
 ]

--- a/src/bookery/collections/__init__.py
+++ b/src/bookery/collections/__init__.py
@@ -5,6 +5,10 @@ from bookery.collections.query import (
     QUERY_FIELD_NAMES,
     CollectionQueryError,
     Op,
+    QueryAnd,
+    QueryNode,
+    QueryNot,
+    QueryOr,
     QueryTerm,
     parse_collection_query,
 )
@@ -13,6 +17,10 @@ __all__ = [
     "QUERY_FIELD_NAMES",
     "CollectionQueryError",
     "Op",
+    "QueryAnd",
+    "QueryNode",
+    "QueryNot",
+    "QueryOr",
     "QueryTerm",
     "parse_collection_query",
 ]

--- a/src/bookery/collections/query.py
+++ b/src/bookery/collections/query.py
@@ -8,7 +8,21 @@ from enum import StrEnum
 
 from luqum.exceptions import ParseError
 from luqum.parser import parser
-from luqum.tree import From, Phrase, Range, SearchField, To, Word
+from luqum.tree import (
+    AndOperation,
+    From,
+    Group,
+    Not,
+    OrOperation,
+    Phrase,
+    Plus,
+    Prohibit,
+    Range,
+    SearchField,
+    To,
+    UnknownOperation,
+    Word,
+)
 
 from bookery.metadata.genres import CANONICAL_GENRES, is_canonical_genre
 
@@ -58,6 +72,31 @@ class QueryTerm:
     high: str | None = None
     include_low: bool = True
     include_high: bool = True
+
+
+@dataclass(frozen=True)
+class QueryAnd:
+    """Boolean AND of two or more child nodes (intersection of their members)."""
+
+    children: tuple["QueryNode", ...]
+
+
+@dataclass(frozen=True)
+class QueryOr:
+    """Boolean OR of two or more child nodes (union of their members)."""
+
+    children: tuple["QueryNode", ...]
+
+
+@dataclass(frozen=True)
+class QueryNot:
+    """Boolean NOT of a child node (every book not matched by the child)."""
+
+    child: "QueryNode"
+
+
+# A node in the validated query IR: either a leaf term or a boolean combinator.
+QueryNode = QueryTerm | QueryAnd | QueryOr | QueryNot
 
 
 def _validate_genre_value(value: str) -> None:
@@ -150,11 +189,6 @@ _SYNTAX_MSG = (
     f"Invalid query syntax. Use a single term like 'genre:\"Science Fiction\"', "
     f"'series:Dune', or 'author:Tolkien' (valid fields: {_FIELD_LIST})."
 )
-_SINGLE_TERM_MSG = (
-    f"Only a single field:value term is supported in this release "
-    f"(e.g. 'author:Tolkien'). Boolean/range queries are not yet supported. "
-    f"Valid fields: {_FIELD_LIST}."
-)
 _UNSUPPORTED_VALUE_MSG = (
     "Unsupported value. Use an exact field:value (e.g. 'series:Dune'), a trailing "
     "'*' prefix on title, or a range/comparison on a numeric/date field."
@@ -165,18 +199,19 @@ _RANGE_FIELD_MSG = (
 )
 
 
-def parse_collection_query(raw: str) -> QueryTerm:
+def parse_collection_query(raw: str) -> QueryNode:
     """Parse and validate a rule-based collection query into the query IR.
 
     Parse-permissive, validate-restrictive: luqum parses the full Lucene grammar,
-    then the AST is walked and anything outside the supported subset is rejected. A
-    valid query is currently exactly one ``field:value`` / ``field:"phrase"`` /
-    ``field:prefix*`` term over a whitelisted field.
+    then the AST is walked and anything outside the supported subset is rejected.
+    A valid query is one or more whitelisted ``field:value`` terms combined with
+    AND/OR/NOT, ``+``/``-`` prefixes, and parentheses; each leaf is an exact,
+    contains, prefix, range, or comparison match per its field.
 
     Raises:
-        CollectionQueryError: on syntax errors, multi-term/boolean queries,
-            unknown fields, unsupported value shapes (interior wildcards, ranges,
-            comparisons), non-integer ids, or non-canonical genre values.
+        CollectionQueryError: on syntax errors, unknown fields, unsupported value
+            shapes (interior wildcards, ranges/comparisons on non-numeric fields),
+            non-integer ids, bad dates, or non-canonical genre values.
     """
     text = raw.strip()
     if not text:
@@ -187,13 +222,28 @@ def parse_collection_query(raw: str) -> QueryTerm:
     except ParseError as exc:
         raise CollectionQueryError(_SYNTAX_MSG) from exc
 
-    # A single field:value term parses to a SearchField at the top level. Anything
-    # else — implicit multi-term (UnknownOperation), explicit AND/OR (And/OrOperation),
-    # NOT, a parenthesised Group, or a bare Word/Phrase with no field — is rejected.
-    if not isinstance(tree, SearchField):
-        raise CollectionQueryError(_SINGLE_TERM_MSG)
+    return _build_node(tree)
 
-    return _validate_term(tree)
+
+def _build_node(node: object) -> QueryNode:
+    """Recursively validate a luqum AST node into the query IR.
+
+    AND/implicit-juxtaposition map to ``QueryAnd``, OR to ``QueryOr``, NOT/``-`` to
+    ``QueryNot``; ``+`` and parentheses are structural and unwrap to their child.
+    Leaf ``field:value`` terms are validated against the whitelist.
+    """
+    if isinstance(node, SearchField):
+        return _validate_term(node)
+    if isinstance(node, AndOperation | UnknownOperation):
+        return QueryAnd(tuple(_build_node(child) for child in node.children))
+    if isinstance(node, OrOperation):
+        return QueryOr(tuple(_build_node(child) for child in node.children))
+    if isinstance(node, Not | Prohibit):
+        return QueryNot(_build_node(node.children[0]))
+    if isinstance(node, Plus | Group):
+        return _build_node(node.children[0])
+    # A bare Word/Phrase with no field, or any other unsupported shape.
+    raise CollectionQueryError(_SYNTAX_MSG)
 
 
 def _validate_term(node: SearchField) -> QueryTerm:

--- a/src/bookery/collections/query.py
+++ b/src/bookery/collections/query.py
@@ -1,8 +1,9 @@
-# ABOUTME: Parses and validates rule-based collection queries (slice-3 subset).
+# ABOUTME: Parses and validates rule-based collection queries into a small query IR.
 # ABOUTME: Pure module — owns the luqum dependency, no DB import; SQL lives in the resolver.
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import StrEnum
 
 from luqum.exceptions import ParseError
 from luqum.parser import parser
@@ -20,16 +21,30 @@ class CollectionQueryError(ValueError):
     """
 
 
-@dataclass(frozen=True)
-class CollectionQuery:
-    """A validated single-field equality query.
+class Op(StrEnum):
+    """How a leaf term matches its field.
 
-    ``field`` is a canonical, lower-cased slice-3 field name (``series`` or
-    ``genre``); ``value`` is the raw user-supplied value (quotes stripped). The
-    resolver turns this into per-field SQL — this object holds no SQL itself.
+    The parser resolves each leaf to exactly one ``Op`` from both the field's
+    capabilities and the parsed value shape; the resolver keys its SQL off it.
+    """
+
+    EQ = "eq"  # exact, case-insensitive equality
+    CONTAINS = "contains"  # substring match (free-text people/subject fields)
+    PREFIX = "prefix"  # left-anchored prefix match (``title:dune*``)
+
+
+@dataclass(frozen=True)
+class QueryTerm:
+    """A validated single-field leaf of the query IR.
+
+    ``field`` is a canonical, lower-cased whitelisted field name; ``op`` is the
+    resolved match strategy; ``value`` is the raw user operand (quotes and any
+    trailing prefix ``*`` already stripped). This object holds no SQL — the
+    resolver compiles it per field.
     """
 
     field: str
+    op: Op
     value: str
 
 
@@ -40,49 +55,75 @@ def _validate_genre_value(value: str) -> None:
         raise CollectionQueryError(f"'{value}' is not a canonical genre. Valid genres: {valid}.")
 
 
-# The slice-3 field whitelist. Maps each supported field to an optional value
-# validator. This registry drives both the compiler (in the db resolver, which
-# keys off these names) and the error messages below. Slice 4 (#236) grows this
-# map and relaxes the validator; the parse entry point does not change.
-SLICE3_FIELDS: dict[str, Callable[[str], None] | None] = {
-    "series": None,
-    "genre": _validate_genre_value,
-}
-SLICE3_FIELD_NAMES: tuple[str, ...] = tuple(SLICE3_FIELDS)
+def _validate_int_value(value: str) -> None:
+    """Reject non-integer ``id`` operands."""
+    try:
+        int(value)
+    except ValueError as exc:
+        raise CollectionQueryError(f"'{value}' is not a valid integer id.") from exc
 
-# Fields deliberately deferred to a later slice, mapped to where they land. These
-# get a specific "coming later" message rather than the generic unknown-field error.
-_DEFERRED_FIELDS: dict[str, str] = {
-    "author": "slice 4 (#236)",
-}
 
-_FIELD_LIST = ", ".join(SLICE3_FIELD_NAMES)
+@dataclass(frozen=True)
+class FieldSpec:
+    """Capabilities of a whitelisted query field.
+
+    ``match`` is the default op for a word/phrase value (``EQ`` for single-valued
+    columns, ``CONTAINS`` for free-text people/subject columns). ``allow_prefix``
+    permits the left-anchored ``value*`` form. ``validate`` runs against the raw
+    value at parse time so an invalid query never reaches the resolver.
+    """
+
+    match: Op
+    allow_prefix: bool = False
+    validate: Callable[[str], None] | None = None
+
+
+# The query field whitelist. This registry drives both the parser (validation and
+# op resolution) and the resolver's per-field SQL compiler, which keys off these
+# names. Later sub-slices grow this map (ranges/comparisons, booleans) without
+# changing the ``parse_collection_query`` entry point.
+QUERY_FIELDS: dict[str, FieldSpec] = {
+    "id": FieldSpec(match=Op.EQ, validate=_validate_int_value),
+    "title": FieldSpec(match=Op.EQ, allow_prefix=True),
+    "author": FieldSpec(match=Op.CONTAINS),
+    "series": FieldSpec(match=Op.EQ),
+    "genre": FieldSpec(match=Op.EQ, validate=_validate_genre_value),
+    "tag": FieldSpec(match=Op.EQ),
+    "language": FieldSpec(match=Op.EQ),
+    "publisher": FieldSpec(match=Op.EQ),
+    "subject": FieldSpec(match=Op.CONTAINS),
+    "isbn": FieldSpec(match=Op.EQ),
+}
+QUERY_FIELD_NAMES: tuple[str, ...] = tuple(QUERY_FIELDS)
+
+_FIELD_LIST = ", ".join(QUERY_FIELD_NAMES)
 _SYNTAX_MSG = (
-    f"Invalid query syntax. Use a single term like 'genre:\"Science Fiction\"' "
-    f"or 'series:Dune' (valid fields: {_FIELD_LIST})."
+    f"Invalid query syntax. Use a single term like 'genre:\"Science Fiction\"', "
+    f"'series:Dune', or 'author:Tolkien' (valid fields: {_FIELD_LIST})."
 )
 _SINGLE_TERM_MSG = (
     f"Only a single field:value term is supported in this release "
-    f"(e.g. 'genre:\"Science Fiction\"'). Valid fields: {_FIELD_LIST}."
+    f"(e.g. 'author:Tolkien'). Boolean/range queries are not yet supported. "
+    f"Valid fields: {_FIELD_LIST}."
 )
 _UNSUPPORTED_VALUE_MSG = (
-    "Wildcards, ranges, and comparisons are not supported in this release — "
-    "use an exact field:value, e.g. 'series:Dune'."
+    "Wildcards (except a trailing '*' on title), ranges, and comparisons are not "
+    "supported in this release — use an exact field:value, e.g. 'series:Dune'."
 )
 
 
-def parse_collection_query(raw: str) -> CollectionQuery:
-    """Parse and validate a rule-based collection query.
+def parse_collection_query(raw: str) -> QueryTerm:
+    """Parse and validate a rule-based collection query into the query IR.
 
     Parse-permissive, validate-restrictive: luqum parses the full Lucene grammar,
-    then the AST is walked and anything outside the slice-3 subset is rejected. A
-    valid query is exactly one ``field:value`` or ``field:"phrase"`` term over a
-    whitelisted field.
+    then the AST is walked and anything outside the supported subset is rejected. A
+    valid query is currently exactly one ``field:value`` / ``field:"phrase"`` /
+    ``field:prefix*`` term over a whitelisted field.
 
     Raises:
         CollectionQueryError: on syntax errors, multi-term/boolean queries,
-            unknown/deferred fields, unsupported value shapes (wildcards/ranges),
-            or non-canonical genre values.
+            unknown fields, unsupported value shapes (interior wildcards, ranges,
+            comparisons), non-integer ids, or non-canonical genre values.
     """
     text = raw.strip()
     if not text:
@@ -99,31 +140,40 @@ def parse_collection_query(raw: str) -> CollectionQuery:
     if not isinstance(tree, SearchField):
         raise CollectionQueryError(_SINGLE_TERM_MSG)
 
-    expr = tree.expr
+    return _validate_term(tree)
+
+
+def _validate_term(node: SearchField) -> QueryTerm:
+    """Validate one ``field:value`` SearchField against the whitelist into a QueryTerm."""
+    field = node.name.lower()
+    if field not in QUERY_FIELDS:
+        raise CollectionQueryError(f"Unknown field '{node.name}'. Valid fields: {_FIELD_LIST}.")
+    spec = QUERY_FIELDS[field]
+
+    expr = node.expr
     if isinstance(expr, Phrase):
-        value = _strip_quotes(expr.value)
+        value, op = _strip_quotes(expr.value), spec.match
     elif isinstance(expr, Word):
-        value = expr.value
-        if "*" in value or "?" in value:
-            raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
+        value, op = _resolve_word(expr.value, spec)
     else:
-        # Range, Fuzzy, Proximity, etc. — not part of the slice-3 subset.
+        # Range, Fuzzy, Proximity, comparison, etc. — not in the current subset.
         raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
 
-    field = tree.name.lower()
+    if spec.validate is not None:
+        spec.validate(value)
 
-    if field in _DEFERRED_FIELDS:
-        raise CollectionQueryError(
-            f"Field '{field}' is not yet supported — coming in {_DEFERRED_FIELDS[field]}."
-        )
-    if field not in SLICE3_FIELDS:
-        raise CollectionQueryError(f"Unknown field '{tree.name}'. Valid fields: {_FIELD_LIST}.")
+    return QueryTerm(field=field, op=op, value=value)
 
-    validate_value = SLICE3_FIELDS[field]
-    if validate_value is not None:
-        validate_value(value)
 
-    return CollectionQuery(field=field, value=value)
+def _resolve_word(raw_value: str, spec: FieldSpec) -> tuple[str, Op]:
+    """Resolve a bare Word value to (value, op), handling the trailing-``*`` prefix form."""
+    if raw_value.endswith("*") and "*" not in raw_value[:-1] and "?" not in raw_value:
+        if not spec.allow_prefix:
+            raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
+        return raw_value[:-1], Op.PREFIX
+    if "*" in raw_value or "?" in raw_value:
+        raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
+    return raw_value, spec.match
 
 
 def _strip_quotes(phrase_value: str) -> str:

--- a/src/bookery/collections/query.py
+++ b/src/bookery/collections/query.py
@@ -3,11 +3,12 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 
 from luqum.exceptions import ParseError
 from luqum.parser import parser
-from luqum.tree import Phrase, SearchField, Word
+from luqum.tree import From, Phrase, Range, SearchField, To, Word
 
 from bookery.metadata.genres import CANONICAL_GENRES, is_canonical_genre
 
@@ -31,6 +32,11 @@ class Op(StrEnum):
     EQ = "eq"  # exact, case-insensitive equality
     CONTAINS = "contains"  # substring match (free-text people/subject fields)
     PREFIX = "prefix"  # left-anchored prefix match (``title:dune*``)
+    RANGE = "range"  # bounded interval (``year:[2000 TO 2010]``)
+    GE = "ge"  # >=
+    GT = "gt"  # >
+    LE = "le"  # <=
+    LT = "lt"  # <
 
 
 @dataclass(frozen=True)
@@ -38,14 +44,20 @@ class QueryTerm:
     """A validated single-field leaf of the query IR.
 
     ``field`` is a canonical, lower-cased whitelisted field name; ``op`` is the
-    resolved match strategy; ``value`` is the raw user operand (quotes and any
-    trailing prefix ``*`` already stripped). This object holds no SQL — the
-    resolver compiles it per field.
+    resolved match strategy. For scalar ops (EQ/CONTAINS/PREFIX/GE/GT/LE/LT)
+    ``value`` carries the raw operand (quotes and any trailing prefix ``*`` already
+    stripped). For ``RANGE`` ``value`` is None and ``low``/``high`` carry the bounds
+    (None = open-ended) with their inclusivity flags. This object holds no SQL —
+    the resolver compiles it per field.
     """
 
     field: str
     op: Op
-    value: str
+    value: str | None = None
+    low: str | None = None
+    high: str | None = None
+    include_low: bool = True
+    include_high: bool = True
 
 
 def _validate_genre_value(value: str) -> None:
@@ -63,18 +75,51 @@ def _validate_int_value(value: str) -> None:
         raise CollectionQueryError(f"'{value}' is not a valid integer id.") from exc
 
 
+def _validate_year_value(value: str) -> None:
+    """Reject non-integer ``year`` operands."""
+    try:
+        int(value)
+    except ValueError as exc:
+        raise CollectionQueryError(
+            f"'{value}' is not a valid year (use a 4-digit year like 2020)."
+        ) from exc
+
+
+def _validate_rating_value(value: str) -> None:
+    """Reject non-numeric ``rating`` operands."""
+    try:
+        float(value)
+    except ValueError as exc:
+        raise CollectionQueryError(
+            f"'{value}' is not a valid rating (use a number like 4 or 4.5)."
+        ) from exc
+
+
+def _validate_iso_date_value(value: str) -> None:
+    """Reject ``added`` operands that are not ISO 8601 calendar dates."""
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise CollectionQueryError(
+            f"'{value}' is not a valid ISO date (use YYYY-MM-DD, e.g. 2024-01-31)."
+        ) from exc
+
+
 @dataclass(frozen=True)
 class FieldSpec:
     """Capabilities of a whitelisted query field.
 
     ``match`` is the default op for a word/phrase value (``EQ`` for single-valued
     columns, ``CONTAINS`` for free-text people/subject columns). ``allow_prefix``
-    permits the left-anchored ``value*`` form. ``validate`` runs against the raw
-    value at parse time so an invalid query never reaches the resolver.
+    permits the left-anchored ``value*`` form. ``allow_range`` permits ranges
+    (``[a TO b]``) and comparisons (``>=``/``<=``/``>``/``<``) — numeric/date fields
+    only. ``validate`` runs against the raw value (and each range bound) at parse
+    time so an invalid query never reaches the resolver.
     """
 
     match: Op
     allow_prefix: bool = False
+    allow_range: bool = False
     validate: Callable[[str], None] | None = None
 
 
@@ -93,8 +138,12 @@ QUERY_FIELDS: dict[str, FieldSpec] = {
     "publisher": FieldSpec(match=Op.EQ),
     "subject": FieldSpec(match=Op.CONTAINS),
     "isbn": FieldSpec(match=Op.EQ),
+    "year": FieldSpec(match=Op.EQ, allow_range=True, validate=_validate_year_value),
+    "rating": FieldSpec(match=Op.EQ, allow_range=True, validate=_validate_rating_value),
+    "added": FieldSpec(match=Op.EQ, allow_range=True, validate=_validate_iso_date_value),
 }
 QUERY_FIELD_NAMES: tuple[str, ...] = tuple(QUERY_FIELDS)
+_RANGE_FIELD_NAMES: tuple[str, ...] = tuple(f for f, s in QUERY_FIELDS.items() if s.allow_range)
 
 _FIELD_LIST = ", ".join(QUERY_FIELD_NAMES)
 _SYNTAX_MSG = (
@@ -107,8 +156,12 @@ _SINGLE_TERM_MSG = (
     f"Valid fields: {_FIELD_LIST}."
 )
 _UNSUPPORTED_VALUE_MSG = (
-    "Wildcards (except a trailing '*' on title), ranges, and comparisons are not "
-    "supported in this release — use an exact field:value, e.g. 'series:Dune'."
+    "Unsupported value. Use an exact field:value (e.g. 'series:Dune'), a trailing "
+    "'*' prefix on title, or a range/comparison on a numeric/date field."
+)
+_RANGE_FIELD_MSG = (
+    f"Ranges ([a TO b]) and comparisons (>=, <=, >, <) are only supported on the "
+    f"numeric/date fields: {', '.join(_RANGE_FIELD_NAMES)}."
 )
 
 
@@ -152,16 +205,61 @@ def _validate_term(node: SearchField) -> QueryTerm:
 
     expr = node.expr
     if isinstance(expr, Phrase):
-        value, op = _strip_quotes(expr.value), spec.match
-    elif isinstance(expr, Word):
+        value = _strip_quotes(expr.value)
+        _apply_validator(spec, value)
+        return QueryTerm(field=field, op=spec.match, value=value)
+    if isinstance(expr, Word):
         value, op = _resolve_word(expr.value, spec)
-    else:
-        # Range, Fuzzy, Proximity, comparison, etc. — not in the current subset.
-        raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
+        _apply_validator(spec, value)
+        return QueryTerm(field=field, op=op, value=value)
+    if isinstance(expr, Range):
+        return _build_range_term(field, spec, expr)
+    if isinstance(expr, From | To):
+        return _build_comparison_term(field, spec, expr)
+    # Fuzzy, Proximity, etc. — not in the supported subset.
+    raise CollectionQueryError(_UNSUPPORTED_VALUE_MSG)
 
+
+def _apply_validator(spec: FieldSpec, value: str) -> None:
+    """Run the field's value validator (if any) against a raw operand."""
     if spec.validate is not None:
         spec.validate(value)
 
+
+def _build_range_term(field: str, spec: FieldSpec, expr: Range) -> QueryTerm:
+    """Validate a ``[a TO b]`` / ``{a TO b}`` range into a RANGE QueryTerm."""
+    if not spec.allow_range:
+        raise CollectionQueryError(_RANGE_FIELD_MSG)
+    low = _range_bound(expr.low.value)
+    high = _range_bound(expr.high.value)
+    for bound in (low, high):
+        if bound is not None:
+            _apply_validator(spec, bound)
+    return QueryTerm(
+        field=field,
+        op=Op.RANGE,
+        low=low,
+        high=high,
+        include_low=expr.include_low,
+        include_high=expr.include_high,
+    )
+
+
+def _range_bound(raw: str) -> str | None:
+    """A luqum range bound; ``*`` means open-ended (None)."""
+    return None if raw == "*" else raw
+
+
+def _build_comparison_term(field: str, spec: FieldSpec, expr: From | To) -> QueryTerm:
+    """Validate a ``>=``/``>``/``<=``/``<`` comparison into a GE/GT/LE/LT QueryTerm."""
+    if not spec.allow_range:
+        raise CollectionQueryError(_RANGE_FIELD_MSG)
+    value = expr.a.value
+    _apply_validator(spec, value)
+    if isinstance(expr, From):
+        op = Op.GE if expr.include else Op.GT
+    else:  # To
+        op = Op.LE if expr.include else Op.LT
     return QueryTerm(field=field, op=op, value=value)
 
 

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -5,7 +5,7 @@ import json
 import sqlite3
 from pathlib import Path
 
-from bookery.collections import CollectionQuery, parse_collection_query
+from bookery.collections import Op, QueryTerm, parse_collection_query
 from bookery.core.dedup import (
     normalize_author_for_dedup,
     normalize_for_dedup,
@@ -78,6 +78,71 @@ def _order_clause_for(sort: str, dir: str) -> str:
     # tiebreakers respect the user's chosen direction.
     parts = [part.strip() for part in columns.split(",")]
     return ", ".join(f"{part} {direction}" for part in parts)
+
+
+# Per-field SQL for a single query term. Every leaf compiles to a
+# ``SELECT id FROM books b WHERE <predicate>`` returning a book-id set, with the
+# value bound as a parameter (never interpolated). Many-to-many fields (genre,
+# tag) use EXISTS so the outer shape stays uniform — later sub-slices compose
+# these sets with INTERSECT/UNION/EXCEPT for boolean queries.
+#
+# ``author``/``subject`` are stored as JSON-array TEXT columns (e.g.
+# ``["J.R.R. Tolkien"]``); contains-match runs LIKE against that JSON text, so a
+# substring like ``Tolkien`` matches regardless of the array wrapping.
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE metacharacters so user input matches literally (with ESCAPE '\\')."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _compile_term(term: QueryTerm) -> tuple[str, list[object]]:
+    """Compile one validated ``QueryTerm`` to ``(sql, params)`` yielding a book-id set."""
+    field, op, value = term.field, term.op, term.value
+
+    if field == "id":
+        return ("SELECT id FROM books b WHERE b.id = ?", [int(value)])
+    if field == "isbn":
+        return ("SELECT id FROM books b WHERE b.isbn = ?", [value])
+    if field == "language":
+        return ("SELECT id FROM books b WHERE b.language = ? COLLATE NOCASE", [value])
+    if field == "publisher":
+        return ("SELECT id FROM books b WHERE b.publisher = ? COLLATE NOCASE", [value])
+    if field == "series":
+        return ("SELECT id FROM books b WHERE b.series = ? COLLATE NOCASE", [value])
+    if field == "title":
+        if op is Op.PREFIX:
+            return (
+                "SELECT id FROM books b WHERE b.title LIKE ? ESCAPE '\\' COLLATE NOCASE",
+                [f"{_escape_like(value)}%"],
+            )
+        return ("SELECT id FROM books b WHERE b.title = ? COLLATE NOCASE", [value])
+    if field == "author":
+        return (
+            "SELECT id FROM books b WHERE b.authors LIKE ? ESCAPE '\\' COLLATE NOCASE",
+            [f"%{_escape_like(value)}%"],
+        )
+    if field == "subject":
+        return (
+            "SELECT id FROM books b WHERE b.subjects LIKE ? ESCAPE '\\' COLLATE NOCASE",
+            [f"%{_escape_like(value)}%"],
+        )
+    if field == "genre":
+        return (
+            "SELECT id FROM books b WHERE EXISTS ("
+            "SELECT 1 FROM book_genres bg JOIN genres g ON bg.genre_id = g.id "
+            "WHERE bg.book_id = b.id AND g.name = ?)",
+            [value],
+        )
+    if field == "tag":
+        return (
+            "SELECT id FROM books b WHERE EXISTS ("
+            "SELECT 1 FROM book_tags bt JOIN tags t ON bt.tag_id = t.id "
+            "WHERE bt.book_id = b.id AND t.name = ?)",
+            [value],
+        )
+    # Guarded by the query validator; unreachable for whitelisted fields.
+    raise ValueError(f"Unsupported query field: {field}")  # pragma: no cover
 
 
 class LibraryCatalog:
@@ -1581,27 +1646,15 @@ class LibraryCatalog:
         )
         self._conn.commit()
 
-    def _compile_query_member_ids(self, query: CollectionQuery) -> list[int]:
-        """Compile a validated query into the matching book IDs (per-field SQL).
+    def _compile_query_member_ids(self, query: QueryTerm) -> list[int]:
+        """Compile a validated query term into the matching book IDs (per-field SQL).
 
-        The query module guarantees ``field`` is a whitelisted slice-3 field and
-        ``value`` passed its per-field validation, so this only constructs SQL.
+        The query module guarantees ``field`` is whitelisted and ``value`` passed
+        its per-field validation. This only assembles parameter-bound SQL — user
+        input is never interpolated into the statement text.
         """
-        if query.field == "series":
-            cursor = self._conn.execute(
-                "SELECT id FROM books WHERE series = ? COLLATE NOCASE",
-                (query.value,),
-            )
-        elif query.field == "genre":
-            cursor = self._conn.execute(
-                "SELECT b.id FROM books b "
-                "JOIN book_genres bg ON b.id = bg.book_id "
-                "JOIN genres g ON bg.genre_id = g.id "
-                "WHERE g.name = ?",
-                (query.value,),
-            )
-        else:  # pragma: no cover - guarded by the query validator
-            raise ValueError(f"Unsupported query field: {query.field}")
+        sql, params = _compile_term(query)
+        cursor = self._conn.execute(sql, params)
         return [int(row[0]) for row in cursor.fetchall()]
 
     def _fetch_books_ordered(self, book_ids: list[int]) -> list[BookRecord]:

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -3,6 +3,7 @@
 
 import json
 import sqlite3
+from collections.abc import Callable
 from pathlib import Path
 
 from bookery.collections import Op, QueryTerm, parse_collection_query
@@ -96,10 +97,60 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _comparable_predicate(
+    operand: str, term: QueryTerm, cast: Callable[[str], object]
+) -> tuple[str, list[object]]:
+    """Build a WHERE predicate for an ordered (numeric/date) operand.
+
+    ``operand`` is a trusted SQL column/expression (never user input); user values
+    flow only through bound ``?`` parameters, cast to the field's type. Handles
+    EQ/GE/GT/LE/LT and RANGE (open bounds skip their clause).
+    """
+    op = term.op
+    if op is Op.EQ:
+        return f"{operand} = ?", [cast(term.value)]  # type: ignore[arg-type]
+    if op is Op.GE:
+        return f"{operand} >= ?", [cast(term.value)]  # type: ignore[arg-type]
+    if op is Op.GT:
+        return f"{operand} > ?", [cast(term.value)]  # type: ignore[arg-type]
+    if op is Op.LE:
+        return f"{operand} <= ?", [cast(term.value)]  # type: ignore[arg-type]
+    if op is Op.LT:
+        return f"{operand} < ?", [cast(term.value)]  # type: ignore[arg-type]
+    # Op.RANGE — one clause per present bound; an all-open range matches any non-null.
+    clauses: list[str] = []
+    params: list[object] = []
+    if term.low is not None:
+        clauses.append(f"{operand} {'>=' if term.include_low else '>'} ?")
+        params.append(cast(term.low))
+    if term.high is not None:
+        clauses.append(f"{operand} {'<=' if term.include_high else '<'} ?")
+        params.append(cast(term.high))
+    if not clauses:
+        return f"{operand} IS NOT NULL", []
+    return " AND ".join(clauses), params
+
+
 def _compile_term(term: QueryTerm) -> tuple[str, list[object]]:
     """Compile one validated ``QueryTerm`` to ``(sql, params)`` yielding a book-id set."""
     field, op, value = term.field, term.op, term.value
 
+    if field == "year":
+        # The 4-char year prefix of the (ISO) edition date, compared numerically.
+        pred, params = _comparable_predicate(
+            "CAST(substr(b.published_date, 1, 4) AS INTEGER)", term, int
+        )
+        return f"SELECT id FROM books b WHERE {pred}", params
+    if field == "rating":
+        pred, params = _comparable_predicate("b.rating", term, float)
+        return f"SELECT id FROM books b WHERE {pred}", params
+    if field == "added":
+        # Compare the date portion of the stored ISO timestamp (day granularity).
+        pred, params = _comparable_predicate("substr(b.date_added, 1, 10)", term, str)
+        return f"SELECT id FROM books b WHERE {pred}", params
+
+    # Remaining fields are scalar-only; the validator guarantees a non-null value.
+    assert value is not None
     if field == "id":
         return ("SELECT id FROM books b WHERE b.id = ?", [int(value)])
     if field == "isbn":

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -6,7 +6,15 @@ import sqlite3
 from collections.abc import Callable
 from pathlib import Path
 
-from bookery.collections import Op, QueryTerm, parse_collection_query
+from bookery.collections import (
+    Op,
+    QueryAnd,
+    QueryNode,
+    QueryNot,
+    QueryOr,
+    QueryTerm,
+    parse_collection_query,
+)
 from bookery.core.dedup import (
     normalize_author_for_dedup,
     normalize_for_dedup,
@@ -129,6 +137,41 @@ def _comparable_predicate(
     if not clauses:
         return f"{operand} IS NOT NULL", []
     return " AND ".join(clauses), params
+
+
+def _compile_node(node: QueryNode) -> tuple[str, list[object]]:
+    """Compile a query IR node to ``(sql, params)`` yielding a book-id set.
+
+    Booleans compose via ``b.id IN (subquery)`` / ``NOT IN`` rather than raw
+    compound set operators: SQLite won't parenthesise compound SELECTs, but nested
+    ``IN`` subqueries give clean, precedence-safe composition with full parameter
+    binding. AND joins child membership with ``AND``, OR with ``OR``, NOT negates.
+    """
+    if isinstance(node, QueryTerm):
+        return _compile_term(node)
+    if isinstance(node, QueryAnd):
+        return _compile_boolean(node.children, "AND")
+    if isinstance(node, QueryOr):
+        return _compile_boolean(node.children, "OR")
+    if isinstance(node, QueryNot):
+        sql, params = _compile_node(node.child)
+        return f"SELECT id FROM books b WHERE b.id NOT IN ({sql})", params
+    # Exhaustive over QueryNode; unreachable for validated trees.
+    raise ValueError(f"Unsupported query node: {type(node).__name__}")  # pragma: no cover
+
+
+def _compile_boolean(
+    children: tuple[QueryNode, ...], conjunction: str
+) -> tuple[str, list[object]]:
+    """Combine child node membership with AND/OR via nested ``b.id IN (...)`` clauses."""
+    clauses: list[str] = []
+    params: list[object] = []
+    for child in children:
+        sql, child_params = _compile_node(child)
+        clauses.append(f"b.id IN ({sql})")
+        params.extend(child_params)
+    joined = f" {conjunction} ".join(clauses)
+    return f"SELECT id FROM books b WHERE {joined}", params
 
 
 def _compile_term(term: QueryTerm) -> tuple[str, list[object]]:
@@ -1697,14 +1740,14 @@ class LibraryCatalog:
         )
         self._conn.commit()
 
-    def _compile_query_member_ids(self, query: QueryTerm) -> list[int]:
-        """Compile a validated query term into the matching book IDs (per-field SQL).
+    def _compile_query_member_ids(self, query: QueryNode) -> list[int]:
+        """Compile a validated query tree into the matching book IDs.
 
-        The query module guarantees ``field`` is whitelisted and ``value`` passed
-        its per-field validation. This only assembles parameter-bound SQL — user
+        The query module guarantees every leaf field is whitelisted and its value
+        passed per-field validation. This only assembles parameter-bound SQL — user
         input is never interpolated into the statement text.
         """
-        sql, params = _compile_term(query)
+        sql, params = _compile_node(query)
         cursor = self._conn.execute(sql, params)
         return [int(row[0]) for row in cursor.fetchall()]
 

--- a/tests/e2e/test_collection_cli.py
+++ b/tests/e2e/test_collection_cli.py
@@ -33,9 +33,14 @@ class TestCollectionsWorkflow:
         result = runner.invoke(
             cli,
             [
-                "--db", str(db_path), "collections", "create",
-                "Sci-Fi Favorites", "-d", "Best science fiction books"
-            ]
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Sci-Fi Favorites",
+                "-d",
+                "Best science fiction books",
+            ],
         )
         assert result.exit_code == 0
         assert "Created collection" in result.output
@@ -50,7 +55,7 @@ class TestCollectionsWorkflow:
                 BookMetadata(
                     title=f"Sci-Fi Book {i}",
                     authors=[f"Author {i}"],
-                    source_path=Path(f"/books/scifi{i}.epub")
+                    source_path=Path(f"/books/scifi{i}.epub"),
                 ),
                 file_hash=f"hash_{i}",
             )
@@ -60,8 +65,16 @@ class TestCollectionsWorkflow:
         # Step 3: Add books to the collection
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "add-books", "1",
-             str(book_ids[0]), str(book_ids[1]), str(book_ids[2])]
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "add-books",
+                "1",
+                str(book_ids[0]),
+                str(book_ids[1]),
+                str(book_ids[2]),
+            ],
         )
         assert result.exit_code == 0
         assert "Added 3 book(s)" in result.output
@@ -84,8 +97,7 @@ class TestCollectionsWorkflow:
 
         # Step 6: Remove a book from the collection
         result = runner.invoke(
-            cli,
-            ["--db", str(db_path), "collections", "remove-books", "1", str(book_ids[1])]
+            cli, ["--db", str(db_path), "collections", "remove-books", "1", str(book_ids[1])]
         )
         assert result.exit_code == 0
         assert "Removed 1 book(s)" in result.output
@@ -99,8 +111,7 @@ class TestCollectionsWorkflow:
 
         # Step 8: Rename the collection
         result = runner.invoke(
-            cli,
-            ["--db", str(db_path), "collections", "rename", "1", "Best Sci-Fi"]
+            cli, ["--db", str(db_path), "collections", "rename", "1", "Best Sci-Fi"]
         )
         assert result.exit_code == 0
         assert "Renamed collection" in result.output
@@ -114,11 +125,7 @@ class TestCollectionsWorkflow:
         assert "Sci-Fi Favorites" not in result.output
 
         # Step 10: Delete the collection
-        result = runner.invoke(
-            cli,
-            ["--db", str(db_path), "collections", "rm", "1"],
-            input="y\n"
-        )
+        result = runner.invoke(cli, ["--db", str(db_path), "collections", "rm", "1"], input="y\n")
         assert result.exit_code == 0
         assert "Deleted collection" in result.output
 
@@ -204,8 +211,15 @@ class TestQueryBasedCollectionsCLI:
         _seed_sci_fi(db_path)
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Sci-Fi",
-             "--query", 'genre:"Science Fiction"'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Sci-Fi",
+                "--query",
+                'genre:"Science Fiction"',
+            ],
         )
         assert result.exit_code == 0
 
@@ -225,8 +239,7 @@ class TestQueryBasedCollectionsCLI:
         _seed_sci_fi(db_path)
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "preview", "--query",
-             'genre:"Science Fiction"'],
+            ["--db", str(db_path), "collections", "preview", "--query", 'genre:"Science Fiction"'],
         )
         assert result.exit_code == 0
         assert "Foundation" in result.output
@@ -239,8 +252,15 @@ class TestQueryBasedCollectionsCLI:
         _seed_sci_fi(db_path)
         runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Sci-Fi",
-             "--query", 'genre:"Science Fiction"'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Sci-Fi",
+                "--query",
+                'genre:"Science Fiction"',
+            ],
         )
         result = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
         assert 'genre:"Science Fiction"' in result.output
@@ -251,8 +271,15 @@ class TestQueryBasedCollectionsCLI:
         runner.invoke(cli, ["--db", str(db_path), "collections", "create", "Sci-Fi"])
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "edit", "1", "--query",
-             'genre:"Science Fiction"'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "edit",
+                "1",
+                "--query",
+                'genre:"Science Fiction"',
+            ],
         )
         assert result.exit_code == 0
 
@@ -260,14 +287,19 @@ class TestQueryBasedCollectionsCLI:
         assert 'genre:"Science Fiction"' in show.output
         assert "Foundation" in show.output
 
-    def test_edit_clear_query_snapshots_to_static(
-        self, runner: CliRunner, db_path: Path
-    ) -> None:
+    def test_edit_clear_query_snapshots_to_static(self, runner: CliRunner, db_path: Path) -> None:
         _seed_sci_fi(db_path)
         runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Sci-Fi",
-             "--query", 'genre:"Science Fiction"'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Sci-Fi",
+                "--query",
+                'genre:"Science Fiction"',
+            ],
         )
         result = runner.invoke(
             cli, ["--db", str(db_path), "collections", "edit", "1", "--clear-query"]
@@ -287,16 +319,31 @@ class TestQueryBasedCollectionsCLI:
 
         both = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "edit", "1", "--query", "series:X",
-             "--clear-query"],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "edit",
+                "1",
+                "--query",
+                "series:X",
+                "--clear-query",
+            ],
         )
         assert both.exit_code != 0
 
     def test_author_query_creates_rule_collection(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Auth", "--query",
-             'author:"Frank Herbert"'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Auth",
+                "--query",
+                'author:"Frank Herbert"',
+            ],
         )
         assert result.exit_code == 0
 
@@ -306,8 +353,15 @@ class TestQueryBasedCollectionsCLI:
     def test_boolean_query_creates_rule_collection(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Combo", "--query",
-             'genre:"Science Fiction" AND author:Herbert'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Combo",
+                "--query",
+                'genre:"Science Fiction" AND author:Herbert',
+            ],
         )
         assert result.exit_code == 0
 
@@ -317,11 +371,79 @@ class TestQueryBasedCollectionsCLI:
     def test_non_canonical_genre_is_rejected(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Borg", "--query",
-             'genre:"Borg Romance"'],
+            [
+                "--db",
+                str(db_path),
+                "collections",
+                "create",
+                "Borg",
+                "--query",
+                'genre:"Borg Romance"',
+            ],
         )
         assert result.exit_code != 0
         # Rich may wrap the long genre list across lines, so assert on stable
         # fragments rather than a single (potentially wrapped) genre name.
         assert "canonical genre" in result.output
         assert "Valid genres" in result.output
+
+
+# The four canonical worked examples surfaced in every query-aware help screen,
+# one per category: single field, boolean, range/comparison, phrase + negation.
+WORKED_EXAMPLES = [
+    "series:Dune",
+    'genre:"Science Fiction" AND year:[2020 TO *]',
+    "rating:>=4",
+    'author:"Ursula K. Le Guin" NOT tag:reread',
+]
+
+
+class TestQueryHelp:
+    def test_query_help_documents_fields_operators_and_dates(
+        self, runner: CliRunner, db_path: Path
+    ) -> None:
+        result = runner.invoke(cli, ["--db", str(db_path), "collections", "query-help"])
+        assert result.exit_code == 0
+        out = result.output
+        # Every whitelisted field is named.
+        for field in [
+            "id",
+            "title",
+            "author",
+            "series",
+            "genre",
+            "tag",
+            "language",
+            "publisher",
+            "subject",
+            "isbn",
+            "year",
+            "rating",
+            "added",
+        ]:
+            assert field in out
+        # Boolean and range operators are documented.
+        assert "AND" in out and "OR" in out and "NOT" in out
+        assert "TO" in out  # range syntax [a TO b]
+        assert ">=" in out
+        # Date format is spelled out.
+        assert "ISO" in out
+        assert "YYYY-MM-DD" in out
+
+    def test_query_help_includes_worked_examples(self, runner: CliRunner, db_path: Path) -> None:
+        result = runner.invoke(cli, ["--db", str(db_path), "collections", "query-help"])
+        for example in WORKED_EXAMPLES:
+            assert example in result.output
+
+    @pytest.mark.parametrize("command", ["create", "edit", "preview"])
+    def test_command_help_has_cheatsheet_and_examples(
+        self, runner: CliRunner, command: str
+    ) -> None:
+        result = runner.invoke(cli, ["collections", command, "--help"])
+        assert result.exit_code == 0
+        out = result.output
+        # Pointer to the full reference.
+        assert "query-help" in out
+        # All four worked examples are present (epilog uses no-rewrap blocks).
+        for example in WORKED_EXAMPLES:
+            assert example in out

--- a/tests/e2e/test_collection_cli.py
+++ b/tests/e2e/test_collection_cli.py
@@ -216,7 +216,7 @@ class TestQueryBasedCollectionsCLI:
     def test_create_with_invalid_query_fails(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Bad", "--query", "publisher:Tor"],
+            ["--db", str(db_path), "collections", "create", "Bad", "--query", "nonsense:Tor"],
         )
         assert result.exit_code != 0
         assert "series" in result.output and "genre" in result.output
@@ -292,14 +292,16 @@ class TestQueryBasedCollectionsCLI:
         )
         assert both.exit_code != 0
 
-    def test_author_query_returns_slice4_deferral(self, runner: CliRunner, db_path: Path) -> None:
+    def test_author_query_creates_rule_collection(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(
             cli,
             ["--db", str(db_path), "collections", "create", "Auth", "--query",
              'author:"Frank Herbert"'],
         )
-        assert result.exit_code != 0
-        assert "#236" in result.output
+        assert result.exit_code == 0
+
+        show = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
+        assert 'author:"Frank Herbert"' in show.output
 
     def test_multi_term_query_is_rejected(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(

--- a/tests/e2e/test_collection_cli.py
+++ b/tests/e2e/test_collection_cli.py
@@ -303,14 +303,16 @@ class TestQueryBasedCollectionsCLI:
         show = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
         assert 'author:"Frank Herbert"' in show.output
 
-    def test_multi_term_query_is_rejected(self, runner: CliRunner, db_path: Path) -> None:
+    def test_boolean_query_creates_rule_collection(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(
             cli,
-            ["--db", str(db_path), "collections", "create", "Multi", "--query",
-             "genre:SF series:Dune"],
+            ["--db", str(db_path), "collections", "create", "Combo", "--query",
+             'genre:"Science Fiction" AND author:Herbert'],
         )
-        assert result.exit_code != 0
-        assert "single" in result.output.lower()
+        assert result.exit_code == 0
+
+        show = runner.invoke(cli, ["--db", str(db_path), "collections", "show", "1"])
+        assert 'genre:"Science Fiction" AND author:Herbert' in show.output
 
     def test_non_canonical_genre_is_rejected(self, runner: CliRunner, db_path: Path) -> None:
         result = runner.invoke(

--- a/tests/e2e/test_collection_cli.py
+++ b/tests/e2e/test_collection_cli.py
@@ -447,3 +447,14 @@ class TestQueryHelp:
         # All four worked examples are present (epilog uses no-rewrap blocks).
         for example in WORKED_EXAMPLES:
             assert example in out
+
+    def test_error_message_renders_brackets_literally(
+        self, runner: CliRunner, db_path: Path
+    ) -> None:
+        # The range-on-text-field error names the bracketed syntax; Rich must not
+        # eat '[a TO b]' as console markup.
+        result = runner.invoke(
+            cli, ["--db", str(db_path), "collections", "preview", "--query", "title:[a TO b]"]
+        )
+        assert result.exit_code != 0
+        assert "[a TO b]" in result.output

--- a/tests/unit/test_collection_query.py
+++ b/tests/unit/test_collection_query.py
@@ -1,29 +1,50 @@
 # ABOUTME: Unit tests for the pure collections query parser/validator module.
-# ABOUTME: Covers the slice-3 single-field equality subset and its error UX.
+# ABOUTME: Covers the scalar-field subset (exact/contains/prefix) and its error UX.
 
 import pytest
 
 from bookery.collections import (
-    CollectionQuery,
     CollectionQueryError,
+    Op,
+    QueryTerm,
     parse_collection_query,
 )
 from bookery.metadata.genres import CANONICAL_GENRES
 
 
-class TestValidQueries:
+class TestExactFields:
     def test_quoted_phrase_value(self) -> None:
         cq = parse_collection_query('genre:"Science Fiction"')
-        assert cq == CollectionQuery(field="genre", value="Science Fiction")
+        assert cq == QueryTerm(field="genre", op=Op.EQ, value="Science Fiction")
 
     def test_bare_word_value(self) -> None:
         cq = parse_collection_query("series:Dune")
-        assert cq == CollectionQuery(field="series", value="Dune")
+        assert cq == QueryTerm(field="series", op=Op.EQ, value="Dune")
 
     def test_series_quoted_multiword(self) -> None:
         cq = parse_collection_query('series:"The Lord of the Rings"')
         assert cq.field == "series"
         assert cq.value == "The Lord of the Rings"
+
+    def test_language_field(self) -> None:
+        cq = parse_collection_query("language:en")
+        assert cq == QueryTerm(field="language", op=Op.EQ, value="en")
+
+    def test_publisher_field(self) -> None:
+        cq = parse_collection_query("publisher:Tor")
+        assert cq == QueryTerm(field="publisher", op=Op.EQ, value="Tor")
+
+    def test_tag_field(self) -> None:
+        cq = parse_collection_query("tag:favorites")
+        assert cq == QueryTerm(field="tag", op=Op.EQ, value="favorites")
+
+    def test_isbn_field(self) -> None:
+        cq = parse_collection_query("isbn:9780441013593")
+        assert cq == QueryTerm(field="isbn", op=Op.EQ, value="9780441013593")
+
+    def test_id_field(self) -> None:
+        cq = parse_collection_query("id:42")
+        assert cq == QueryTerm(field="id", op=Op.EQ, value="42")
 
     def test_field_name_is_case_insensitive(self) -> None:
         cq = parse_collection_query('GENRE:"Science Fiction"')
@@ -37,39 +58,70 @@ class TestValidQueries:
 
     def test_surrounding_whitespace_is_ignored(self) -> None:
         cq = parse_collection_query("  series:Dune  ")
-        assert cq == CollectionQuery(field="series", value="Dune")
+        assert cq == QueryTerm(field="series", op=Op.EQ, value="Dune")
+
+
+class TestContainsFields:
+    def test_author_is_contains(self) -> None:
+        cq = parse_collection_query("author:Tolkien")
+        assert cq == QueryTerm(field="author", op=Op.CONTAINS, value="Tolkien")
+
+    def test_author_phrase_is_contains(self) -> None:
+        cq = parse_collection_query('author:"J.R.R. Tolkien"')
+        assert cq == QueryTerm(field="author", op=Op.CONTAINS, value="J.R.R. Tolkien")
+
+    def test_subject_is_contains(self) -> None:
+        cq = parse_collection_query("subject:dystopia")
+        assert cq == QueryTerm(field="subject", op=Op.CONTAINS, value="dystopia")
+
+
+class TestPrefix:
+    def test_title_prefix(self) -> None:
+        cq = parse_collection_query("title:Dune*")
+        assert cq == QueryTerm(field="title", op=Op.PREFIX, value="Dune")
+
+    def test_title_exact(self) -> None:
+        cq = parse_collection_query('title:"Children of Dune"')
+        assert cq == QueryTerm(field="title", op=Op.EQ, value="Children of Dune")
+
+    def test_prefix_on_non_prefix_field_is_rejected(self) -> None:
+        # Only title supports prefix in this release; series does not.
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("series:Sci*")
+
+    def test_interior_wildcard_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("title:Du*ne")
+
+    def test_question_mark_wildcard_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("title:Dun?")
 
 
 class TestFieldValidation:
     def test_unknown_field_lists_whitelist(self) -> None:
         with pytest.raises(CollectionQueryError) as exc:
-            parse_collection_query("publisher:Tor")
+            parse_collection_query("nonsense:x")
         msg = str(exc.value)
-        assert "publisher" in msg
-        assert "series" in msg and "genre" in msg
-
-    def test_author_returns_slice4_deferral(self) -> None:
-        with pytest.raises(CollectionQueryError) as exc:
-            parse_collection_query('author:"Frank Herbert"')
-        msg = str(exc.value)
-        assert "#236" in msg
-        # Must be the specific deferral, not the generic unknown-field error.
-        assert "Unknown field" not in msg
+        assert "nonsense" in msg
+        # The whitelist should be advertised in the error.
+        assert "series" in msg and "genre" in msg and "author" in msg
 
     def test_non_canonical_genre_lists_valid_genres(self) -> None:
         with pytest.raises(CollectionQueryError) as exc:
             parse_collection_query('genre:"Borg Romance"')
         msg = str(exc.value)
         assert "Borg Romance" in msg
-        # A sampling of canonical genres should be named in the message.
         assert "Science Fiction" in msg
         assert all(g in msg for g in CANONICAL_GENRES)
 
-
-class TestRejectedShapes:
-    def test_multi_term_is_rejected(self) -> None:
+    def test_id_non_integer_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):
-            parse_collection_query("genre:SF series:Y")
+            parse_collection_query("id:abc")
+
+
+class TestStillRejected:
+    """Shapes that land in later sub-slices remain rejected for now."""
 
     def test_explicit_and_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):
@@ -83,17 +135,21 @@ class TestRejectedShapes:
         with pytest.raises(CollectionQueryError):
             parse_collection_query("NOT genre:Horror")
 
-    def test_bare_term_without_field_is_rejected(self) -> None:
+    def test_implicit_multi_term_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):
-            parse_collection_query("Dune")
-
-    def test_wildcard_is_rejected(self) -> None:
-        with pytest.raises(CollectionQueryError):
-            parse_collection_query("series:Sci*")
+            parse_collection_query("genre:SF series:Y")
 
     def test_range_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):
-            parse_collection_query("series:[a TO b]")
+            parse_collection_query("year:[2000 TO 2010]")
+
+    def test_comparison_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("rating:>=4")
+
+    def test_bare_term_without_field_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("Dune")
 
     def test_empty_query_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):

--- a/tests/unit/test_collection_query.py
+++ b/tests/unit/test_collection_query.py
@@ -6,6 +6,9 @@ import pytest
 from bookery.collections import (
     CollectionQueryError,
     Op,
+    QueryAnd,
+    QueryNot,
+    QueryOr,
     QueryTerm,
     parse_collection_query,
 )
@@ -23,6 +26,7 @@ class TestExactFields:
 
     def test_series_quoted_multiword(self) -> None:
         cq = parse_collection_query('series:"The Lord of the Rings"')
+        assert isinstance(cq, QueryTerm)
         assert cq.field == "series"
         assert cq.value == "The Lord of the Rings"
 
@@ -48,11 +52,13 @@ class TestExactFields:
 
     def test_field_name_is_case_insensitive(self) -> None:
         cq = parse_collection_query('GENRE:"Science Fiction"')
+        assert isinstance(cq, QueryTerm)
         assert cq.field == "genre"
 
     def test_genre_value_is_case_insensitive(self) -> None:
         # Canonical match is case-insensitive; the raw value is preserved.
         cq = parse_collection_query('genre:"science fiction"')
+        assert isinstance(cq, QueryTerm)
         assert cq.field == "genre"
         assert cq.value == "science fiction"
 
@@ -214,25 +220,77 @@ class TestRangeValidation:
             parse_collection_query("year:[abc TO 2010]")
 
 
-class TestStillRejected:
-    """Shapes that land in later sub-slices remain rejected for now."""
+class TestBooleanComposition:
+    def test_explicit_and(self) -> None:
+        cq = parse_collection_query('genre:"Science Fiction" AND series:Dune')
+        assert cq == QueryAnd(
+            (
+                QueryTerm(field="genre", op=Op.EQ, value="Science Fiction"),
+                QueryTerm(field="series", op=Op.EQ, value="Dune"),
+            )
+        )
 
-    def test_explicit_and_is_rejected(self) -> None:
+    def test_explicit_or(self) -> None:
+        cq = parse_collection_query("author:Tolkien OR author:Lewis")
+        assert cq == QueryOr(
+            (
+                QueryTerm(field="author", op=Op.CONTAINS, value="Tolkien"),
+                QueryTerm(field="author", op=Op.CONTAINS, value="Lewis"),
+            )
+        )
+
+    def test_top_level_not(self) -> None:
+        cq = parse_collection_query("NOT genre:Horror")
+        assert cq == QueryNot(QueryTerm(field="genre", op=Op.EQ, value="Horror"))
+
+    def test_implicit_and(self) -> None:
+        cq = parse_collection_query("author:Tolkien author:Lewis")
+        assert cq == QueryAnd(
+            (
+                QueryTerm(field="author", op=Op.CONTAINS, value="Tolkien"),
+                QueryTerm(field="author", op=Op.CONTAINS, value="Lewis"),
+            )
+        )
+
+    def test_and_with_not(self) -> None:
+        cq = parse_collection_query("genre:Fantasy NOT tag:reread")
+        assert cq == QueryAnd(
+            (
+                QueryTerm(field="genre", op=Op.EQ, value="Fantasy"),
+                QueryNot(QueryTerm(field="tag", op=Op.EQ, value="reread")),
+            )
+        )
+
+    def test_plus_minus_prefixes(self) -> None:
+        cq = parse_collection_query("+genre:Fantasy -tag:reread")
+        assert cq == QueryAnd(
+            (
+                QueryTerm(field="genre", op=Op.EQ, value="Fantasy"),
+                QueryNot(QueryTerm(field="tag", op=Op.EQ, value="reread")),
+            )
+        )
+
+    def test_grouping_controls_precedence(self) -> None:
+        cq = parse_collection_query("(author:Tolkien OR author:Lewis) AND year:[2020 TO *]")
+        assert cq == QueryAnd(
+            (
+                QueryOr(
+                    (
+                        QueryTerm(field="author", op=Op.CONTAINS, value="Tolkien"),
+                        QueryTerm(field="author", op=Op.CONTAINS, value="Lewis"),
+                    )
+                ),
+                QueryTerm(field="year", op=Op.RANGE, low="2020", high=None),
+            )
+        )
+
+    def test_validation_applies_inside_boolean(self) -> None:
+        # A non-canonical genre nested in a boolean is still rejected.
         with pytest.raises(CollectionQueryError):
-            parse_collection_query('genre:"Science Fiction" AND series:Dune')
+            parse_collection_query('genre:"Borg Romance" OR series:Dune')
 
-    def test_explicit_or_is_rejected(self) -> None:
-        with pytest.raises(CollectionQueryError):
-            parse_collection_query('genre:"Science Fiction" OR genre:Fantasy')
 
-    def test_explicit_not_is_rejected(self) -> None:
-        with pytest.raises(CollectionQueryError):
-            parse_collection_query("NOT genre:Horror")
-
-    def test_implicit_multi_term_is_rejected(self) -> None:
-        with pytest.raises(CollectionQueryError):
-            parse_collection_query("genre:SF series:Y")
-
+class TestRejectedSyntax:
     def test_bare_term_without_field_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):
             parse_collection_query("Dune")

--- a/tests/unit/test_collection_query.py
+++ b/tests/unit/test_collection_query.py
@@ -120,6 +120,100 @@ class TestFieldValidation:
             parse_collection_query("id:abc")
 
 
+class TestRangesAndComparisons:
+    def test_inclusive_range(self) -> None:
+        cq = parse_collection_query("year:[2000 TO 2010]")
+        assert cq == QueryTerm(
+            field="year",
+            op=Op.RANGE,
+            low="2000",
+            high="2010",
+            include_low=True,
+            include_high=True,
+        )
+
+    def test_exclusive_range(self) -> None:
+        cq = parse_collection_query("year:{2000 TO 2010}")
+        assert cq == QueryTerm(
+            field="year",
+            op=Op.RANGE,
+            low="2000",
+            high="2010",
+            include_low=False,
+            include_high=False,
+        )
+
+    def test_open_upper_range(self) -> None:
+        cq = parse_collection_query("year:[2020 TO *]")
+        assert cq == QueryTerm(field="year", op=Op.RANGE, low="2020", high=None)
+
+    def test_open_lower_range(self) -> None:
+        cq = parse_collection_query("year:[* TO 2010]")
+        assert cq == QueryTerm(field="year", op=Op.RANGE, low=None, high="2010")
+
+    def test_ge_comparison(self) -> None:
+        assert parse_collection_query("rating:>=4") == QueryTerm(
+            field="rating", op=Op.GE, value="4"
+        )
+
+    def test_gt_comparison(self) -> None:
+        assert parse_collection_query("rating:>4") == QueryTerm(
+            field="rating", op=Op.GT, value="4"
+        )
+
+    def test_le_comparison(self) -> None:
+        assert parse_collection_query("rating:<=5") == QueryTerm(
+            field="rating", op=Op.LE, value="5"
+        )
+
+    def test_lt_comparison(self) -> None:
+        assert parse_collection_query("rating:<2") == QueryTerm(
+            field="rating", op=Op.LT, value="2"
+        )
+
+    def test_fractional_rating(self) -> None:
+        assert parse_collection_query("rating:>=4.5") == QueryTerm(
+            field="rating", op=Op.GE, value="4.5"
+        )
+
+    def test_year_equality_still_works(self) -> None:
+        assert parse_collection_query("year:2020") == QueryTerm(
+            field="year", op=Op.EQ, value="2020"
+        )
+
+    def test_added_iso_date_range(self) -> None:
+        cq = parse_collection_query("added:[2024-01-01 TO 2024-12-31]")
+        assert cq == QueryTerm(field="added", op=Op.RANGE, low="2024-01-01", high="2024-12-31")
+
+
+class TestRangeValidation:
+    def test_range_on_non_comparable_field_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError) as exc:
+            parse_collection_query("series:[a TO b]")
+        # The message should name the comparable fields.
+        assert "year" in str(exc.value) and "rating" in str(exc.value)
+
+    def test_comparison_on_non_comparable_field_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("title:>=4")
+
+    def test_non_integer_year_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("year:twenty")
+
+    def test_non_numeric_rating_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("rating:>=high")
+
+    def test_bad_added_date_is_rejected(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("added:2024-13-99")
+
+    def test_range_bound_is_validated(self) -> None:
+        with pytest.raises(CollectionQueryError):
+            parse_collection_query("year:[abc TO 2010]")
+
+
 class TestStillRejected:
     """Shapes that land in later sub-slices remain rejected for now."""
 
@@ -138,14 +232,6 @@ class TestStillRejected:
     def test_implicit_multi_term_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):
             parse_collection_query("genre:SF series:Y")
-
-    def test_range_is_rejected(self) -> None:
-        with pytest.raises(CollectionQueryError):
-            parse_collection_query("year:[2000 TO 2010]")
-
-    def test_comparison_is_rejected(self) -> None:
-        with pytest.raises(CollectionQueryError):
-            parse_collection_query("rating:>=4")
 
     def test_bare_term_without_field_is_rejected(self) -> None:
         with pytest.raises(CollectionQueryError):

--- a/tests/unit/test_collection_query_resolver.py
+++ b/tests/unit/test_collection_query_resolver.py
@@ -23,13 +23,30 @@ def _add(
     *,
     series: str | None = None,
     genre: str | None = None,
+    authors: list[str] | None = None,
+    language: str | None = None,
+    publisher: str | None = None,
+    isbn: str | None = None,
+    subjects: list[str] | None = None,
+    tag: str | None = None,
 ) -> int:
     book_id = catalog.add_book(
-        BookMetadata(title=title, series=series, source_path=Path(f"/books/{title}.epub")),
+        BookMetadata(
+            title=title,
+            series=series,
+            authors=authors or [],
+            language=language,
+            publisher=publisher,
+            isbn=isbn,
+            subjects=subjects or [],
+            source_path=Path(f"/books/{title}.epub"),
+        ),
         file_hash=f"hash_{title}",
     )
     if genre is not None:
         catalog.add_genre(book_id, genre, is_primary=True)
+    if tag is not None:
+        catalog.add_tag(book_id, tag)
     return book_id
 
 
@@ -100,6 +117,65 @@ class TestResolveMembers:
         assert [r.id for r in catalog.get_collection_books(cid)] == [sf]
 
 
+class TestScalarFieldRules:
+    def test_author_contains_matches_substring(self, catalog: LibraryCatalog) -> None:
+        a = _add(catalog, "Fellowship", authors=["J.R.R. Tolkien"])
+        b = _add(catalog, "Silmarillion", authors=["J.R.R. Tolkien", "Christopher Tolkien"])
+        _add(catalog, "Narnia", authors=["C.S. Lewis"])
+        cid = catalog.create_collection("Tolkien", query="author:Tolkien")
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([a, b])
+
+    def test_subject_contains_matches_substring(self, catalog: LibraryCatalog) -> None:
+        d = _add(catalog, "1984", subjects=["Dystopian fiction", "Politics"])
+        _add(catalog, "Pride", subjects=["Romance"])
+        cid = catalog.create_collection("Dystopia", query="subject:Dystopian")
+        assert catalog.resolve_collection_member_ids(cid) == [d]
+
+    def test_title_prefix_is_left_anchored(self, catalog: LibraryCatalog) -> None:
+        d1 = _add(catalog, "Dune")
+        d2 = _add(catalog, "Dune Messiah")
+        _add(catalog, "Children of Dune")  # "Dune" not a prefix here
+        cid = catalog.create_collection("Dune-prefixed", query="title:Dune*")
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([d1, d2])
+
+    def test_publisher_equality(self, catalog: LibraryCatalog) -> None:
+        t = _add(catalog, "Hyperion", publisher="Tor")
+        _add(catalog, "Other", publisher="Ace")
+        cid = catalog.create_collection("Tor", query="publisher:Tor")
+        assert catalog.resolve_collection_member_ids(cid) == [t]
+
+    def test_language_equality(self, catalog: LibraryCatalog) -> None:
+        en = _add(catalog, "English Book", language="en")
+        _add(catalog, "French Book", language="fr")
+        cid = catalog.create_collection("English", query="language:en")
+        assert catalog.resolve_collection_member_ids(cid) == [en]
+
+    def test_isbn_equality(self, catalog: LibraryCatalog) -> None:
+        target = _add(catalog, "ISBN Book", isbn="9780441013593")
+        _add(catalog, "Other ISBN", isbn="9780553283686")
+        cid = catalog.create_collection("ByISBN", query="isbn:9780441013593")
+        assert catalog.resolve_collection_member_ids(cid) == [target]
+
+    def test_tag_membership(self, catalog: LibraryCatalog) -> None:
+        f1 = _add(catalog, "Fav One", tag="favorites")
+        _add(catalog, "Meh", tag="meh")
+        cid = catalog.create_collection("Favs", query="tag:favorites")
+        assert catalog.resolve_collection_member_ids(cid) == [f1]
+
+    def test_id_equality(self, catalog: LibraryCatalog) -> None:
+        a = _add(catalog, "A")
+        _add(catalog, "B")
+        cid = catalog.create_collection("ById", query=f"id:{a}")
+        assert catalog.resolve_collection_member_ids(cid) == [a]
+
+    def test_like_metacharacters_match_literally(self, catalog: LibraryCatalog) -> None:
+        # A literal '%' in the value must not become a wildcard.
+        match = _add(catalog, "Pct", authors=["50% Off"])
+        _add(catalog, "NoPct", authors=["Frank Herbert"])
+        cid = catalog.create_collection("Pct", query='author:"50% Off"')
+        assert catalog.resolve_collection_member_ids(cid) == [match]
+
+
 class TestPreviewQuery:
     def test_preview_returns_records_without_saving(self, catalog: LibraryCatalog) -> None:
         _add(catalog, "SF One", genre="Science Fiction")
@@ -110,7 +186,7 @@ class TestPreviewQuery:
 
     def test_preview_invalid_query_raises(self, catalog: LibraryCatalog) -> None:
         with pytest.raises(CollectionQueryError):
-            catalog.preview_query("publisher:Tor")
+            catalog.preview_query("nonsense:Tor")
 
 
 class TestConversion:
@@ -154,7 +230,7 @@ class TestConversion:
     ) -> None:
         cid = catalog.create_collection("X")
         with pytest.raises(CollectionQueryError):
-            catalog.set_collection_query(cid, "publisher:Tor")
+            catalog.set_collection_query(cid, "nonsense:Tor")
         assert _query_of(catalog, cid) is None
 
 

--- a/tests/unit/test_collection_query_resolver.py
+++ b/tests/unit/test_collection_query_resolver.py
@@ -243,6 +243,50 @@ class TestRangeAndComparisonRules:
         assert before not in members
 
 
+class TestBooleanRules:
+    def test_and_intersects(self, catalog: LibraryCatalog) -> None:
+        match = _add(catalog, "Dune", genre="Science Fiction", authors=["Frank Herbert"])
+        _add(catalog, "Neuromancer", genre="Science Fiction", authors=["William Gibson"])
+        _add(catalog, "Hellstrom", genre="Horror", authors=["Frank Herbert"])
+        cid = catalog.create_collection(
+            "SF Herbert", query='genre:"Science Fiction" AND author:Herbert'
+        )
+        assert catalog.resolve_collection_member_ids(cid) == [match]
+
+    def test_or_unions(self, catalog: LibraryCatalog) -> None:
+        t = _add(catalog, "Hobbit", authors=["J.R.R. Tolkien"])
+        lewis = _add(catalog, "Narnia", authors=["C.S. Lewis"])
+        _add(catalog, "Dune", authors=["Frank Herbert"])
+        cid = catalog.create_collection("Inklings", query="author:Tolkien OR author:Lewis")
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([t, lewis])
+
+    def test_and_not_excludes(self, catalog: LibraryCatalog) -> None:
+        keep = _add(catalog, "Fresh Fantasy", genre="Fantasy")
+        _add(catalog, "Old Favorite", genre="Fantasy", tag="reread")
+        cid = catalog.create_collection("Unread Fantasy", query="genre:Fantasy NOT tag:reread")
+        assert catalog.resolve_collection_member_ids(cid) == [keep]
+
+    def test_top_level_not_returns_complement(self, catalog: LibraryCatalog) -> None:
+        _add(catalog, "Scary", genre="Horror")
+        fantasy = _add(catalog, "Friendly", genre="Fantasy")
+        plain = _add(catalog, "Plain")  # no genre at all
+        cid = catalog.create_collection("Not Horror", query="NOT genre:Horror")
+        members = catalog.resolve_collection_member_ids(cid)
+        assert set(members) == {fantasy, plain}
+
+    def test_grouping_controls_precedence(self, catalog: LibraryCatalog) -> None:
+        recent_t = _add(
+            catalog, "New Tolkien", authors=["J.R.R. Tolkien"], published_date="2021-01-01"
+        )
+        _add(catalog, "Old Lewis", authors=["C.S. Lewis"], published_date="2019-01-01")
+        _add(catalog, "New Herbert", authors=["Frank Herbert"], published_date="2022-01-01")
+        cid = catalog.create_collection(
+            "Recent Inklings",
+            query="(author:Tolkien OR author:Lewis) AND year:[2020 TO *]",
+        )
+        assert catalog.resolve_collection_member_ids(cid) == [recent_t]
+
+
 class TestPreviewQuery:
     def test_preview_returns_records_without_saving(self, catalog: LibraryCatalog) -> None:
         _add(catalog, "SF One", genre="Science Fiction")

--- a/tests/unit/test_collection_query_resolver.py
+++ b/tests/unit/test_collection_query_resolver.py
@@ -29,6 +29,9 @@ def _add(
     isbn: str | None = None,
     subjects: list[str] | None = None,
     tag: str | None = None,
+    published_date: str | None = None,
+    rating: float | None = None,
+    date_added: str | None = None,
 ) -> int:
     book_id = catalog.add_book(
         BookMetadata(
@@ -39,6 +42,8 @@ def _add(
             publisher=publisher,
             isbn=isbn,
             subjects=subjects or [],
+            published_date=published_date,
+            rating=rating,
             source_path=Path(f"/books/{title}.epub"),
         ),
         file_hash=f"hash_{title}",
@@ -47,6 +52,12 @@ def _add(
         catalog.add_genre(book_id, genre, is_primary=True)
     if tag is not None:
         catalog.add_tag(book_id, tag)
+    if date_added is not None:
+        # date_added is DB-managed (defaults to now); override it for added: tests.
+        catalog._conn.execute(
+            "UPDATE books SET date_added = ? WHERE id = ?", (date_added, book_id)
+        )
+        catalog._conn.commit()
     return book_id
 
 
@@ -176,6 +187,62 @@ class TestScalarFieldRules:
         assert catalog.resolve_collection_member_ids(cid) == [match]
 
 
+class TestRangeAndComparisonRules:
+    def test_year_inclusive_range(self, catalog: LibraryCatalog) -> None:
+        old = _add(catalog, "Old", published_date="1999-06-01")
+        lo = _add(catalog, "Lo", published_date="2000-01-01")
+        mid = _add(catalog, "Mid", published_date="2005-03-03")
+        hi = _add(catalog, "Hi", published_date="2010-12-31")
+        _add(catalog, "Future", published_date="2011-01-01")
+        cid = catalog.create_collection("00s", query="year:[2000 TO 2010]")
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([lo, mid, hi])
+        assert old not in catalog.resolve_collection_member_ids(cid)
+
+    def test_year_exclusive_range_drops_endpoints(self, catalog: LibraryCatalog) -> None:
+        _add(catalog, "Lo", published_date="2000-01-01")
+        mid = _add(catalog, "Mid", published_date="2005-03-03")
+        _add(catalog, "Hi", published_date="2010-12-31")
+        cid = catalog.create_collection("strict", query="year:{2000 TO 2010}")
+        assert catalog.resolve_collection_member_ids(cid) == [mid]
+
+    def test_year_open_upper_bound(self, catalog: LibraryCatalog) -> None:
+        _add(catalog, "Old", published_date="2019-01-01")
+        new1 = _add(catalog, "New1", published_date="2020-01-01")
+        new2 = _add(catalog, "New2", published_date="2024-06-01")
+        cid = catalog.create_collection("2020+", query="year:[2020 TO *]")
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([new1, new2])
+
+    def test_year_equality(self, catalog: LibraryCatalog) -> None:
+        match = _add(catalog, "Y2020", published_date="2020-07-07")
+        _add(catalog, "Y2019", published_date="2019-07-07")
+        cid = catalog.create_collection("Just2020", query="year:2020")
+        assert catalog.resolve_collection_member_ids(cid) == [match]
+
+    def test_rating_ge_comparison(self, catalog: LibraryCatalog) -> None:
+        good = _add(catalog, "Good", rating=4.5)
+        edge = _add(catalog, "Edge", rating=4.0)
+        _add(catalog, "Meh", rating=3.0)
+        cid = catalog.create_collection("Top", query="rating:>=4")
+        assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([good, edge])
+
+    def test_rating_gt_excludes_boundary(self, catalog: LibraryCatalog) -> None:
+        good = _add(catalog, "Good", rating=4.5)
+        _add(catalog, "Edge", rating=4.0)
+        cid = catalog.create_collection("AboveFour", query="rating:>4")
+        assert catalog.resolve_collection_member_ids(cid) == [good]
+
+    def test_added_date_range(self, catalog: LibraryCatalog) -> None:
+        before = _add(catalog, "Before", date_added="2023-12-31T10:00:00")
+        within = _add(catalog, "Within", date_added="2024-06-15T08:30:00")
+        on_end = _add(catalog, "OnEnd", date_added="2024-12-31T23:59:59")
+        _add(catalog, "After", date_added="2025-01-02T00:00:00")
+        cid = catalog.create_collection("2024", query="added:[2024-01-01 TO 2024-12-31]")
+        members = sorted(catalog.resolve_collection_member_ids(cid))
+        # Day-granularity: a timestamp late on the end date is still included.
+        assert members == sorted([within, on_end])
+        assert before not in members
+
+
 class TestPreviewQuery:
     def test_preview_returns_records_without_saving(self, catalog: LibraryCatalog) -> None:
         _add(catalog, "SF One", genre="Science Fiction")
@@ -225,9 +292,7 @@ class TestConversion:
         assert snapshot == {sf1, sf2}
         assert sorted(catalog.resolve_collection_member_ids(cid)) == sorted([sf1, sf2])
 
-    def test_set_invalid_query_raises_and_does_not_persist(
-        self, catalog: LibraryCatalog
-    ) -> None:
+    def test_set_invalid_query_raises_and_does_not_persist(self, catalog: LibraryCatalog) -> None:
         cid = catalog.create_collection("X")
         with pytest.raises(CollectionQueryError):
             catalog.set_collection_query(cid, "nonsense:Tor")


### PR DESCRIPTION
## Summary

Slice 4 of the Collections epic (#179) grows the rule-based collection query engine from the slice-3 subset (a single `series`/`genre` equality term) to the full whitelisted Lucene surface: every documented field, boolean composition, ranges, comparisons, phrases, and prefix — plus CLI help surfaces. The governing constraint held throughout: **the `parse_collection_query` entry point signature never changed** — only the validator whitelist relaxed and the compiler grew.

Shipped as 5 TDD commits across 4 vertical sub-slices, each with paired tests.

## Changes

- **`collections/query.py`** — `parse_collection_query` now walks the full luqum AST into an immutable query IR: `QueryTerm` leaves (ops `EQ`/`CONTAINS`/`PREFIX`/`RANGE`/`GE`/`GT`/`LE`/`LT`) and `QueryAnd`/`QueryOr`/`QueryNot` combinators. Parse-permissive / validate-restrictive: every leaf is whitelist-validated at any nesting depth. luqum stays quarantined here (no DB import).
- **`db/catalog.py`** — recursive IR→SQL compiler. Leaves compile to `SELECT id FROM books b WHERE …` (EXISTS for genre/tag joins); booleans compose via nested `b.id IN (subquery)` / `NOT IN` (precedence-safe, since SQLite won't parenthesize compound SELECTs). **Every value is a bound parameter** — no user input is interpolated into SQL text. LIKE metacharacters escaped via `ESCAPE '\'`.
- **`cli/commands/collection_cmd.py`** — new `collections query-help` Rich reference (fields, operators, ISO dates, worked examples, pitfalls); a shared no-rewrap cheat-sheet epilog with four worked examples on `create`/`edit`/`preview --help`; and escaping of query-error text so Rich renders `[a TO b]` literally.
- **`README.md`** — full query-language reference replaces the stale "deliberately small subset" note.

### Field surface

| Field | Match |
|-------|-------|
| `id` | exact |
| `title` | exact, phrase, prefix `*` |
| `author`, `subject` | contains (substring) |
| `series`, `genre`, `tag`, `language`, `publisher`, `isbn` | exact (genre canonical) |
| `year`, `rating`, `added` | `=`, range `[a TO b]`/`{a TO b}`, comparisons `>= <= > <` |

Operators: `AND` `OR` `NOT`, grouping `( )`, `+`/`-` prefixes. Fuzzy `~` and boost `^` remain deferred (out of scope per the issue).

### Design decisions
- `author`/`subject` use **contains** semantics (the `authors` column is a comma/JSON-joined string, so exact equality is useless for a single name).
- `year` derives from `published_date` (edition date), compared as an integer-cast 4-char prefix.
- `added` compares at **day granularity** (date prefix of the stored ISO timestamp), so an inclusive end-date still matches late-in-day timestamps.

## Testing
- [x] Unit (parser) + unit (resolver) + e2e (CLI) — paired with each sub-slice (TDD)
- [x] Full suite: **2248 passing**; ruff + pyright clean
- [x] Manual smoke against a real DB: boolean+range+comparison preview/create/show, `query-help` rendering, and error UX (bad genre, range-on-text-field, bad date)
- [x] Regression test for the Rich bracket-escaping fix

## Related Issues
Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)