### PR TITLE
Add #262: write opf:file-as + authors fix-sort backfill (device sort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ bookery info 42
 | `genre stats` | Show the most common subjects that don't map to a canonical genre |
 | `genre unmatched` | Show books with subjects but no genre assigned |
 | `mark finished <id>` | Mark a book as finished (also `mark reading <id>`, `mark unread <id>`; supports `--bulk-from FILE`) |
+| `authors fix-sort` | Backfill `opf:file-as` so devices sort authors by surname (dry-run by default; `--apply` to write) |
 | `verify` | Check for missing or changed files (supports `--check-hash`) |
 
 ### Collections
@@ -273,6 +274,11 @@ sideloads, Kobo store purchases, and library borrows. Sync is currently
 cache at `{data_dir}/kepub_cache.db` keyed on the source EPUB hash plus
 the `kepubify` version makes re-syncs effectively free when nothing has
 changed.
+
+Readers sort authors by the EPUB's `opf:file-as` key. If a device files
+an author under their given name (e.g. "Brandon" instead of "Sanderson"),
+the library copies are missing that key — run `bookery authors fix-sort`
+to backfill a surname-first `file-as`, then re-sync.
 
 ### The `vault-export` workflow
 

--- a/src/bookery/cli/__init__.py
+++ b/src/bookery/cli/__init__.py
@@ -8,6 +8,7 @@ import click
 
 from bookery.cli.commands import (
     add_cmd,
+    authors_cmd,
     collection_cmd,
     convert_cmd,
     genre_cmd,
@@ -59,6 +60,7 @@ def cli(ctx: click.Context, verbose: int, db_path: Path | None) -> None:
 
 
 cli.add_command(add_cmd.add_command)
+cli.add_command(authors_cmd.authors)
 cli.add_command(collection_cmd.collections)
 cli.add_command(convert_cmd.convert)
 cli.add_command(genre_cmd.genre)

--- a/src/bookery/cli/commands/authors_cmd.py
+++ b/src/bookery/cli/commands/authors_cmd.py
@@ -143,7 +143,16 @@ def fix_sort(db_path: Path | None, apply_changes: bool) -> None:
 
         fixed = 0
         for cand in candidates:
-            if _apply_fix(catalog, cand):
+            try:
+                applied = _apply_fix(catalog, cand)
+            except (OSError, EpubReadError) as exc:
+                # One unreadable file shouldn't abort the whole backfill; each
+                # fix is atomic, so already-processed books stay valid.
+                console.print(
+                    f"[red]failed:[/red] {cand.record.metadata.title}: {exc}"
+                )
+                continue
+            if applied:
                 fixed += 1
             else:
                 console.print(

--- a/src/bookery/cli/commands/authors_cmd.py
+++ b/src/bookery/cli/commands/authors_cmd.py
@@ -1,0 +1,155 @@
+# ABOUTME: The `bookery authors` command group, incl. `fix-sort` file-as backfill.
+# ABOUTME: Rewrites library EPUBs so devices sort authors by surname (issue #262).
+
+import os
+import shutil
+import xml.etree.ElementTree as ET
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from bookery.cli.options import db_option, resolve_db_path
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.db.hashing import compute_file_hash
+from bookery.db.mapping import BookRecord
+from bookery.formats.epub import (
+    EpubReadError,
+    creator_file_as_pairs,
+    read_creator_file_as,
+    read_epub_metadata,
+    write_epub_metadata,
+)
+
+console = Console()
+
+
+@dataclass
+class _Candidate:
+    """A cataloged book whose written file-as does not match the expected sort."""
+
+    record: BookRecord
+    current: list[tuple[str, str | None]]
+    expected: list[tuple[str, str]]
+
+
+def _find_candidates(catalog: LibraryCatalog) -> list[_Candidate]:
+    """Return books whose library EPUB lacks the correct per-author file-as."""
+    candidates: list[_Candidate] = []
+    for record in catalog.list_all():
+        out = record.output_path
+        if out is None or out.suffix.lower() != ".epub" or not out.exists():
+            continue
+        if not record.metadata.authors:
+            continue
+        expected = creator_file_as_pairs(record.metadata)
+        try:
+            current = read_creator_file_as(out)
+        except (OSError, zipfile.BadZipFile, ET.ParseError):
+            continue
+        if current != expected:
+            candidates.append(_Candidate(record, current, expected))
+    return candidates
+
+
+def _apply_fix(catalog: LibraryCatalog, candidate: _Candidate) -> bool:
+    """Rewrite one library EPUB atomically; return False if read-back verify fails.
+
+    Writes to a sibling temp file, verifies the authors round-trip, then
+    ``os.replace`` swaps it in (atomic on the same filesystem). A failed verify
+    leaves the original untouched. The new file_hash is persisted so ``verify``
+    doesn't later flag the rewritten copy as changed.
+    """
+    src = candidate.record.output_path
+    assert src is not None  # guaranteed by _find_candidates
+    tmp = src.with_name(src.name + ".fixtmp")
+    shutil.copy2(src, tmp)
+    try:
+        write_epub_metadata(tmp, candidate.record.metadata)
+        if read_epub_metadata(tmp).authors != candidate.record.metadata.authors:
+            tmp.unlink(missing_ok=True)
+            return False
+        os.replace(tmp, src)
+    except (OSError, EpubReadError):
+        tmp.unlink(missing_ok=True)
+        raise
+    catalog.update_book(candidate.record.id, file_hash=compute_file_hash(src))
+    return True
+
+
+def _render_table(candidates: list[_Candidate]) -> Table:
+    """Build the preview table: which authors change file-as, per book."""
+    table = Table(title="Author file-as fixes")
+    table.add_column("ID", style="dim", width=6, justify="right")
+    table.add_column("Title")
+    table.add_column("Author")
+    table.add_column("file-as: now → fixed")
+    for cand in candidates:
+        current_by_name = dict(cand.current)
+        for i, (author, expected_fa) in enumerate(cand.expected):
+            now = current_by_name.get(author)
+            table.add_row(
+                str(cand.record.id) if i == 0 else "",
+                cand.record.metadata.title if i == 0 else "",
+                author,
+                f"{now or '(none)'} → {expected_fa}",
+            )
+    return table
+
+
+@click.group("authors")
+def authors() -> None:
+    """Manage author metadata across the library."""
+
+
+@authors.command("fix-sort")
+@db_option
+@click.option(
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    default=False,
+    help="Rewrite files. Without it, fix-sort only previews (dry run).",
+)
+def fix_sort(db_path: Path | None, apply_changes: bool) -> None:
+    """Backfill opf:file-as so devices sort authors by surname.
+
+    Library EPUBs written before this fix carry no file-as, so Kobo and others
+    file authors by their given name. This rewrites each affected copy with a
+    surname-first file-as. Dry-run by default; pass --apply to write.
+    """
+    conn = open_library(resolve_db_path(db_path))
+    try:
+        catalog = LibraryCatalog(conn)
+        candidates = _find_candidates(catalog)
+
+        if not candidates:
+            console.print(
+                "[green]All author file-as sort keys are already correct.[/green]"
+            )
+            return
+
+        if not apply_changes:
+            console.print(_render_table(candidates))
+            console.print(
+                f"\n[dim]dry-run:[/dim] {len(candidates)} book(s) would be updated. "
+                "Re-run with --apply to write."
+            )
+            return
+
+        fixed = 0
+        for cand in candidates:
+            if _apply_fix(catalog, cand):
+                fixed += 1
+            else:
+                console.print(
+                    f"[yellow]skipped (verify failed):[/yellow] "
+                    f"{cand.record.metadata.title}"
+                )
+        console.print(f"[green]Updated file-as for {fixed} book(s).[/green]")
+    finally:
+        conn.close()

--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -291,6 +291,24 @@ def _set_dc_metadata(book: epub.EpubBook, name: str, value: str) -> None:
     book.add_metadata("DC", name, value)
 
 
+def creator_file_as_pairs(metadata: BookMetadata) -> list[tuple[str, str]]:
+    """Return ``(author, file_as)`` pairs as written to the OPF.
+
+    ``file_as`` is the surname-first sort key a reader uses to file the author:
+    the curator-set ``author_sort`` for the primary author when present,
+    otherwise derived per author via ``compute_author_sort``. Shared by the
+    write path and the ``authors fix-sort`` backfill so they can't drift.
+    """
+    pairs: list[tuple[str, str]] = []
+    for index, author in enumerate(metadata.authors):
+        if index == 0 and metadata.author_sort:
+            file_as = metadata.author_sort
+        else:
+            file_as = compute_author_sort([author])
+        pairs.append((author, file_as))
+    return pairs
+
+
 def _clear_creator_file_as(book: epub.EpubBook) -> None:
     """Drop existing ``file-as`` refines meta so re-writes don't accumulate them.
 
@@ -433,15 +451,11 @@ def write_epub_metadata(path: Path, metadata: BookMetadata) -> None:
     if metadata.authors:
         _clear_dc_metadata(book, "creator")
         _clear_creator_file_as(book)
-        for index, author in enumerate(metadata.authors):
+        for index, (author, file_as) in enumerate(creator_file_as_pairs(metadata)):
             # Each creator needs a distinct id so its file-as refines meta binds
             # to the right author; ebooklib defaults every author to uid
             # "creator", which would collapse co-authors onto one sort key.
             uid = "creator" if index == 0 else f"creator{index}"
-            if index == 0 and metadata.author_sort:
-                file_as = metadata.author_sort
-            else:
-                file_as = compute_author_sort([author])
             book.add_author(author, file_as=file_as, uid=uid)
 
     if metadata.language is not None:

--- a/src/bookery/formats/epub.py
+++ b/src/bookery/formats/epub.py
@@ -3,11 +3,14 @@
 
 import contextlib
 import logging
+import xml.etree.ElementTree as ET
+import zipfile
 from pathlib import Path
 
 import ebooklib
 from ebooklib import epub
 
+from bookery.core.text_sort import compute_author_sort
 from bookery.metadata.types import BookMetadata
 from bookery.util.text import strip_html
 
@@ -288,6 +291,66 @@ def _set_dc_metadata(book: epub.EpubBook, name: str, value: str) -> None:
     book.add_metadata("DC", name, value)
 
 
+def _clear_creator_file_as(book: epub.EpubBook) -> None:
+    """Drop existing ``file-as`` refines meta so re-writes don't accumulate them.
+
+    ebooklib stores an author's sort key as a separate ``<meta refines="#uid"
+    property="file-as">`` entry under the OPF (``None``) namespace, which
+    ``_clear_dc_metadata(book, "creator")`` does not touch. Without clearing it,
+    re-running the write piles stale file-as entries onto each creator.
+    """
+    for ns_entries in book.metadata.values():
+        meta = ns_entries.get("meta")
+        if not meta:
+            continue
+        kept = [
+            (value, attrs)
+            for value, attrs in meta
+            if not (isinstance(attrs, dict) and attrs.get("property") == "file-as")
+        ]
+        if len(kept) != len(meta):
+            ns_entries["meta"] = kept
+
+
+_OPF_NS = "http://www.idpf.org/2007/opf"
+_DC_NS = "http://purl.org/dc/elements/1.1/"
+_CONTAINER = "META-INF/container.xml"
+
+
+def read_creator_file_as(path: Path) -> list[tuple[str, str | None]]:
+    """Return ``(creator, file_as)`` pairs from an EPUB's OPF, in document order.
+
+    Handles both EPUB2 (``opf:file-as`` attribute on ``dc:creator``) and EPUB3
+    (a ``<meta refines="#id" property="file-as">`` pointing at the creator's
+    ``id``). ``file_as`` is ``None`` when the creator declares no sort key.
+    """
+    with zipfile.ZipFile(path) as zf:
+        container = ET.fromstring(zf.read(_CONTAINER))
+        rootfile = container.find(".//{*}rootfile")
+        opf_path = rootfile.get("full-path") if rootfile is not None else None
+        if not opf_path:
+            return []
+        opf = ET.fromstring(zf.read(opf_path))
+
+    # EPUB3 file-as refines, keyed by the creator id they refine.
+    refines: dict[str, str] = {}
+    for meta in opf.iter(f"{{{_OPF_NS}}}meta"):
+        target = meta.get("refines")
+        if meta.get("property") == "file-as" and target:
+            refines[target.lstrip("#")] = (meta.text or "").strip()
+
+    pairs: list[tuple[str, str | None]] = []
+    for creator in opf.iter(f"{{{_DC_NS}}}creator"):
+        name = (creator.text or "").strip()
+        if not name:
+            continue
+        file_as = creator.get(f"{{{_OPF_NS}}}file-as")
+        if file_as is None:
+            file_as = refines.get(creator.get("id", ""))
+        pairs.append((name, file_as))
+    return pairs
+
+
 _COVER_EXTENSION_FOR_CONTENT_TYPE: dict[str, str] = {
     "image/jpeg": "jpg",
     "image/png": "png",
@@ -369,8 +432,17 @@ def write_epub_metadata(path: Path, metadata: BookMetadata) -> None:
 
     if metadata.authors:
         _clear_dc_metadata(book, "creator")
-        for author in metadata.authors:
-            book.add_author(author)
+        _clear_creator_file_as(book)
+        for index, author in enumerate(metadata.authors):
+            # Each creator needs a distinct id so its file-as refines meta binds
+            # to the right author; ebooklib defaults every author to uid
+            # "creator", which would collapse co-authors onto one sort key.
+            uid = "creator" if index == 0 else f"creator{index}"
+            if index == 0 and metadata.author_sort:
+                file_as = metadata.author_sort
+            else:
+                file_as = compute_author_sort([author])
+            book.add_author(author, file_as=file_as, uid=uid)
 
     if metadata.language is not None:
         _set_dc_metadata(book, "language", metadata.language)

--- a/tests/e2e/test_authors_cli.py
+++ b/tests/e2e/test_authors_cli.py
@@ -1,0 +1,113 @@
+# ABOUTME: E2E tests for the `bookery authors fix-sort` file-as backfill command.
+# ABOUTME: Seeds a real catalog + EPUBs lacking file-as and drives the CLI.
+
+from pathlib import Path
+
+from click.testing import CliRunner
+from ebooklib import epub
+
+from bookery.cli import cli
+from bookery.db.catalog import LibraryCatalog
+from bookery.db.connection import open_library
+from bookery.formats.epub import read_creator_file_as
+from bookery.metadata import BookMetadata
+
+
+def _make_epub(path: Path, title: str, authors: list[str]) -> None:
+    """Write a minimal EPUB whose creators carry no file-as (reproduces the bug)."""
+    book = epub.EpubBook()
+    book.set_identifier(f"id-{title}")
+    book.set_title(title)
+    book.set_language("en")
+    for author in authors:
+        book.add_author(author)  # no file_as -> the broken state we backfill
+    chapter = epub.EpubHtml(title="c", file_name="c.xhtml", lang="en")
+    chapter.content = b"<html><body><p>x</p></body></html>"
+    book.add_item(chapter)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+    epub.write_epub(str(path), book)
+
+
+def _seed(db_path: Path, title: str, authors: list[str], output: Path) -> int:
+    conn = open_library(db_path)
+    catalog = LibraryCatalog(conn)
+    book_id = catalog.add_book(
+        BookMetadata(title=title, authors=authors, source_path=output),
+        file_hash=f"hash-{title}",
+        output_path=output,
+    )
+    conn.close()
+    return book_id
+
+
+class TestAuthorsFixSort:
+    def test_dry_run_lists_candidate_and_writes_nothing(self, tmp_path: Path) -> None:
+        epub_path = tmp_path / "way_of_kings.epub"
+        _make_epub(epub_path, "The Way of Kings", ["Sanderson, Brandon"])
+        db_path = tmp_path / "lib.db"
+        _seed(db_path, "The Way of Kings", ["Sanderson, Brandon"], epub_path)
+
+        result = CliRunner().invoke(cli, ["--db", str(db_path), "authors", "fix-sort"])
+
+        assert result.exit_code == 0, result.output
+        assert "The Way of Kings" in result.output
+        # Dry run must not touch the file.
+        assert read_creator_file_as(epub_path) == [("Sanderson, Brandon", None)]
+
+    def test_apply_writes_file_as_and_updates_hash(self, tmp_path: Path) -> None:
+        epub_path = tmp_path / "way_of_kings.epub"
+        _make_epub(epub_path, "The Way of Kings", ["Sanderson, Brandon"])
+        db_path = tmp_path / "lib.db"
+        book_id = _seed(
+            db_path, "The Way of Kings", ["Sanderson, Brandon"], epub_path
+        )
+
+        result = CliRunner().invoke(
+            cli, ["--db", str(db_path), "authors", "fix-sort", "--apply"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert read_creator_file_as(epub_path) == [
+            ("Sanderson, Brandon", "Sanderson, Brandon")
+        ]
+        conn = open_library(db_path)
+        record = LibraryCatalog(conn).get_by_id(book_id)
+        conn.close()
+        assert record is not None
+        assert record.file_hash != "hash-The Way of Kings"
+
+    def test_apply_is_idempotent(self, tmp_path: Path) -> None:
+        epub_path = tmp_path / "always.epub"
+        _make_epub(epub_path, "Always Be Testing", ["Eisenberg, Bryan"])
+        db_path = tmp_path / "lib.db"
+        _seed(db_path, "Always Be Testing", ["Eisenberg, Bryan"], epub_path)
+        runner = CliRunner()
+
+        runner.invoke(cli, ["--db", str(db_path), "authors", "fix-sort", "--apply"])
+        second = runner.invoke(
+            cli, ["--db", str(db_path), "authors", "fix-sort", "--apply"]
+        )
+
+        assert second.exit_code == 0, second.output
+        # Nothing left to fix on the second pass.
+        assert "Always Be Testing" not in second.output
+        assert read_creator_file_as(epub_path) == [
+            ("Eisenberg, Bryan", "Eisenberg, Bryan")
+        ]
+
+    def test_coauthors_left_intact(self, tmp_path: Path) -> None:
+        epub_path = tmp_path / "barbarians.epub"
+        _make_epub(epub_path, "Barbarians", ["Bryan Burrough", "John Helyar"])
+        db_path = tmp_path / "lib.db"
+        _seed(db_path, "Barbarians", ["Bryan Burrough", "John Helyar"], epub_path)
+
+        CliRunner().invoke(
+            cli, ["--db", str(db_path), "authors", "fix-sort", "--apply"]
+        )
+
+        assert read_creator_file_as(epub_path) == [
+            ("Bryan Burrough", "Burrough, Bryan"),
+            ("John Helyar", "Helyar, John"),
+        ]

--- a/tests/e2e/test_authors_cli.py
+++ b/tests/e2e/test_authors_cli.py
@@ -97,6 +97,41 @@ class TestAuthorsFixSort:
             ("Eisenberg, Bryan", "Eisenberg, Bryan")
         ]
 
+    def test_one_failed_book_does_not_abort_the_batch(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A single book raising during apply is reported; others still process."""
+        from bookery.cli.commands import authors_cmd
+        from bookery.formats.epub import EpubReadError
+
+        good = tmp_path / "good.epub"
+        bad = tmp_path / "bad.epub"
+        _make_epub(good, "Good Book", ["Brandon Sanderson"])
+        _make_epub(bad, "Bad Book", ["Bryan Burrough"])
+        db_path = tmp_path / "lib.db"
+        _seed(db_path, "Bad Book", ["Bryan Burrough"], bad)
+        _seed(db_path, "Good Book", ["Brandon Sanderson"], good)
+
+        real_apply = authors_cmd._apply_fix
+
+        def flaky(catalog, candidate):
+            if candidate.record.metadata.title == "Bad Book":
+                raise EpubReadError("boom")
+            return real_apply(catalog, candidate)
+
+        monkeypatch.setattr(authors_cmd, "_apply_fix", flaky)
+
+        result = CliRunner().invoke(
+            cli, ["--db", str(db_path), "authors", "fix-sort", "--apply"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "failed:" in result.output and "Bad Book" in result.output
+        # The healthy book was still fixed despite the other's failure.
+        assert read_creator_file_as(good) == [
+            ("Brandon Sanderson", "Sanderson, Brandon")
+        ]
+
     def test_coauthors_left_intact(self, tmp_path: Path) -> None:
         epub_path = tmp_path / "barbarians.epub"
         _make_epub(epub_path, "Barbarians", ["Bryan Burrough", "John Helyar"])

--- a/tests/unit/test_epub_writer.py
+++ b/tests/unit/test_epub_writer.py
@@ -1,6 +1,7 @@
 # ABOUTME: Unit tests for EPUB metadata writing.
 # ABOUTME: Tests round-trip: read metadata, modify, write back, verify.
 
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -261,6 +262,36 @@ class TestWriteCreatorFileAs:
         assert read_creator_file_as(sample_epub) == [
             ("Brandon Sanderson", "Sanderson, Brandon")
         ]
+
+    def test_reads_epub2_file_as_attribute(self, tmp_path: Path) -> None:
+        """Reader also handles the EPUB2 ``opf:file-as`` attribute form."""
+        opf = (
+            '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="2.0"'
+            ' unique-identifier="id">'
+            '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"'
+            ' xmlns:opf="http://www.idpf.org/2007/opf">'
+            '<dc:identifier id="id">x</dc:identifier><dc:title>T</dc:title>'
+            '<dc:creator opf:file-as="Brooks, John">John Brooks</dc:creator>'
+            "</metadata>"
+            '<manifest><item id="x" href="x.html"'
+            ' media-type="application/xhtml+xml"/></manifest>'
+            '<spine><itemref idref="x"/></spine></package>'
+        )
+        container = (
+            '<?xml version="1.0"?>'
+            '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"'
+            ' version="1.0"><rootfiles><rootfile full-path="content.opf"'
+            ' media-type="application/oebps-package+xml"/></rootfiles></container>'
+        )
+        path = tmp_path / "book.epub"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr("META-INF/container.xml", container)
+            zf.writestr("content.opf", opf)
+            zf.writestr("x.html", "<html></html>")
+
+        assert read_creator_file_as(path) == [("John Brooks", "Brooks, John")]
 
 
 _JPEG_COVER = b"\xff\xd8\xff\xe0" + b"new-cover-bytes" * 8

--- a/tests/unit/test_epub_writer.py
+++ b/tests/unit/test_epub_writer.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from bookery.formats.epub import EpubReadError, read_epub_metadata, write_epub_metadata
+from bookery.formats.epub import (
+    EpubReadError,
+    read_creator_file_as,
+    read_epub_metadata,
+    write_epub_metadata,
+)
 from bookery.metadata import BookMetadata
 
 
@@ -202,6 +207,60 @@ class TestWriteEpubMetadata:
         assert re_read.authors == ["Umberto Eco"]
         assert re_read.publisher == "Harcourt"
         assert re_read.description == "A mystery set in a medieval monastery."
+
+
+class TestWriteCreatorFileAs:
+    """Writing authors emits a surname-first opf:file-as so devices sort right."""
+
+    def test_first_last_gets_inverted_file_as(self, sample_epub: Path) -> None:
+        """A "First Last" author writes file-as "Last, First"."""
+        write_epub_metadata(
+            sample_epub, BookMetadata(title="T", authors=["Brandon Sanderson"])
+        )
+        assert read_creator_file_as(sample_epub) == [
+            ("Brandon Sanderson", "Sanderson, Brandon")
+        ]
+
+    def test_already_inverted_author_keeps_file_as(self, sample_epub: Path) -> None:
+        """A "Last, First" author keeps its order as the file-as."""
+        write_epub_metadata(
+            sample_epub, BookMetadata(title="T", authors=["Sanderson, Brandon"])
+        )
+        assert read_creator_file_as(sample_epub) == [
+            ("Sanderson, Brandon", "Sanderson, Brandon")
+        ]
+
+    def test_each_coauthor_gets_its_own_file_as(self, sample_epub: Path) -> None:
+        """Co-authors each get an independent file-as (no shared sort key)."""
+        write_epub_metadata(
+            sample_epub,
+            BookMetadata(title="T", authors=["Bryan Burrough", "John Helyar"]),
+        )
+        assert read_creator_file_as(sample_epub) == [
+            ("Bryan Burrough", "Burrough, Bryan"),
+            ("John Helyar", "Helyar, John"),
+        ]
+
+    def test_explicit_author_sort_wins_for_primary(self, sample_epub: Path) -> None:
+        """A curator-set author_sort is used for the primary author's file-as."""
+        write_epub_metadata(
+            sample_epub,
+            BookMetadata(
+                title="T", authors=["Plato"], author_sort="Plato (Greek)"
+            ),
+        )
+        assert read_creator_file_as(sample_epub) == [("Plato", "Plato (Greek)")]
+
+    def test_rewrite_does_not_accumulate_stale_file_as(
+        self, sample_epub: Path
+    ) -> None:
+        """Re-writing leaves exactly one file-as per creator, not a pile of them."""
+        meta = BookMetadata(title="T", authors=["Brandon Sanderson"])
+        write_epub_metadata(sample_epub, meta)
+        write_epub_metadata(sample_epub, meta)
+        assert read_creator_file_as(sample_epub) == [
+            ("Brandon Sanderson", "Sanderson, Brandon")
+        ]
 
 
 _JPEG_COVER = b"\xff\xd8\xff\xe0" + b"new-cover-bytes" * 8


### PR DESCRIPTION
## Summary
Authors sort by their given name on Kobo (e.g. "Brandon", "Bryan") because bookery's EPUB write-back emitted `<dc:creator>` with no `opf:file-as`, so the device fell back to "last token = surname" and mis-filed any creator stored `Last, First`. This writes a surname-first `file-as` per author and adds a backfill command to fix the existing library.

## Changes
- **formats/epub.py**: `write_epub_metadata` now writes `opf:file-as` per creator (distinct uid each, so co-authors get independent sort keys; stale file-as refines cleared on rewrite). New `creator_file_as_pairs` (shared file-as rule) and `read_creator_file_as` (reads EPUB2 attribute + EPUB3 refines forms).
- **cli/commands/authors_cmd.py**: new `bookery authors fix-sort` — finds cataloged EPUBs whose written file-as is wrong, previews them (dry-run default), and with `--apply` rewrites each via atomic temp+verify+swap, updating `file_hash`. Idempotent, co-author-safe, and resilient (one bad file doesn't abort the batch).
- **cli/__init__.py**: register the `authors` group.
- **README.md**: document the command + device-sort rationale.

## Testing
- [x] Unit: file-as derivation, EPUB2/EPUB3 read-back, no stale accumulation (`tests/unit/test_epub_writer.py`)
- [x] E2E: dry-run lists candidates, `--apply` writes file-as + updates hash, idempotent, co-authors intact, batch-resilient (`tests/e2e/test_authors_cli.py`)
- [x] Full suite: 2354 passed, `ruff` + `pyright` clean
- [x] Manual: dry-run against real `~/.bookery` lists candidates with correct surname-first keys

## Notes
Scope is the device-facing sort key only. Fixing reversed *display names* and collapsing duplicate author entries is #261 (author dedupe/normalize) — they compose but ship independently. Surfaced during manual run: book 614 has a junk DB author string (`Steve Berry (conflated)`) — that's #261 data, not this fix.

## Related Issues
Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)