### PR TITLE
Add #255: Static↔rule conversion warnings with confirm gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,19 @@ current automatically as the library changes.
 | `collections show <id>` | Show a collection's books; rule-based collections also show the rule and live match count (`--sync-status` for per-device shelf state) |
 | `collections add-books <id> <book_id>...` | Add books to a static collection |
 | `collections remove-books <id> <book_id>...` | Remove books from a static collection |
-| `collections edit <id> --query '<rule>'` | Convert a static collection to rule-based |
+| `collections edit <id> --query '<rule>'` | Convert a static collection to rule-based (discards hand-picked books) |
 | `collections edit <id> --clear-query` | Convert a rule-based collection to static, snapshotting current members |
 | `collections preview --query '<rule>'` | Show which books a rule matches, without saving |
 | `collections query-help` | Print the full query reference (fields, operators, dates, examples) |
 | `collections rename <id> <new_name>` | Rename a collection |
 | `collections rm <id>` | Delete a collection (books are not deleted) |
+
+Converting between the two kinds is one-way destructive in one direction:
+setting a rule on a static collection **discards** its hand-picked books, while
+clearing a rule **snapshots** the currently-matching books into a static list.
+In the web edit form these conversions are gated — when a static collection with
+hand-picked books gains a rule, or any rule is cleared, the form warns with the
+exact count of books affected and requires a second confirm before writing.
 
 #### Rule query language
 

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1267,6 +1267,11 @@ def collection_query_append():
     )
 
 
