### PR TITLE
Add #252: Web create & edit collection pages (incl. rule strings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 - **Interactive review** — presents candidates in a Rich table, lets you accept, compare details, look up by URL, or skip
 - **Smart normalization** — splits mangled filenames like `SteveBerry-TheTemplarLegacy` into clean search queries, detects embedded author names
 - **SQLite catalog** — imports books into a local database for querying, tagging, and integrity checks
-- **Web UI** — `bookery serve` launches a local browser UI for paginated/sortable browsing of the catalog, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail/edit pages, search-active-providers, and "apply candidate metadata with diff" rematch flow.
+- **Web UI** — `bookery serve` launches a local browser UI for paginated/sortable browsing of the catalog, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail/edit pages, collection create/edit (including raw rule strings) with inline validation, search-active-providers, and "apply candidate metadata with diff" rematch flow.
 - **Genre management** — `bookery genre` auto-maps raw provider subjects to a canonical genre vocabulary, with `assign` / `apply` / `auto` / `stats` / `unmatched` for curation.
 - **Obsidian vault-export** — `bookery vault-export` turns an Obsidian vault into a single EPUB with a hierarchical folder/note TOC, A-Z buckets within each folder, leading-article-aware filing ("The Loop" files under L), resolved `[[wiki-links]]` and `![[image]]` embeds, and an optional tag index. Can auto-catalog the export so it ships on the next Kobo sync.
 - **Non-destructive** — metadata writes always go to a copy; original file contents are never modified. `add` copies each source into your library by default (`--move` deletes the source after a successful catalog insert)
@@ -243,6 +243,8 @@ author:"Ursula K. Le Guin" NOT tag:reread
 | `serve` | Launch the local web UI (`--host`, `--port`; default `127.0.0.1:5000`) |
 
 The web UI provides paginated and sortable browsing, filter chips, cover thumbnails, a responsive mobile card layout, per-book detail and edit pages, a "search active providers" flow that lets you apply candidate metadata with a side-by-side diff, and inline delete. When you apply a candidate, its cover image (if the provider offers one) is fetched and embedded into the non-destructive EPUB copy alongside the text fields; a cover-fetch failure is non-fatal — the text metadata still applies and the result message notes the cover was skipped.
+
+Collections can be created and edited directly from the web UI. "New collection" (on the collections page) opens a form for the name, an optional description, and an optional raw rule query (the same Lucene subset as `collections create --query`); leave the query blank for a hand-picked static collection. Each collection's detail page has an "Edit" affordance for changing its name, description, and (for an already rule-based collection) its rule. Invalid input — a blank or duplicate name, or an unparseable rule — is reported inline on the form with the field whitelist hint, never as an error page.
 
 ### Device sync
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,6 +72,7 @@
 - [x] Apply candidate metadata with side-by-side diff
 - [x] Delete book from detail page
 - [x] Persistent book context subhead on sub-flows
+- [x] Create and edit collections from the UI (incl. raw rule strings) with inline validation
 
 ## Phase 8: Vault-Export
 - [x] Obsidian vault → single EPUB pipeline (pandoc)

--- a/src/bookery/db/catalog.py
+++ b/src/bookery/db/catalog.py
@@ -1801,6 +1801,28 @@ class LibraryCatalog:
         if cursor.rowcount == 0:
             raise ValueError(f"Collection {collection_id} not found")
 
