### PR TITLE
Add #266: stat-based quick-skip for kobo sync

### DIFF
--- a/src/bookery/device/kepub_cache.py
+++ b/src/bookery/device/kepub_cache.py
@@ -15,6 +15,16 @@ class KepubCacheEntry:
     device_path: Path
 
 
+@dataclass(frozen=True)
+class QuickCheckEntry:
+    kepubify_version: str
+    source_size: int
+    source_mtime: float
+    dest_path: Path
+    dest_size: int
+    dest_mtime: float
+
+
 class KepubCache:
     """Persistent cache of kepub hashes keyed on (source_hash, kepubify_version).
 
@@ -34,6 +44,22 @@ class KepubCache:
                 "  kepub_sha TEXT NOT NULL,"
                 "  device_path TEXT NOT NULL,"
                 "  PRIMARY KEY (source_hash, kepubify_version)"
+                ")"
+            )
+            # Stat-based quick-check table (keyed on source path) lets sync skip
+            # both the source and on-device file hashes when size+mtime are
+            # unchanged since the last sync — the common "nothing changed" case.
+            # One row per source file; INSERT OR REPLACE keeps it current and
+            # leaves no stale rows when a file's content changes.
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS quickcheck_entries ("
+                "  source_path TEXT PRIMARY KEY,"
+                "  kepubify_version TEXT NOT NULL,"
+                "  source_size INTEGER NOT NULL,"
+                "  source_mtime REAL NOT NULL,"
+                "  dest_path TEXT NOT NULL,"
+                "  dest_size INTEGER NOT NULL,"
+                "  dest_mtime REAL NOT NULL"
                 ")"
             )
             conn.commit()
@@ -60,6 +86,61 @@ class KepubCache:
                 "(source_hash, kepubify_version, kepub_sha, device_path) "
                 "VALUES (?, ?, ?, ?)",
                 (source_hash, kepubify_version, kepub_sha, str(device_path)),
+            )
+            conn.commit()
+
+    def get_quickcheck(
+        self, source_path: str, kepubify_version: str
+    ) -> QuickCheckEntry | None:
+        """Return the recorded stat snapshot for ``source_path``, if any.
+
+        Returns ``None`` when no row exists or the recorded kepubify version
+        differs (a version bump forces a reconvert, so the snapshot is stale).
+        """
+        with closing(sqlite3.connect(self.path)) as conn:
+            row = conn.execute(
+                "SELECT kepubify_version, source_size, source_mtime, "
+                "dest_path, dest_size, dest_mtime FROM quickcheck_entries "
+                "WHERE source_path = ? AND kepubify_version = ?",
+                (source_path, kepubify_version),
+            ).fetchone()
+        if row is None:
+            return None
+        return QuickCheckEntry(
+            kepubify_version=row[0],
+            source_size=row[1],
+            source_mtime=row[2],
+            dest_path=Path(row[3]),
+            dest_size=row[4],
+            dest_mtime=row[5],
+        )
+
+    def record_quickcheck(
+        self,
+        *,
+        source_path: str,
+        kepubify_version: str,
+        source_size: int,
+        source_mtime: float,
+        dest_path: str,
+        dest_size: int,
+        dest_mtime: float,
+    ) -> None:
+        with closing(sqlite3.connect(self.path)) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO quickcheck_entries "
+                "(source_path, kepubify_version, source_size, source_mtime, "
+                "dest_path, dest_size, dest_mtime) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    source_path,
+                    kepubify_version,
+                    source_size,
+                    source_mtime,
+                    dest_path,
+                    dest_size,
+                    dest_mtime,
+                ),
             )
             conn.commit()
 

--- a/src/bookery/device/kobo.py
+++ b/src/bookery/device/kobo.py
@@ -18,6 +18,7 @@ from bookery.core.pathformat import sanitize_component
 from bookery.db.hashing import compute_file_hash
 from bookery.db.mapping import BookRecord
 from bookery.db.status import PushCandidate
+from bookery.device.kepub_cache import QuickCheckEntry
 from bookery.device.kobo_backup import backup_kobo_db
 from bookery.device.kobo_reader import pull_read_state, read_kobo_serial
 from bookery.device.kobo_writer import (
@@ -200,6 +201,22 @@ class _CacheProto(Protocol):
         device_path: Path,
     ) -> None: ...
 
+    def get_quickcheck(
+        self, source_path: str, kepubify_version: str
+    ) -> QuickCheckEntry | None: ...
+
+    def record_quickcheck(
+        self,
+        *,
+        source_path: str,
+        kepubify_version: str,
+        source_size: int,
+        source_mtime: float,
+        dest_path: str,
+        dest_size: int,
+        dest_mtime: float,
+    ) -> None: ...
+
 
 ProgressCallback = Callable[[int, int, BookRecord], None]
 StageCallback = Callable[[str], None]
@@ -307,6 +324,58 @@ def _sync_record(
     dest = _compute_device_dest(target, books_subdir, record)
     dest_dir = dest.parent
 
+    def stamp_device_file() -> None:
+        # Re-stamp device_files on every skip/copy path; otherwise books that
+        # pre-date P1a (#180) — or any book that's been on the device long
+        # enough to skip conversion — stay invisible to ``list_push_candidates``
+        # and the read-status push silently no-ops (#188). Idempotent.
+        if device_id is not None:
+            catalog.upsert_device_file(
+                device_id=device_id,
+                book_id=record.id,
+                remote_path=_to_device_path(dest, target),
+                now=now,
+            )
+
+    def record_quickcheck() -> None:
+        # Best-effort: a missing snapshot just costs a hash next sync.
+        try:
+            s = source.stat()
+            d = dest.stat()
+        except OSError:
+            return
+        cache.record_quickcheck(
+            source_path=str(source),
+            kepubify_version=version,
+            source_size=s.st_size,
+            source_mtime=s.st_mtime,
+            dest_path=str(dest),
+            dest_size=d.st_size,
+            dest_mtime=d.st_mtime,
+        )
+
+    # Quick-skip: if size+mtime of both the source and the on-device file match
+    # what we recorded last sync, nothing changed — skip both hashes (the dest
+    # hash is a full read back over USB, the dominant resync cost). Any mismatch
+    # falls through to the hash path below, which re-records the snapshot.
+    qc = cache.get_quickcheck(str(source), version)
+    if qc is not None and qc.dest_path == dest and dest.exists():
+        try:
+            s_stat = source.stat()
+            d_stat = dest.stat()
+        except OSError:
+            s_stat = d_stat = None
+        if (
+            s_stat is not None
+            and d_stat is not None
+            and (s_stat.st_size, s_stat.st_mtime) == (qc.source_size, qc.source_mtime)
+            and (d_stat.st_size, d_stat.st_mtime) == (qc.dest_size, qc.dest_mtime)
+        ):
+            stage("cached")
+            report.skipped.append((dest, "already up to date"))
+            stamp_device_file()
+            return
+
     stage("hash")
     try:
         source_hash = compute_file_hash(source)
@@ -320,18 +389,10 @@ def _sync_record(
             if compute_file_hash(dest) == cached_kepub_sha:
                 stage("cached")
                 report.skipped.append((dest, "already up to date"))
-                # Re-stamp device_files even on the cached path; otherwise
-                # books that pre-date P1a (#180) — or any book that's been on
-                # the device long enough to hit this branch — stay invisible
-                # to ``list_push_candidates`` and the read-status push
-                # silently no-ops (#188). The upsert is idempotent.
-                if device_id is not None:
-                    catalog.upsert_device_file(
-                        device_id=device_id,
-                        book_id=record.id,
-                        remote_path=_to_device_path(dest, target),
-                        now=now,
-                    )
+                # Record the stat snapshot so the next sync quick-skips this
+                # book without reading either file.
+                record_quickcheck()
+                stamp_device_file()
                 return
         except OSError:
             pass  # fall through to re-convert
@@ -354,15 +415,10 @@ def _sync_record(
         return
 
     cache.put(source_hash, version, kepub_sha, dest)
+    record_quickcheck()
     stage("done")
     report.copied.append(dest)
-    if device_id is not None:
-        catalog.upsert_device_file(
-            device_id=device_id,
-            book_id=record.id,
-            remote_path=_to_device_path(dest, target),
-            now=now,
-        )
+    stamp_device_file()
 
 
 def _build_push_updates(candidates: list[PushCandidate]) -> list[ReadStatusUpdate]:

--- a/tests/unit/test_device_kepub_cache.py
+++ b/tests/unit/test_device_kepub_cache.py
@@ -45,3 +45,68 @@ def test_creates_parent_directory(tmp_path: Path) -> None:
     db = tmp_path / "nested" / "dir" / "kepub.db"
     KepubCache(db)
     assert db.parent.exists()
+
+
+def test_get_quickcheck_returns_none_on_miss(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    assert cache.get_quickcheck("/lib/A/T/T.epub", "v4.4.0") is None
+
+
+def test_record_then_get_quickcheck_round_trip(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    cache.record_quickcheck(
+        source_path="/lib/A/T/T.epub",
+        kepubify_version="v4.4.0",
+        source_size=100,
+        source_mtime=1_700_000_000.0,
+        dest_path="/dev/A/T/T.kepub.epub",
+        dest_size=120,
+        dest_mtime=1_700_000_500.0,
+    )
+    entry = cache.get_quickcheck("/lib/A/T/T.epub", "v4.4.0")
+    assert entry is not None
+    assert entry.source_size == 100
+    assert entry.source_mtime == 1_700_000_000.0
+    assert entry.dest_path == Path("/dev/A/T/T.kepub.epub")
+    assert entry.dest_size == 120
+    assert entry.dest_mtime == 1_700_000_500.0
+
+
+def test_get_quickcheck_misses_on_version_change(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    cache.record_quickcheck(
+        source_path="/lib/A/T/T.epub",
+        kepubify_version="v4.4.0",
+        source_size=100,
+        source_mtime=1_700_000_000.0,
+        dest_path="/dev/A/T/T.kepub.epub",
+        dest_size=120,
+        dest_mtime=1_700_000_500.0,
+    )
+    assert cache.get_quickcheck("/lib/A/T/T.epub", "v4.5.0") is None
+
+
+def test_record_quickcheck_overwrites_same_source_path(tmp_path: Path) -> None:
+    cache = KepubCache(tmp_path / "kepub.db")
+    cache.record_quickcheck(
+        source_path="/lib/A/T/T.epub",
+        kepubify_version="v4.4.0",
+        source_size=100,
+        source_mtime=1.0,
+        dest_path="/dev/A/T/T.kepub.epub",
+        dest_size=120,
+        dest_mtime=2.0,
+    )
+    cache.record_quickcheck(
+        source_path="/lib/A/T/T.epub",
+        kepubify_version="v4.4.0",
+        source_size=200,
+        source_mtime=3.0,
+        dest_path="/dev/A/T/T.kepub.epub",
+        dest_size=220,
+        dest_mtime=4.0,
+    )
+    entry = cache.get_quickcheck("/lib/A/T/T.epub", "v4.4.0")
+    assert entry is not None
+    assert entry.source_size == 200
+    assert entry.dest_size == 220

--- a/tests/unit/test_device_kobo_sync.py
+++ b/tests/unit/test_device_kobo_sync.py
@@ -1,6 +1,7 @@
 # ABOUTME: Unit tests for sync_library_to_kobo — orchestrates kepubify + cache + copy.
 # ABOUTME: Stubs the kepubify wrapper and uses a real KepubCache + tmp filesystem.
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -78,6 +79,22 @@ class StubCatalog:
     def list_push_candidates(self, *, device_id: int) -> list:
         # Stub catalog never produces push candidates; the push phase
         # short-circuits without touching the device DB.
+        return []
+
+    def upsert_device_shelf_state(self, **kwargs) -> None:
+        pass
+
+    def get_collection_shelf_state(
+        self, device_id: int, collection_id: int
+    ) -> dict | None:
+        return None
+
+    def list_collection_shelf_candidates(self, *, device_id: int) -> list:
+        return []
+
+    def list_collection_device_paths(
+        self, *, collection_id: int, device_id: int
+    ) -> list[str]:
         return []
 
 
@@ -402,7 +419,148 @@ def test_on_stage_emits_cached_when_skipping(tmp_path: Path) -> None:
         on_stage=stages.append,
     )
 
+    # Quick-skip fires on an unchanged resync: stats match the recorded
+    # snapshot, so neither the source nor the on-device file is hashed.
+    assert stages == ["cached"]
+
+
+def test_source_mtime_change_falls_through_to_hash(tmp_path: Path) -> None:
+    # A changed source mtime invalidates the quick-check, so sync falls back
+    # to the hash path. The content is unchanged, so the conversion cache
+    # still hits and the book is reported cached (not re-converted).
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+    )
+    first_calls = len(env["kepubify"].calls)
+
+    # Bump the source mtime without changing bytes.
+    st = epub.stat()
+    os.utime(epub, (st.st_atime, st.st_mtime + 100))
+
+    stages: list[str] = []
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        on_stage=stages.append,
+    )
+
     assert stages == ["hash", "cached"]
+    assert len(env["kepubify"].calls) == first_calls
+    assert len(report.skipped) == 1
+    assert len(report.copied) == 0
+
+
+def test_dest_change_falls_through_and_reconverts(tmp_path: Path) -> None:
+    # A changed on-device file invalidates the quick-check; the hash path then
+    # sees the dest hash differs and re-converts to restore the canonical kepub.
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    first = sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+    )
+    dest = first.copied[0]
+    first_calls = len(env["kepubify"].calls)
+
+    # Tamper with the on-device file (different size and content).
+    dest.write_bytes(b"CORRUPTED-ON-DEVICE-CONTENT")
+
+    report = sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+    )
+
+    assert len(env["kepubify"].calls) == first_calls + 1
+    assert len(report.copied) == 1
+    assert dest.read_bytes() == env["kepubify"].payload
+
+
+def test_missing_quickcheck_row_falls_through_then_repopulates(tmp_path: Path) -> None:
+    # A cache from before this feature has content-hash rows but no quick-check
+    # snapshot. The first sync after upgrade must fall through to the hash path
+    # (cached, not re-converted) and record a snapshot so the next sync skips.
+    import sqlite3
+
+    env = _setup(tmp_path)
+    epub = env["library"] / "A" / "T" / "T.epub"
+    _write_epub(epub)
+    record = _make_record(rec_id=1, title="T", author="A", epub_path=epub)
+    catalog = StubCatalog(records=[record])
+
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+    )
+    first_calls = len(env["kepubify"].calls)
+
+    # Simulate a pre-feature cache: drop the recorded snapshot, keep content rows.
+    with sqlite3.connect(env["cache"].path) as conn:
+        conn.execute("DELETE FROM quickcheck_entries")
+        conn.commit()
+
+    legacy_stages: list[str] = []
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        on_stage=legacy_stages.append,
+    )
+    assert legacy_stages == ["hash", "cached"]
+    assert len(env["kepubify"].calls) == first_calls
+
+    # Snapshot is now repopulated, so a third sync quick-skips.
+    repeat_stages: list[str] = []
+    sync_library_to_kobo(
+        catalog=catalog,
+        target=env["target"],
+        cache=env["cache"],
+        run_kepubify=env["kepubify"].run,
+        kepubify_version=env["kepubify"].get_version,
+        workspace_dir=env["workspace"],
+        books_subdir="Books",
+        on_stage=repeat_stages.append,
+    )
+    assert repeat_stages == ["cached"]
 
 
 def test_on_progress_callback_invoked_per_record(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Skips re-hashing unchanged books on `bookery sync kobo` by comparing `(size, mtime)` against a recorded snapshot, instead of hashing the source EPUB and reading the on-device kepub back over USB.
- An unchanged resync drops from two full-file hashes per book to two `stat()` calls. The on-device USB read-back — the dominant resync cost — is gone from the common path.

## Changes
- **`device/kepub_cache.py`**: new path-keyed `quickcheck_entries` table + `get_quickcheck`/`record_quickcheck`. Stores source and dest `size`/`mtime`. Separate from the content-hash conversion cache; `INSERT OR REPLACE` on source path leaves no stale rows.
- **`device/kobo.py`**: `_sync_record` consults the snapshot before any hashing. If `dest` exists and both source and dest stats match, it skips (emits `cached`, re-stamps `device_files`) with no file reads. Any mismatch — or a missing snapshot (pre-feature cache) — falls through to the existing hash path, which re-records the snapshot. Also extracts a `stamp_device_file()` helper, collapsing the duplicated `upsert_device_file` block.

## Correctness
A stat mismatch only ever costs one extra (correct) hash, never a wrong skip. Source EPUB mtime is stable across syncs (metadata rewrites go to copies → mtime bump → cache miss → reconvert, which is correct).

## Testing
- [x] Unit: cache round-trip / version-miss / overwrite; quick-skip hit emits `["cached"]`; source-mtime change → `["hash","cached"]` no reconvert; dest tamper → reconvert; pre-feature cache (no snapshot) → falls through then repopulates.
- [x] Full suite passes (2408), ruff + pyright clean.
- [x] Manually verified on device: first sync ~48s (populates snapshots), second unchanged sync instant.

## Related Issues
Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)