+def _books(n: int) -> str:
+    """Pluralize "book" for warning copy: 1 book, 0/2/... books."""
+    return "book" if n == 1 else "books"
+
+
 def _render_collection_form(
     *,
     mode: str,
@@ -1276,11 +1281,14 @@ def _render_collection_form(
     cancel_url: str,
     form: Mapping[str, str],
     errors: Mapping[str, str],
+    convert_warning: str | None = None,
 ) -> tuple[str, int]:
     """Render the collection form, full-page on plain GET and partial under htmx.
 
     Always returns HTTP 200: validation failures re-render the partial inline so
-    the htmx swap lands rather than surfacing a browser error page.
+    the htmx swap lands rather than surfacing a browser error page. When
+    ``convert_warning`` is set, the form shows the destructive-conversion banner
+    and a hidden ``confirm`` field so the next submit executes the conversion.
     """
     template = (
         "_collection_form.html"
@@ -1304,6 +1312,7 @@ def _render_collection_form(
         form=form,
         errors=errors,
         query_fields=query_fields,
+        convert_warning=convert_warning,
     )
     return html, 200
 
@@ -1388,7 +1397,11 @@ def collection_update(collection_id):
         "query": request.form.get("query", ""),
     }
 
-    def render_errors(errors: dict[str, str]) -> tuple[str, int]:
+    confirmed = request.form.get("confirm") == "1"
+
+    def render_errors(
+        errors: dict[str, str], *, convert_warning: str | None = None
+    ) -> tuple[str, int]:
         return _render_collection_form(
             mode="edit",
             action_url=url_for("web.collection_update", collection_id=collection_id),
@@ -1397,22 +1410,26 @@ def collection_update(collection_id):
             cancel_url=url_for("web.collection_detail", collection_id=collection_id),
             form=form,
             errors=errors,
+            convert_warning=convert_warning,
         )
 
     errors: dict[str, str] = {}
     if not name:
         errors["name"] = "Collection name is required."
 
-    # Only a rule-based collection accepts an in-place rule re-set in this PR;
-    # validate it before any write so an invalid rule never mutates state.
-    # ``rule_query`` stays None for every other case (static collection, blank
-    # query), leaving the collection's kind untouched — the destructive
-    # static<->rule transitions are PR 4.
-    rule_query: str | None = None
-    if collection["query"] is not None and query is not None:
+    # Classify the query change against the collection's current kind. A
+    # rule-based collection (``query`` set) accepts an in-place rule re-set; a
+    # static collection (``query`` None) keeps explicit ``collection_books``.
+    # Crossing between the two is destructive and gated below.
+    old_query = collection["query"]
+    is_static_to_rule = old_query is None and query is not None
+    is_rule_to_static = old_query is not None and query is None
+
+    # Validate any non-blank query before any write, so an invalid rule never
+    # mutates state (applies to both an in-place reset and a static->rule set).
+    if query is not None:
         try:
             parse_collection_query(query)
-            rule_query = query
         except CollectionQueryError as exc:
             errors["query"] = str(exc)
 
@@ -1427,6 +1444,32 @@ def collection_update(collection_id):
     if errors:
         return render_errors(errors)
 
+    # Confirm gate for destructive conversions. The first POST that detects a
+    # conversion with data at stake re-renders the form with a warning banner and
+    # a hidden ``confirm`` field; the second POST (``confirm=1``) executes it.
+    # static->rule only warns when there are hand-picked books to discard; an
+    # empty static collection has nothing to lose, so it converts straight away.
+    if not confirmed:
+        if is_static_to_rule:
+            member_count = len(catalog.resolve_collection_member_ids(collection_id))
+            if member_count > 0:
+                return render_errors(
+                    {},
+                    convert_warning=(
+                        f"Setting a rule discards the {member_count} hand-picked "
+                        f"{_books(member_count)} in this collection."
+                    ),
+                )
+        elif is_rule_to_static:
+            member_count = len(catalog.resolve_collection_member_ids(collection_id))
+            return render_errors(
+                {},
+                convert_warning=(
+                    f"Removing the rule snapshots the {member_count} currently-matching "
+                    f"{_books(member_count)} as a static list."
+                ),
+            )
+
     if name != collection["name"]:
         try:
             catalog.rename_collection(collection_id, name)
@@ -1438,8 +1481,12 @@ def collection_update(collection_id):
     if description != collection["description"]:
         catalog.set_collection_description(collection_id, description)
 
-    if rule_query is not None:
-        catalog.set_collection_query(collection_id, rule_query)
+    # Apply the query change: a set (in-place reset or static->rule conversion)
+    # drops any hand-picked rows; a clear (rule->static) snapshots live matches.
+    if query is not None:
+        catalog.set_collection_query(collection_id, query)
+    elif is_rule_to_static:
+        catalog.clear_collection_query(collection_id)
 
     flash(f'Updated collection "{name}".', "success")
     return _redirect_after_save(

--- a/src/bookery/web/templates/_collection_form.html
+++ b/src/bookery/web/templates/_collection_form.html
@@ -4,6 +4,14 @@
       hx-post="{{ action_url }}"
       hx-target="{{ target }}"
       hx-swap="innerHTML">
+    {% if convert_warning %}
+    {# Destructive static<->rule conversion: warn before the irreversible write. #}
+    {# The hidden confirm field makes the next submit execute the conversion. #}
+    <p class="convert-warning" role="status">
+        &#9888; {{ convert_warning }}
+    </p>
+    <input type="hidden" name="confirm" value="1">
+    {% endif %}
     <div class="form-field">
         <label for="collection-name">Name</label>
         <input type="text" id="collection-name" name="name"

--- a/tests/e2e/test_collection_web.py
+++ b/tests/e2e/test_collection_web.py
@@ -183,3 +183,87 @@ class TestQueryBuilderEndToEnd:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 400
+
+
+class TestConversionGateEndToEnd:
+    """Full edit-form conversions on a real catalog: warn, confirm, mutate."""
+
+    def test_static_to_rule_warns_then_confirm_drops_handpicked(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        """Hand-picked books trigger a discard warning; confirming converts the
+        collection to rule-based and drops the manual membership."""
+        # A static collection holding the seeded Dune book (id 1) by hand.
+        cid = catalog.create_collection("Favorites")
+        catalog.add_books_to_collection(cid, [1])
+
+        # First edit: set a rule. The hand-picked book is at stake, so the form
+        # comes back with the discard warning and persists nothing.
+        warn = client.post(
+            f"/collections/{cid}/edit",
+            data={"name": "Favorites", "query": "series:Dune"},
+            headers={"HX-Request": "true"},
+        )
+        assert warn.status_code == 200
+        assert "HX-Redirect" not in warn.headers
+        assert "discards the 1 hand-picked book" in warn.data.decode()
+        # Still static, still holding the manual member.
+        before = catalog.get_collection_by_id(cid)
+        assert before is not None and before["query"] is None
+        assert catalog.resolve_collection_member_ids(cid) == [1]
+
+        # Second edit with confirm=1 executes the conversion.
+        done = client.post(
+            f"/collections/{cid}/edit",
+            data={"name": "Favorites", "query": "series:Dune", "confirm": "1"},
+            headers={"HX-Request": "true"},
+        )
+        assert done.headers["HX-Redirect"] == f"/collections/{cid}"
+
+        collection = catalog.get_collection_by_id(cid)
+        assert collection is not None and collection["query"] == "series:Dune"
+        # Membership is now rule-derived (still matches Dune), and the detail page
+        # shows the rule with no manual "Remove" affordance.
+        detail = client.get(f"/collections/{cid}").data.decode()
+        assert "series:Dune" in detail
+        assert "Dune" in detail
+        assert "Remove" not in detail
+
+    def test_rule_to_static_warns_then_confirm_snapshots_members(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        """Clearing a rule snapshots live matches as a static list; confirming
+        makes manual removal available again."""
+        cid = catalog.create_collection("Sci-Fi", query="series:Dune")
+
+        # First edit: clear the rule. Always warns, since the kind change is
+        # meaningful, and persists nothing yet.
+        warn = client.post(
+            f"/collections/{cid}/edit",
+            data={"name": "Sci-Fi", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert warn.status_code == 200
+        assert "HX-Redirect" not in warn.headers
+        assert "snapshots the 1 currently-matching book" in warn.data.decode()
+        before = catalog.get_collection_by_id(cid)
+        assert before is not None and before["query"] == "series:Dune"
+
+        # Confirm: the rule is cleared and the matched book is snapshotted static.
+        done = client.post(
+            f"/collections/{cid}/edit",
+            data={"name": "Sci-Fi", "query": "", "confirm": "1"},
+            headers={"HX-Request": "true"},
+        )
+        assert done.headers["HX-Redirect"] == f"/collections/{cid}"
+
+        collection = catalog.get_collection_by_id(cid)
+        assert collection is not None and collection["query"] is None
+        assert catalog.resolve_collection_member_ids(cid) == [1]
+        # Manual removal is available again on a static collection's detail page.
+        detail = client.get(f"/collections/{cid}").data.decode()
+        assert "Remove" in detail
+
+        # And the snapshot is genuinely static: removing the book sticks.
+        catalog.remove_books_from_collection(cid, [1])
+        assert catalog.resolve_collection_member_ids(cid) == []

--- a/tests/web/test_collection_form.py
+++ b/tests/web/test_collection_form.py
@@ -217,22 +217,8 @@ class TestEditForm:
             4, 'genre:"Science Fiction"'
         )
 
-    def test_post_edit_static_query_change_is_deferred(self, mock_catalog, client):
-        # Static -> rule is a destructive transition handled in PR 4; this PR
-        # must not silently convert it.
-        mock_catalog.get_collection_by_id.return_value = _collection(
-            collection_id=4, name="Favorites", query=None
-        )
-        mock_catalog.get_collection_by_name.return_value = None
-
-        resp = client.post(
-            "/collections/4/edit",
-            data={"name": "Favorites", "query": 'genre:"Science Fiction"'},
-            headers={"HX-Request": "true"},
-        )
-
-        assert resp.headers.get("HX-Redirect") == "/collections/4"
-        mock_catalog.set_collection_query.assert_not_called()
+    # static -> rule and rule -> static are destructive conversions gated behind
+    # a one-time confirm; see TestConversionGate for that behavior.
 
     def test_post_edit_invalid_query_inline_alert(self, mock_catalog, client):
         mock_catalog.get_collection_by_id.return_value = _collection(
@@ -248,6 +234,166 @@ class TestEditForm:
 
         assert resp.status_code == 200
         assert 'role="alert"' in resp.data.decode()
+        mock_catalog.set_collection_query.assert_not_called()
+
+
+class TestConversionGate:
+    """static<->rule conversions are destructive in one direction, so the edit
+    form gates them behind a one-time confirm (mirrors the delete-confirm flow).
+    """
+
+    def test_static_to_rule_with_members_warns_before_mutation(
+        self, mock_catalog, client
+    ):
+        # A static collection that holds hand-picked books. Setting a rule would
+        # drop them, so the first POST must warn and persist nothing.
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Favorites", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = [1, 2, 3]
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Favorites", "query": "series:Dune"},
+            headers={"HX-Request": "true"},
+        )
+
+        body = resp.data.decode()
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") is None
+        assert "discards the 3 hand-picked books" in body
+        assert 'name="confirm"' in body
+        mock_catalog.set_collection_query.assert_not_called()
+        mock_catalog.clear_collection_query.assert_not_called()
+
+    def test_static_to_rule_no_members_skips_gate(self, mock_catalog, client):
+        # Nothing to lose: an empty static collection converts straight to a rule
+        # without a confirm step.
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Empty", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = []
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Empty", "query": "series:Dune"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.set_collection_query.assert_called_once_with(4, "series:Dune")
+
+    def test_static_to_rule_confirmed_mutates(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Favorites", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = [1, 2, 3]
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Favorites", "query": "series:Dune", "confirm": "1"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.set_collection_query.assert_called_once_with(4, "series:Dune")
+
+    def test_rule_to_static_warns_before_mutation(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Sci-Fi", query="series:Dune"
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = [1, 2]
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Sci-Fi", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        body = resp.data.decode()
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") is None
+        assert "snapshots the 2 currently-matching books" in body
+        assert 'name="confirm"' in body
+        mock_catalog.clear_collection_query.assert_not_called()
+
+    def test_rule_to_static_confirmed_mutates(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Sci-Fi", query="series:Dune"
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = [1, 2]
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Sci-Fi", "query": "", "confirm": "1"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.clear_collection_query.assert_called_once_with(4)
+
+    def test_rule_reset_is_not_a_conversion(self, mock_catalog, client):
+        # rule -> rule (same kind) keeps the existing in-place reset path: no gate.
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Sci-Fi", query="series:Dune"
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Sci-Fi", "query": 'genre:"Science Fiction"'},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.set_collection_query.assert_called_once_with(
+            4, 'genre:"Science Fiction"'
+        )
+        mock_catalog.clear_collection_query.assert_not_called()
+
+    def test_name_only_edit_on_static_skips_gate(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Old", description="d", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = [1, 2, 3]
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "New", "description": "d", "query": ""},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.headers.get("HX-Redirect") == "/collections/4"
+        mock_catalog.rename_collection.assert_called_once_with(4, "New")
+        mock_catalog.set_collection_query.assert_not_called()
+        mock_catalog.clear_collection_query.assert_not_called()
+
+    def test_static_to_rule_invalid_query_rejects_without_warning(
+        self, mock_catalog, client
+    ):
+        # Invalid rule on a conversion: inline alert, no mutation, no confirm gate.
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            collection_id=4, name="Favorites", query=None
+        )
+        mock_catalog.get_collection_by_name.return_value = None
+        mock_catalog.resolve_collection_member_ids.return_value = [1, 2, 3]
+
+        resp = client.post(
+            "/collections/4/edit",
+            data={"name": "Favorites", "query": "notafield:value"},
+            headers={"HX-Request": "true"},
+        )
+
+        body = resp.data.decode()
+        assert resp.status_code == 200
+        assert 'role="alert"' in body
+        assert "discards" not in body
         mock_catalog.set_collection_query.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Adds a two-phase confirm gate to the collection edit form so converting between static and rule-based collections can't silently destroy data.
- static→rule discards hand-picked books; rule→static snapshots currently-matching books as a static list. Both now warn before writing.

## Changes
- **src/bookery/web/routes.py**: `collection_update()` classifies the query change against the collection's current kind (`is_static_to_rule` / `is_rule_to_static`). Query is validated before any write. On the first POST, a destructive conversion re-renders the form with a warning banner + hidden `confirm` field; the second POST (`confirm=1`) executes it. static→rule only warns when hand-picked books exist (empty collection converts straight through). Added `_books()` pluralization helper and `convert_warning` param to `_render_collection_form()`.
- **tests/web/test_collection_form.py**: gate behavior — warning shown, confirm executes, no-op skips gate, invalid query still rejects without mutation.
- **tests/e2e/test_collection_web.py**: end-to-end conversion gate on a real catalog.

## Testing
- [x] Unit + integration tests pass (`tests/web/`)
- [x] E2E tests pass on real catalog
- [x] Full suite: 2343 passed, 0 lint violations (`ruff check`)

## Related Issues
Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)