+    def set_collection_description(
+        self, collection_id: int, description: str | None
+    ) -> None:
+        """Set (or clear) a collection's description.
+
+        Args:
+            collection_id: The ID of the collection to update.
+            description: The new description, or None to clear it.
+
+        Raises:
+            ValueError: If the collection doesn't exist.
+        """
+        cursor = self._conn.execute(
+            "UPDATE collections SET description = ?, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%S', 'now') WHERE id = ?",
+            (description, collection_id),
+        )
+        self._conn.commit()
+
+        if cursor.rowcount == 0:
+            raise ValueError(f"Collection {collection_id} not found")
+
     def get_collections_for_book(self, book_id: int) -> list[dict[str, object]]:
         """Get all collections that a book belongs to.
 

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -3,6 +3,8 @@
 
 import logging
 import os
+import sqlite3
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -19,7 +21,9 @@ from flask import (
     request,
     url_for,
 )
+from werkzeug.wrappers import Response as WerkzeugResponse
 
+from bookery.collections import CollectionQueryError, parse_collection_query
 from bookery.core.config import get_library_root
 from bookery.core.coverfetch import fetch_cover_image
 from bookery.core.enrichment import dispatch_from_form, multi_provider_search
@@ -1124,23 +1128,235 @@ def collection_remove_book(collection_id, book_id):
 
 @bp.route("/collections/create", methods=["POST"])
 def collection_create():
-    """Create a new collection."""
+    """Create a collection (static or rule-based) with inline validation.
+
+    User-input failures (blank name, duplicate name, invalid rule query) re-render
+    the form partial at HTTP 200 so the htmx swap lands; no exception escapes as a
+    500. On success the browser is redirected to the new collection's detail page.
+    """
     catalog = current_app.config["CATALOG"]
 
     name = request.form.get("name", "").strip()
     description = request.form.get("description", "").strip() or None
+    query = request.form.get("query", "").strip() or None
+    form = {
+        "name": name,
+        "description": request.form.get("description", ""),
+        "query": request.form.get("query", ""),
+    }
 
+    errors: dict[str, str] = {}
     if not name:
-        flash("Collection name is required.", "error")
-        return redirect(url_for("web.collections_list"))
+        errors["name"] = "Collection name is required."
+    elif catalog.get_collection_by_name(name) is not None:
+        errors["name"] = f"A collection named '{name}' already exists."
+
+    if query is not None:
+        try:
+            parse_collection_query(query)
+        except CollectionQueryError as exc:
+            errors["query"] = str(exc)
+
+    if errors:
+        return _render_collection_form(
+            mode="create",
+            action_url=url_for("web.collection_create"),
+            target="#collections-content",
+            container_id="collections-content",
+            cancel_url=url_for("web.collections_list"),
+            form=form,
+            errors=errors,
+        )
 
     try:
-        collection_id = catalog.create_collection(name, description)
-        flash(f'Created collection "{name}".', "success")
-        return redirect(url_for("web.collection_detail", collection_id=collection_id))
-    except Exception as exc:
-        flash(f"Failed to create collection: {exc}", "error")
-        return redirect(url_for("web.collections_list"))
+        collection_id = catalog.create_collection(name, description, query=query)
+    except sqlite3.IntegrityError:
+        return _render_collection_form(
+            mode="create",
+            action_url=url_for("web.collection_create"),
+            target="#collections-content",
+            container_id="collections-content",
+            cancel_url=url_for("web.collections_list"),
+            form=form,
+            errors={"name": f"A collection named '{name}' already exists."},
+        )
+
+    flash(f'Created collection "{name}".', "success")
+    return _redirect_after_save(
+        url_for("web.collection_detail", collection_id=collection_id)
+    )
+
+
+def _render_collection_form(
+    *,
+    mode: str,
+    action_url: str,
+    target: str,
+    container_id: str,
+    cancel_url: str,
+    form: Mapping[str, str],
+    errors: Mapping[str, str],
+) -> tuple[str, int]:
+    """Render the collection form, full-page on plain GET and partial under htmx.
+
+    Always returns HTTP 200: validation failures re-render the partial inline so
+    the htmx swap lands rather than surfacing a browser error page.
+    """
+    template = (
+        "_collection_form.html"
+        if request.headers.get("HX-Request")
+        else "collection_form.html"
+    )
+    html = render_template(
+        template,
+        mode=mode,
+        action_url=action_url,
+        target=target,
+        container_id=container_id,
+        cancel_url=cancel_url,
+        form=form,
+        errors=errors,
+    )
+    return html, 200
+
+
+def _redirect_after_save(target_url: str) -> WerkzeugResponse:
+    """Send the browser to ``target_url`` — via HX-Redirect under htmx, else a 302."""
+    if request.headers.get("HX-Request"):
+        return _hx_redirect(target_url)
+    return redirect(target_url)
+
+
+@bp.route("/collections/new")
+def collection_new_form():
+    """Render the create-collection form (full page or htmx partial).
+
+    An optional ``?query=`` prefills the rule textarea so the book-detail
+    "New collection from this book" link (PR 5) can seed a starting rule.
+    """
+    form = {
+        "name": "",
+        "description": "",
+        "query": request.args.get("query", ""),
+    }
+    return _render_collection_form(
+        mode="create",
+        action_url=url_for("web.collection_create"),
+        target="#collections-content",
+        container_id="collections-content",
+        cancel_url=url_for("web.collections_list"),
+        form=form,
+        errors={},
+    )
+
+
+@bp.route("/collections/<int:collection_id>/edit")
+def collection_edit_form(collection_id):
+    """Render the edit-collection form, prefilled with name/description/query."""
+    catalog = current_app.config["CATALOG"]
+
+    collection = catalog.get_collection_by_id(collection_id)
+    if collection is None:
+        abort(404)
+
+    form = {
+        "name": str(collection["name"]),
+        "description": str(collection["description"] or ""),
+        "query": str(collection["query"] or ""),
+    }
+    return _render_collection_form(
+        mode="edit",
+        action_url=url_for("web.collection_update", collection_id=collection_id),
+        target="#collection-content",
+        container_id="collection-content",
+        cancel_url=url_for("web.collection_detail", collection_id=collection_id),
+        form=form,
+        errors={},
+    )
+
+
+@bp.route("/collections/<int:collection_id>/edit", methods=["POST"])
+def collection_update(collection_id):
+    """Persist name/description edits, with inline validation at HTTP 200.
+
+    Query handling is intentionally narrow here: a query is only applied when it
+    is a pure re-set on an already rule-based collection. The destructive
+    static<->rule transitions (which drop hand-picked books or snapshot matches)
+    and their warnings are PR 4 — this route leaves the collection's kind
+    unchanged for those cases.
+    """
+    catalog = current_app.config["CATALOG"]
+
+    collection = catalog.get_collection_by_id(collection_id)
+    if collection is None:
+        abort(404)
+
+    name = request.form.get("name", "").strip()
+    description = request.form.get("description", "").strip() or None
+    query = request.form.get("query", "").strip() or None
+    form = {
+        "name": name,
+        "description": request.form.get("description", ""),
+        "query": request.form.get("query", ""),
+    }
+
+    def render_errors(errors: dict[str, str]) -> tuple[str, int]:
+        return _render_collection_form(
+            mode="edit",
+            action_url=url_for("web.collection_update", collection_id=collection_id),
+            target="#collection-content",
+            container_id="collection-content",
+            cancel_url=url_for("web.collection_detail", collection_id=collection_id),
+            form=form,
+            errors=errors,
+        )
+
+    errors: dict[str, str] = {}
+    if not name:
+        errors["name"] = "Collection name is required."
+
+    # Only a rule-based collection accepts an in-place rule re-set in this PR;
+    # validate it before any write so an invalid rule never mutates state.
+    # ``rule_query`` stays None for every other case (static collection, blank
+    # query), leaving the collection's kind untouched — the destructive
+    # static<->rule transitions are PR 4.
+    rule_query: str | None = None
+    if collection["query"] is not None and query is not None:
+        try:
+            parse_collection_query(query)
+            rule_query = query
+        except CollectionQueryError as exc:
+            errors["query"] = str(exc)
+
+    # Duplicate-name pre-check, only when the name actually changes.
+    if (
+        not errors.get("name")
+        and name.lower() != str(collection["name"]).lower()
+        and catalog.get_collection_by_name(name) is not None
+    ):
+        errors["name"] = f"A collection named '{name}' already exists."
+
+    if errors:
+        return render_errors(errors)
+
+    if name != collection["name"]:
+        try:
+            catalog.rename_collection(collection_id, name)
+        except sqlite3.IntegrityError:
+            return render_errors(
+                {"name": f"A collection named '{name}' already exists."}
+            )
+
+    if description != collection["description"]:
+        catalog.set_collection_description(collection_id, description)
+
+    if rule_query is not None:
+        catalog.set_collection_query(collection_id, rule_query)
+
+    flash(f'Updated collection "{name}".', "success")
+    return _redirect_after_save(
+        url_for("web.collection_detail", collection_id=collection_id)
+    )
 
 
 @bp.route("/collections/<int:collection_id>/delete", methods=["POST"])

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1145,6 +1145,17 @@ def collection_create():
         "query": request.form.get("query", ""),
     }
 
+    def render_errors(errors: dict[str, str]) -> tuple[str, int]:
+        return _render_collection_form(
+            mode="create",
+            action_url=url_for("web.collection_create"),
+            target="#collections-content",
+            container_id="collections-content",
+            cancel_url=url_for("web.collections_list"),
+            form=form,
+            errors=errors,
+        )
+
     errors: dict[str, str] = {}
     if not name:
         errors["name"] = "Collection name is required."
@@ -1158,28 +1169,12 @@ def collection_create():
             errors["query"] = str(exc)
 
     if errors:
-        return _render_collection_form(
-            mode="create",
-            action_url=url_for("web.collection_create"),
-            target="#collections-content",
-            container_id="collections-content",
-            cancel_url=url_for("web.collections_list"),
-            form=form,
-            errors=errors,
-        )
+        return render_errors(errors)
 
     try:
         collection_id = catalog.create_collection(name, description, query=query)
     except sqlite3.IntegrityError:
-        return _render_collection_form(
-            mode="create",
-            action_url=url_for("web.collection_create"),
-            target="#collections-content",
-            container_id="collections-content",
-            cancel_url=url_for("web.collections_list"),
-            form=form,
-            errors={"name": f"A collection named '{name}' already exists."},
-        )
+        return render_errors({"name": f"A collection named '{name}' already exists."})
 
     flash(f'Created collection "{name}".', "success")
     return _redirect_after_save(

--- a/src/bookery/web/templates/_collection_detail.html
+++ b/src/bookery/web/templates/_collection_detail.html
@@ -9,6 +9,12 @@
         <span class="query-label">Rule:</span> <code>{{ collection.query }}</code>
     </p>
     {% endif %}
+    <p class="collection-actions">
+        <a href="{{ url_for('web.collection_edit_form', collection_id=collection.id) }}"
+           hx-get="{{ url_for('web.collection_edit_form', collection_id=collection.id) }}"
+           hx-target="#collection-content"
+           class="btn-secondary">Edit</a>
+    </p>
 </header>
 
 {% if books %}

--- a/src/bookery/web/templates/_collection_form.html
+++ b/src/bookery/web/templates/_collection_form.html
@@ -1,0 +1,41 @@
+{# ABOUTME: Collection create/edit form partial — name, description, raw rule query. #}
+{# ABOUTME: The raw query textarea is the single source of truth; errors render inline at HTTP 200. #}
+<form class="collection-form"
+      hx-post="{{ action_url }}"
+      hx-target="{{ target }}"
+      hx-swap="innerHTML">
+    <div class="form-field">
+        <label for="collection-name">Name</label>
+        <input type="text" id="collection-name" name="name"
+               value="{{ form.name or '' }}"
+               required
+               aria-required="true"
+               {% if errors.name %}aria-invalid="true" aria-describedby="name-error"{% endif %}>
+        {% if errors.name %}
+        <p class="field-error" id="name-error" role="alert">{{ errors.name }}</p>
+        {% endif %}
+    </div>
+
+    <div class="form-field">
+        <label for="collection-description">Description <span class="optional">(optional)</span></label>
+        <textarea id="collection-description" name="description" rows="2">{{ form.description or '' }}</textarea>
+    </div>
+
+    <div class="form-field">
+        <label for="collection-query">Rule query <span class="optional">(optional — leave blank for a hand-picked collection)</span></label>
+        <textarea id="collection-query" name="query" rows="3"
+                  placeholder='e.g. genre:"Science Fiction" AND year:[2000 TO 2010]'
+                  {% if errors.query %}aria-invalid="true" aria-describedby="query-error"{% endif %}>{{ form.query or '' }}</textarea>
+        {% if errors.query %}
+        <span id="query-error">{% include "_collection_query_error.html" %}</span>
+        {% endif %}
+        {# Composer block + match preview are wired in PR 2 / PR 3. #}
+    </div>
+
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">
+            {% if mode == "edit" %}Save changes{% else %}Create collection{% endif %}
+        </button>
+        <a href="{{ cancel_url }}" hx-get="{{ cancel_url }}" hx-target="{{ target }}" class="btn-secondary">Cancel</a>
+    </div>
+</form>

--- a/src/bookery/web/templates/_collection_query_error.html
+++ b/src/bookery/web/templates/_collection_query_error.html
@@ -1,0 +1,3 @@
+{# ABOUTME: Inline role=alert error for an invalid collection rule query. #}
+{# ABOUTME: Returned at HTTP 200 so the htmx swap lands; message carries the field hint. #}
+<p class="field-error query-error" role="alert">{{ errors.query }}</p>

--- a/src/bookery/web/templates/_collections_list.html
+++ b/src/bookery/web/templates/_collections_list.html
@@ -14,5 +14,5 @@
     {% endfor %}
 </ul>
 {% else %}
-<p class="empty">No collections yet. Create one from a book's detail page.</p>
+<p class="empty">No collections yet. Use “New collection” to create one.</p>
 {% endif %}

--- a/src/bookery/web/templates/collection_form.html
+++ b/src/bookery/web/templates/collection_form.html
@@ -1,0 +1,19 @@
+{# ABOUTME: Full-page shell for the collection create/edit form. #}
+{# ABOUTME: Title switches on `mode`; wraps the shared _collection_form.html partial. #}
+{% extends "base.html" %}
+
+{% block title %}{% if mode == "edit" %}Edit collection{% else %}New collection{% endif %} - Bookery{% endblock %}
+
+{% block content %}
+<div class="collection-form-page">
+    <nav aria-label="Breadcrumb" class="back-link">
+        <a href="{{ cancel_url }}">&larr; Back</a>
+    </nav>
+
+    <h1>{% if mode == "edit" %}Edit collection{% else %}New collection{% endif %}</h1>
+
+    <div id="{{ container_id }}" aria-live="polite">
+        {% include "_collection_form.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/src/bookery/web/templates/collections_list.html
+++ b/src/bookery/web/templates/collections_list.html
@@ -10,6 +10,13 @@
 
     <h1>Collections</h1>
 
+    <p class="toolbar">
+        <a href="{{ url_for('web.collection_new_form') }}"
+           hx-get="{{ url_for('web.collection_new_form') }}"
+           hx-target="#collections-content"
+           class="btn-primary">New collection</a>
+    </p>
+
     <div id="collections-content" aria-live="polite">
         {% include "_collections_list.html" %}
     </div>

--- a/tests/e2e/test_collection_web.py
+++ b/tests/e2e/test_collection_web.py
@@ -1,0 +1,90 @@
+# ABOUTME: E2E tests for the web collection create flow against a real catalog (#252).
+# ABOUTME: Drives create_app over a temp SQLite DB through the Flask test client.
+
+from pathlib import Path
+
+import pytest
+
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.metadata.types import BookMetadata
+from bookery.web import create_app
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> LibraryCatalog:
+    """A real LibraryCatalog backed by a temporary database, with one book."""
+    conn = open_library(tmp_path / "web_e2e.db")
+    catalog = LibraryCatalog(conn)
+    catalog.add_book(
+        BookMetadata(
+            title="Dune",
+            authors=["Frank Herbert"],
+            series="Dune",
+            source_path=Path("/books/dune.epub"),
+        ),
+        file_hash="dune_hash",
+    )
+    return catalog
+
+
+@pytest.fixture()
+def client(catalog: LibraryCatalog):
+    """Flask test client wired to the real catalog."""
+    app = create_app(catalog)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+class TestCreateRuleCollectionEndToEnd:
+    def test_create_rule_collection_lands_on_detail(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        """A valid rule persists a rule-based collection; the redirect target shows it."""
+        resp = client.post(
+            "/collections/create",
+            data={"name": "Dune Saga", "query": "series:Dune"},
+            headers={"HX-Request": "true"},
+        )
+
+        # Inline create returns an HX-Redirect to the new collection's detail page.
+        target = resp.headers["HX-Redirect"]
+        assert target.startswith("/collections/")
+
+        # The row is persisted as rule-based (query stored, not static membership).
+        collection = catalog.get_collection_by_name("Dune Saga")
+        assert collection is not None
+        assert collection["query"] == "series:Dune"
+
+        # Following the redirect lands on the detail page, which surfaces the rule
+        # and the live-matched book.
+        detail = client.get(target).data.decode()
+        assert "Dune Saga" in detail
+        assert "series:Dune" in detail
+        assert "Dune" in detail  # the matched book title
+
+    def test_duplicate_name_inline_error_creates_no_second_row(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        """A duplicate (case-insensitive) name re-renders the form inline, no new row."""
+        first = client.post(
+            "/collections/create",
+            data={"name": "Favorites", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert first.headers.get("HX-Redirect", "").startswith("/collections/")
+
+        second = client.post(
+            "/collections/create",
+            data={"name": "favorites", "query": ""},  # case-insensitive clash
+            headers={"HX-Request": "true"},
+        )
+
+        assert second.status_code == 200
+        assert "HX-Redirect" not in second.headers
+        assert "already exists" in second.data.decode()
+
+        # Only the original row exists.
+        names = [c["name"] for c in catalog.list_collections()]
+        assert names.count("Favorites") == 1
+        assert len(names) == 1

--- a/tests/unit/test_collections_crud.py
+++ b/tests/unit/test_collections_crud.py
@@ -446,6 +446,59 @@ class TestRenameCollection:
             catalog.rename_collection(9999, "New Name")
 
 
+class TestSetCollectionDescription:
+    """Tests for LibraryCatalog.set_collection_description()."""
+
+    def test_set_description(self, catalog: LibraryCatalog) -> None:
+        """Setting a description updates the stored value."""
+        collection_id = catalog.create_collection("My Collection")
+
+        catalog.set_collection_description(collection_id, "A fresh description")
+
+        collection = catalog.get_collection_by_id(collection_id)
+        assert collection is not None
+        assert collection["description"] == "A fresh description"
+
+    def test_overwrite_description(self, catalog: LibraryCatalog) -> None:
+        """Setting a description overwrites an existing one."""
+        collection_id = catalog.create_collection("My Collection", "Original")
+
+        catalog.set_collection_description(collection_id, "Updated")
+
+        collection = catalog.get_collection_by_id(collection_id)
+        assert collection is not None
+        assert collection["description"] == "Updated"
+
+    def test_clear_description_with_none(self, catalog: LibraryCatalog) -> None:
+        """Passing None clears the description."""
+        collection_id = catalog.create_collection("My Collection", "Original")
+
+        catalog.set_collection_description(collection_id, None)
+
+        collection = catalog.get_collection_by_id(collection_id)
+        assert collection is not None
+        assert collection["description"] is None
+
+    def test_set_description_preserves_name_and_query(self, catalog: LibraryCatalog) -> None:
+        """Setting a description leaves name and query untouched."""
+        collection_id = catalog.create_collection(
+            "Sci-Fi", "Old", query='genre:"Science Fiction"'
+        )
+
+        catalog.set_collection_description(collection_id, "New")
+
+        collection = catalog.get_collection_by_id(collection_id)
+        assert collection is not None
+        assert collection["name"] == "Sci-Fi"
+        assert collection["query"] == 'genre:"Science Fiction"'
+        assert collection["description"] == "New"
+
+    def test_set_description_nonexistent_raises(self, catalog: LibraryCatalog) -> None:
+        """Setting a description on a non-existent collection raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            catalog.set_collection_description(9999, "Nope")
+
+
 class TestGetCollectionsForBook:
     """Tests for LibraryCatalog.get_collections_for_book()."""
 

