### PR TITLE
Add #267: Google Books API key via GOOGLE_BOOKS_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ bookery info 42
 
 - **`--no-cache`** on `match`/`rematch` bypasses the on-disk metadata response cache and forces fresh provider lookups. Cached responses live at `{data_dir}/metadata_cache.db` and expire after `[matching].cache_ttl_days`.
 - **`[matching].providers`** selects and orders metadata sources. With a single entry the named provider is used directly; with two or more, results are merged by a consensus step that prefers values agreed on by ≥2 providers and falls back to the priority order otherwise. Supported: `openlibrary`, `googlebooks`.
+- **Google Books API key** — set the `GOOGLE_BOOKS_API_KEY` environment variable to authenticate Google Books requests. Without it, requests use the shared anonymous per-IP quota, which a full-library `rematch` exhausts quickly (HTTP 429). Create a free key in the [Google Cloud Console](https://console.cloud.google.com/): create/select a project, enable the **Books API**, then **Credentials → Create credentials → API key**. Then `export GOOGLE_BOOKS_API_KEY=AIza...`. The key is read from the environment only — never written to config.
 - **Per-field provenance** is recorded for every cataloged book in the `book_field_provenance` table. Use `bookery info <id> --provenance` to see which source supplied each field and when it was fetched. Use `bookery info <id> --set field=value` to hand-edit a value (it's stamped as `user` and locked against overwrite), and `--lock field` / `--unlock field` to gate fields against `rematch`.
 
 ## Commands

--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -1,6 +1,7 @@
 # ABOUTME: Shared helpers for building match and progress callbacks.
 # ABOUTME: Used by both `import` and `add` commands so behavior stays in one place.
 
+import os
 from pathlib import Path
 
 from rich.console import Console
@@ -55,7 +56,10 @@ def build_active_providers(*, use_cache: bool = True) -> dict[str, MetadataProvi
         if name == "openlibrary":
             providers[name] = OpenLibraryProvider(http_client=_http_for("openlibrary"))  # type: ignore[arg-type]
         elif name == "googlebooks":
-            providers[name] = GoogleBooksProvider(http_client=_http_for("googlebooks"))  # type: ignore[arg-type]
+            providers[name] = GoogleBooksProvider(
+                http_client=_http_for("googlebooks"),  # type: ignore[arg-type]
+                api_key=os.environ.get("GOOGLE_BOOKS_API_KEY"),
+            )
         else:
             import logging
 

--- a/src/bookery/metadata/googlebooks.py
+++ b/src/bookery/metadata/googlebooks.py
@@ -141,12 +141,22 @@ class GoogleBooksProvider:
     pageCount, and cover thumbnails that Open Library routinely lacks.
     """
 
-    def __init__(self, http_client: HttpClient) -> None:
+    def __init__(self, http_client: HttpClient, api_key: str | None = None) -> None:
         self._http = http_client
+        # Normalize "" (unset env var resolves to empty) to None so we never
+        # send key="". With a key, Google Books lifts the low anonymous per-IP
+        # quota that otherwise 429s a full-library rematch (#267).
+        self._api_key = api_key or None
 
     @property
     def name(self) -> str:
         return "googlebooks"
+
+    def _get(self, url: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        merged = dict(params or {})
+        if self._api_key:
+            merged["key"] = self._api_key
+        return self._http.get(url, params=merged or None)
 
     def search_by_isbn(self, isbn: str) -> list[MetadataCandidate]:
         """Look up a book by ISBN via Google Books.
@@ -155,7 +165,7 @@ class GoogleBooksProvider:
         """
         clean_isbn = re.sub(r"[\s-]", "", isbn)
         try:
-            data = self._http.get(_GB_BASE, params={"q": f"isbn:{clean_isbn}"})
+            data = self._get(_GB_BASE, params={"q": f"isbn:{clean_isbn}"})
         except MetadataFetchError as exc:
             logger.warning("ISBN lookup failed for %s: %s", isbn, exc)
             return []
@@ -188,7 +198,7 @@ class GoogleBooksProvider:
         query = " ".join(query_parts)
 
         try:
-            data = self._http.get(
+            data = self._get(
                 _GB_BASE,
                 params={"q": query, "maxResults": str(_SEARCH_LIMIT)},
             )
@@ -234,7 +244,7 @@ class GoogleBooksProvider:
         if not volume_id:
             return None
         try:
-            data = self._http.get(f"{_GB_BASE}/{volume_id}")
+            data = self._get(f"{_GB_BASE}/{volume_id}")
         except MetadataFetchError as exc:
             logger.warning("URL lookup failed for %s: %s", url, exc)
             return None

--- a/tests/unit/test_googlebooks_provider.py
+++ b/tests/unit/test_googlebooks_provider.py
@@ -134,6 +134,46 @@ def test_subtitle_is_kept_separate_from_title() -> None:
     assert candidates[0].metadata.subtitle == "A Novel"
 
 
+def test_api_key_injected_into_isbn_search() -> None:
+    http = FakeHttpClient({"volumes": {"items": [_volume()]}})
+    provider = GoogleBooksProvider(http_client=http, api_key="SECRET")
+    provider.search_by_isbn("9780441013593")
+    assert http.last_params == {"q": "isbn:9780441013593", "key": "SECRET"}
+
+
+def test_api_key_injected_into_title_author_search() -> None:
+    http = FakeHttpClient({"volumes": {"items": [_volume()]}})
+    provider = GoogleBooksProvider(http_client=http, api_key="SECRET")
+    provider.search_by_title_author("Dune", "Frank Herbert")
+    assert http.last_params == {
+        "q": "intitle:Dune inauthor:Frank Herbert",
+        "maxResults": "5",
+        "key": "SECRET",
+    }
+
+
+def test_api_key_injected_into_url_lookup() -> None:
+    http = FakeHttpClient({"VOL1": _volume()})
+    provider = GoogleBooksProvider(http_client=http, api_key="SECRET")
+    provider.lookup_by_url("https://books.google.com/books?id=VOL1")
+    assert http.last_params == {"key": "SECRET"}
+
+
+def test_no_api_key_omits_key_param() -> None:
+    http = FakeHttpClient({"volumes": {"items": [_volume()]}})
+    provider = GoogleBooksProvider(http_client=http)
+    provider.search_by_isbn("9780441013593")
+    assert http.last_params == {"q": "isbn:9780441013593"}
+
+
+def test_empty_api_key_treated_as_absent() -> None:
+    # An unset env var resolves to "" upstream; that must not send key="".
+    http = FakeHttpClient({"volumes": {"items": [_volume()]}})
+    provider = GoogleBooksProvider(http_client=http, api_key="")
+    provider.search_by_isbn("9780441013593")
+    assert http.last_params == {"q": "isbn:9780441013593"}
+
+
 def test_parses_rating_ratings_count_print_type_and_maturity() -> None:
     vol = _volume(title="Dune")
     vol["volumeInfo"]["averageRating"] = 4.3

--- a/tests/unit/test_match_providers_config.py
+++ b/tests/unit/test_match_providers_config.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 from bookery.cli._match_helpers import build_metadata_provider
+from bookery.metadata.googlebooks import GoogleBooksProvider
 
 
 def _install_config(home: Path, body: str | None) -> None:
@@ -42,6 +43,22 @@ def test_googlebooks_only_config(monkeypatch, tmp_path) -> None:
     _isolate(monkeypatch, tmp_path, body='[matching]\nproviders = ["googlebooks"]\n')
     provider = build_metadata_provider(use_cache=False)
     assert type(provider).__name__ == "GoogleBooksProvider"
+
+
+def test_googlebooks_reads_api_key_from_env(monkeypatch, tmp_path) -> None:
+    _isolate(monkeypatch, tmp_path, body='[matching]\nproviders = ["googlebooks"]\n')
+    monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "env-key-123")
+    provider = build_metadata_provider(use_cache=False)
+    assert isinstance(provider, GoogleBooksProvider)
+    assert provider._api_key == "env-key-123"
+
+
+def test_googlebooks_without_api_key_env_is_none(monkeypatch, tmp_path) -> None:
+    _isolate(monkeypatch, tmp_path, body='[matching]\nproviders = ["googlebooks"]\n')
+    monkeypatch.delenv("GOOGLE_BOOKS_API_KEY", raising=False)
+    provider = build_metadata_provider(use_cache=False)
+    assert isinstance(provider, GoogleBooksProvider)
+    assert provider._api_key is None
 
 
 def test_unknown_provider_is_skipped(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Adds Google Books API key support to fix sustained HTTP 429s on full-library `rematch`. Unauthenticated requests share a low per-IP quota that a bulk rematch exhausts; the 1/2/4s retry backoff can't outwait a quota block.
- Scope: **API key only**. Retry-After handling and a configurable per-provider request interval remain open follow-ups on #267.

## Changes
- **`metadata/googlebooks.py`**: `GoogleBooksProvider` takes an optional `api_key`; a small `_get` wrapper injects `key=` on all three request sites (ISBN, title/author, URL lookup). `api_key or None` normalizes unset/empty so anonymous behavior is unchanged when no key is set.
- **`cli/_match_helpers.py`**: reads the key from the `GOOGLE_BOOKS_API_KEY` env var.
- **`README.md`**: documents obtaining and setting the key.

## Testing
- [x] Unit: key injected on all 3 endpoints; no-key and empty-key omit `key`; env-var wiring present/absent.
- [x] Full suite passes (2408), ruff + pyright clean.

## Notes
- The key value becomes part of `CachingHttpClient`'s cache-key composition, so it's embedded in cache-key strings in the local `metadata_cache.db` (user's own key, local file — low risk).

## Related Issues
Partially addresses #267 (API key piece; Retry-After + configurable interval still open — see issue comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)