--- a/tests/web/test_collection_form.py
+++ b/tests/web/test_collection_form.py
@@ -1,0 +1,231 @@
+# ABOUTME: Integration tests for the web collection create/edit form flow (#252).
+# ABOUTME: Covers GET new, POST create (valid/static/blank/dup/invalid), and edit prefill+save.
+
+import sqlite3
+
+
+def _collection(
+    collection_id: int = 1,
+    name: str = "Sci-Fi",
+    description: str | None = None,
+    query: str | None = None,
+) -> dict[str, object]:
+    """Build a collection dict shaped like the catalog return value."""
+    return {
+        "id": collection_id,
+        "name": name,
+        "description": description,
+        "query": query,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+
+
+class TestNewForm:
+    def test_get_new_full_page(self, mock_catalog, client):
+        html = client.get("/collections/new").data.decode()
+        assert "New collection" in html
+        assert 'name="name"' in html
+        assert 'name="query"' in html
+        # Full page carries the site chrome (base template).
+        assert "Skip to main content" in html
+
+    def test_get_new_htmx_partial(self, mock_catalog, client):
+        resp = client.get("/collections/new", headers={"HX-Request": "true"})
+        html = resp.data.decode()
+        assert 'name="name"' in html
+        # Partial omits the full-page chrome.
+        assert "Skip to main content" not in html
+
+    def test_get_new_prefills_query(self, mock_catalog, client):
+        html = client.get(
+            "/collections/new", query_string={"query": 'genre:"Science Fiction"'}
+        ).data.decode()
+        assert 'genre:"Science Fiction"' in html
+
+
+class TestCreate:
+    def test_create_with_valid_query_redirects_to_detail(self, mock_catalog, client):
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.create_collection.return_value = 7
+
+        resp = client.post(
+            "/collections/create",
+            data={"name": "Sci-Fi", "query": 'genre:"Science Fiction"'},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/7"
+        _, kwargs = mock_catalog.create_collection.call_args
+        assert kwargs.get("query") == 'genre:"Science Fiction"'
+
+    def test_create_static_blank_query(self, mock_catalog, client):
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.create_collection.return_value = 3
+
+        resp = client.post(
+            "/collections/create",
+            data={"name": "Favorites", "description": "Hand-picked", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/3"
+        _, kwargs = mock_catalog.create_collection.call_args
+        assert kwargs.get("query") is None
+
+    def test_blank_name_inline_error_no_create(self, mock_catalog, client):
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/create",
+            data={"name": "  ", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        assert "HX-Redirect" not in resp.headers
+        assert "required" in resp.data.decode().lower()
+        mock_catalog.create_collection.assert_not_called()
+
+    def test_duplicate_name_precheck_inline_error(self, mock_catalog, client):
+        mock_catalog.get_collection_by_name.return_value = _collection(name="Sci-Fi")
+
+        resp = client.post(
+            "/collections/create",
+            data={"name": "Sci-Fi", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        assert "already exists" in resp.data.decode()
+        mock_catalog.create_collection.assert_not_called()
+
+    def test_duplicate_name_integrity_error_inline(self, mock_catalog, client):
+        # Pre-check misses (race), but the DB UNIQUE constraint catches it.
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.create_collection.side_effect = sqlite3.IntegrityError(
+            "UNIQUE constraint failed: collections.name"
+        )
+
+        resp = client.post(
+            "/collections/create",
+            data={"name": "Sci-Fi", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        assert "already exists" in resp.data.decode()
+
+    def test_invalid_query_inline_alert_no_create(self, mock_catalog, client):
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/create",
+            data={"name": "Broken", "query": "notafield:value"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'role="alert"' in html
+        # The textarea value is preserved for correction.
+        assert "notafield:value" in html
+        mock_catalog.create_collection.assert_not_called()
+
+
+class TestEditForm:
+    def test_get_edit_prefilled(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Sci-Fi", description="Best of", query="series:Dune"
+        )
+
+        html = client.get("/collections/4/edit").data.decode()
+
+        assert "Edit collection" in html
+        assert 'value="Sci-Fi"' in html
+        assert "Best of" in html
+        assert "series:Dune" in html
+
+    def test_get_edit_404_when_missing(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = None
+        assert client.get("/collections/999/edit").status_code == 404
+
+    def test_post_edit_persists_name_and_description(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Old", description="Old desc", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "New", "description": "New desc", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.rename_collection.assert_called_once_with(4, "New")
+        mock_catalog.set_collection_description.assert_called_once_with(4, "New desc")
+
+    def test_post_edit_rule_based_reset_applies_query(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Sci-Fi", query="series:Dune"
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Sci-Fi", "query": 'genre:"Science Fiction"'},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.set_collection_query.assert_called_once_with(
+            4, 'genre:"Science Fiction"'
+        )
+
+    def test_post_edit_static_query_change_is_deferred(self, mock_catalog, client):
+        # Static -> rule is a destructive transition handled in PR 4; this PR
+        # must not silently convert it.
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Favorites", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Favorites", "query": 'genre:"Science Fiction"'},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.set_collection_query.assert_not_called()
+
+    def test_post_edit_invalid_query_inline_alert(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Sci-Fi", query="series:Dune"
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Sci-Fi", "query": "notafield:value"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        assert 'role="alert"' in resp.data.decode()
+        mock_catalog.set_collection_query.assert_not_called()
+
+
+class TestListAndDetailAffordances:
+    def test_list_has_new_collection_button(self, mock_catalog, client):
+        mock_catalog.list_collections.return_value = []
+        html = client.get("/collections").data.decode()
+        assert "/collections/new" in html
+        assert "New collection" in html
+
+    def test_detail_has_edit_affordance(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(collection_id=4)
+        mock_catalog.get_collection_books.return_value = []
+        html = client.get("/collections/4").data.decode()
+        assert "/collections/4/edit" in html


### PR DESCRIPTION
## Summary
- Brings collection **create & edit** fully into the web UI, including raw Lucene rule strings, with friendly **inline** validation that never 500s on user input.
- First sub-slice of the Collections slice-5 web UI epic (#238) — unblocks PR 2–5.
- Replaces the old broad-`except`/redirect create handler that swallowed every error.

## Changes
- **`web/routes.py`**:
  - `GET /collections/new` → `collection_new_form` (full page or htmx partial; `?query=` prefills the rule textarea for PR 5's book-detail link).
  - `POST /collections/create` tightened — blank name, duplicate name (pre-check **and** specific `sqlite3.IntegrityError`), and invalid rule query (`CollectionQueryError`) all re-render the form inline at **HTTP 200**.
  - `GET /collections/<id>/edit` → prefilled form; `POST /collections/<id>/edit` → persists name (`rename_collection`) and description (`set_collection_description`). Query is applied **only** as a pure re-set on an already rule-based collection — destructive static↔rule transitions are deferred to **PR 4** (marked with a code comment).
- **`db/catalog.py`**: new `set_collection_description(collection_id, description)` setter (mirrors `rename_collection`'s not-found `ValueError` contract).
- **Templates** (all start with `{# ABOUTME #}`): new `collection_form.html`, `_collection_form.html`, `_collection_query_error.html` (`role="alert"`); modified `collections_list.html` (primary "New collection" button + refreshed empty state) and `_collection_detail.html` (Edit affordance).
- **Docs**: `README.md` (×2) and `docs/roadmap.md` updated for the web create/edit surface.

## Testing
- [x] Unit: `set_collection_description` (set/overwrite/clear/preserve/not-found).
- [x] Integration (`tests/web/test_collection_form.py`, 17 tests): GET new full+htmx, `?query=` prefill, create valid/static/blank/dup(pre-check+IntegrityError)/invalid, edit prefill+404+save, rule re-set vs static-query-deferred, list/detail affordances.
- [x] E2E (`tests/e2e/test_collection_web.py`, real catalog): create rule collection → lands on detail; case-insensitive duplicate-name inline error, no second row.
- [x] Full suite: 2272 passed. Ruff clean. Pyright 0 errors.

## Acceptance criteria
All 8 from #252 covered (see test table in the PR discussion).

## Related Issues
Part of #238 (epic #179). First sub-slice; blocks #253–#256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)