### PR TITLE
Add #267: honor Retry-After + configurable min_request_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ bookery info 42
   auto_accept_threshold = 0.85
   cache_ttl_days = 30        # metadata response cache TTL (default 30)
   providers = ["openlibrary", "googlebooks"]   # priority order; default ["openlibrary"]
+  min_request_interval = 0.1 # seconds between provider HTTP requests (default 0.1)
   ```
 
 - **`--no-cache`** on `match`/`rematch` bypasses the on-disk metadata response cache and forces fresh provider lookups. Cached responses live at `{data_dir}/metadata_cache.db` and expire after `[matching].cache_ttl_days`.
 - **`[matching].providers`** selects and orders metadata sources. With a single entry the named provider is used directly; with two or more, results are merged by a consensus step that prefers values agreed on by ≥2 providers and falls back to the priority order otherwise. Supported: `openlibrary`, `googlebooks`.
 - **Google Books API key** — set the `GOOGLE_BOOKS_API_KEY` environment variable to authenticate Google Books requests. Without it, requests use the shared anonymous per-IP quota, which a full-library `rematch` exhausts quickly (HTTP 429). Create a free key in the [Google Cloud Console](https://console.cloud.google.com/): create/select a project, enable the **Books API**, then **Credentials → Create credentials → API key**. Then `export GOOGLE_BOOKS_API_KEY=AIza...`. The key is read from the environment only — never written to config.
+- **`[matching].min_request_interval`** is the minimum seconds between provider HTTP requests (default `0.1`). Raise it to throttle a bulk `rematch` below a provider's rate limit; on a `429` the client also honors the response's `Retry-After` header (capped at 60s) before retrying.
 - **Per-field provenance** is recorded for every cataloged book in the `book_field_provenance` table. Use `bookery info <id> --provenance` to see which source supplied each field and when it was fetched. Use `bookery info <id> --set field=value` to hand-edit a value (it's stamped as `user` and locked against overwrite), and `--lock field` / `--unlock field` to gate fields against `rematch`.
 
 ## Commands

--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -44,9 +44,7 @@ def build_active_providers(*, use_cache: bool = True) -> dict[str, MetadataProvi
     def _http_for(provider_name: str):
         # ponytail: one library-wide interval for every provider, not per-provider
         # config — both providers want the same throttle today (#267).
-        client: object = BookeryHttpClient(
-            min_request_interval=matching.min_request_interval
-        )
+        client: object = BookeryHttpClient(min_request_interval=matching.min_request_interval)
         if cache is not None:
             client = CachingHttpClient(
                 client,  # type: ignore[arg-type]

--- a/src/bookery/cli/_match_helpers.py
+++ b/src/bookery/cli/_match_helpers.py
@@ -42,7 +42,11 @@ def build_active_providers(*, use_cache: bool = True) -> dict[str, MetadataProvi
         )
 
     def _http_for(provider_name: str):
-        client: object = BookeryHttpClient()
+        # ponytail: one library-wide interval for every provider, not per-provider
+        # config — both providers want the same throttle today (#267).
+        client: object = BookeryHttpClient(
+            min_request_interval=matching.min_request_interval
+        )
         if cache is not None:
             client = CachingHttpClient(
                 client,  # type: ignore[arg-type]

--- a/src/bookery/core/config.py
+++ b/src/bookery/core/config.py
@@ -67,6 +67,10 @@ class MatchingConfig:
     auto_accept_threshold: float = DEFAULT_AUTO_ACCEPT_THRESHOLD
     cache_ttl_days: int = 30
     providers: tuple[str, ...] = ("openlibrary",)
+    # Minimum seconds between provider HTTP requests. Default matches the
+    # BookeryHttpClient default; raise it to throttle a bulk rematch below the
+    # anonymous Google Books limit without editing code (#267).
+    min_request_interval: float = 0.1
 
 
 @dataclass(frozen=True)
@@ -163,6 +167,7 @@ def _parse_matching(section: dict[str, Any] | None) -> MatchingConfig:
         ),
         cache_ttl_days=int(section.get("cache_ttl_days", 30)),
         providers=providers,
+        min_request_interval=float(section.get("min_request_interval", 0.1)),
     )
 
 

--- a/src/bookery/metadata/http.py
+++ b/src/bookery/metadata/http.py
@@ -15,6 +15,9 @@ logger = logging.getLogger(__name__)
 
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
+# Cap on Retry-After so a hostile or huge header value can't hang the CLI.
+_MAX_RETRY_AFTER = 60.0
+
 
 class MetadataFetchError(Exception):
     """Raised when an HTTP request to a metadata provider fails."""
@@ -88,7 +91,9 @@ class BookeryHttpClient:
                 )
 
             if attempt < attempts - 1:
-                delay = self._retry_delay * (2**attempt)
+                delay = self._retry_after(response)
+                if delay is None:
+                    delay = self._retry_delay * (2**attempt)
                 logger.warning(
                     "HTTP %d from %s, retrying in %.1fs (attempt %d/%d)",
                     response.status_code,
@@ -100,6 +105,23 @@ class BookeryHttpClient:
                 time.sleep(delay)
 
         raise MetadataFetchError(f"HTTP {last_status} from {url} after {attempts} attempts")
+
+    @staticmethod
+    def _retry_after(response: httpx.Response) -> float | None:
+        """Seconds to wait per the Retry-After header, capped.
+
+        Returns None when the header is absent or not the integer-seconds form
+        (e.g. an HTTP-date), so the caller falls back to exponential backoff.
+        """
+        raw = response.headers.get("Retry-After")
+        if not raw:
+            return None
+        try:
+            secs = float(raw)
+        except ValueError:
+            # ponytail: HTTP-date form unsupported; falls back to backoff.
+            return None
+        return min(max(secs, 0.0), _MAX_RETRY_AFTER)
 
     def _rate_limit(self) -> None:
         """Sleep if needed to maintain minimum interval between requests."""

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -140,9 +140,7 @@ class TestBookeryHttpClient:
         client.get("https://example.com/api")
         assert slept == [_MAX_RETRY_AFTER]
 
-    def test_retry_after_non_numeric_falls_back(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_retry_after_non_numeric_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An HTTP-date Retry-After (unparseable here) falls back to backoff."""
         slept: list[float] = []
         monkeypatch.setattr(time, "sleep", slept.append)
@@ -155,16 +153,12 @@ class TestBookeryHttpClient:
             httpx.Response(200, json={"ok": True}),
         ]
         transport = FakeTransport(responses=responses)
-        client = BookeryHttpClient(
-            min_request_interval=0.0, transport=transport, retry_delay=0.01
-        )
+        client = BookeryHttpClient(min_request_interval=0.0, transport=transport, retry_delay=0.01)
 
         client.get("https://example.com/api")
         assert slept == [0.01]  # retry_delay * 2**0
 
-    def test_retry_after_absent_falls_back(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_retry_after_absent_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A 429 without Retry-After uses the existing exponential backoff."""
         slept: list[float] = []
         monkeypatch.setattr(time, "sleep", slept.append)
@@ -173,9 +167,7 @@ class TestBookeryHttpClient:
             httpx.Response(200, json={"ok": True}),
         ]
         transport = FakeTransport(responses=responses)
-        client = BookeryHttpClient(
-            min_request_interval=0.0, transport=transport, retry_delay=0.01
-        )
+        client = BookeryHttpClient(min_request_interval=0.0, transport=transport, retry_delay=0.01)
 
         client.get("https://example.com/api")
         assert slept == [0.01]

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from bookery.metadata.http import (
+    _MAX_RETRY_AFTER,
     BookeryHttpClient,
     HttpClient,
     MetadataFetchError,
@@ -109,3 +110,72 @@ class TestBookeryHttpClient:
         with pytest.raises(MetadataFetchError, match="500"):
             client.get("https://example.com/api")
         assert transport.call_count == 4  # 1 initial + 3 retries
+
+    def test_retry_after_header_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A 429 with Retry-After waits exactly that many seconds before retrying."""
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", slept.append)
+        responses = [
+            httpx.Response(429, headers={"Retry-After": "5"}, json={}),
+            httpx.Response(200, json={"ok": True}),
+        ]
+        transport = FakeTransport(responses=responses)
+        client = BookeryHttpClient(min_request_interval=0.0, transport=transport)
+
+        result = client.get("https://example.com/api")
+        assert result == {"ok": True}
+        assert slept == [5.0]
+
+    def test_retry_after_capped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A huge Retry-After is capped at _MAX_RETRY_AFTER so the CLI can't hang."""
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", slept.append)
+        responses = [
+            httpx.Response(429, headers={"Retry-After": "9999"}, json={}),
+            httpx.Response(200, json={"ok": True}),
+        ]
+        transport = FakeTransport(responses=responses)
+        client = BookeryHttpClient(min_request_interval=0.0, transport=transport)
+
+        client.get("https://example.com/api")
+        assert slept == [_MAX_RETRY_AFTER]
+
+    def test_retry_after_non_numeric_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An HTTP-date Retry-After (unparseable here) falls back to backoff."""
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", slept.append)
+        responses = [
+            httpx.Response(
+                429,
+                headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+                json={},
+            ),
+            httpx.Response(200, json={"ok": True}),
+        ]
+        transport = FakeTransport(responses=responses)
+        client = BookeryHttpClient(
+            min_request_interval=0.0, transport=transport, retry_delay=0.01
+        )
+
+        client.get("https://example.com/api")
+        assert slept == [0.01]  # retry_delay * 2**0
+
+    def test_retry_after_absent_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 429 without Retry-After uses the existing exponential backoff."""
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", slept.append)
+        responses = [
+            httpx.Response(429, json={}),
+            httpx.Response(200, json={"ok": True}),
+        ]
+        transport = FakeTransport(responses=responses)
+        client = BookeryHttpClient(
+            min_request_interval=0.0, transport=transport, retry_delay=0.01
+        )
+
+        client.get("https://example.com/api")
+        assert slept == [0.01]

--- a/tests/unit/test_match_providers_config.py
+++ b/tests/unit/test_match_providers_config.py
@@ -3,7 +3,8 @@
 
 from pathlib import Path
 
-from bookery.cli._match_helpers import build_metadata_provider
+from bookery.cli._match_helpers import build_active_providers, build_metadata_provider
+from bookery.core.config import get_matching_config
 from bookery.metadata.googlebooks import GoogleBooksProvider
 
 
@@ -59,6 +60,33 @@ def test_googlebooks_without_api_key_env_is_none(monkeypatch, tmp_path) -> None:
     provider = build_metadata_provider(use_cache=False)
     assert isinstance(provider, GoogleBooksProvider)
     assert provider._api_key is None
+
+
+def test_matching_config_parses_min_request_interval(monkeypatch, tmp_path) -> None:
+    _isolate(monkeypatch, tmp_path, body="[matching]\nmin_request_interval = 0.5\n")
+    assert get_matching_config().min_request_interval == 0.5
+
+
+def test_matching_config_min_request_interval_defaults(monkeypatch, tmp_path) -> None:
+    _isolate(monkeypatch, tmp_path, body=None)
+    assert get_matching_config().min_request_interval == 0.1
+
+
+def test_http_client_uses_configured_interval(monkeypatch, tmp_path) -> None:
+    _isolate(
+        monkeypatch,
+        tmp_path,
+        body='[matching]\nproviders = ["openlibrary"]\nmin_request_interval = 2.0\n',
+    )
+    captured: list[float] = []
+
+    class _CapturingClient:
+        def __init__(self, *, min_request_interval: float = 0.1, **_: object) -> None:
+            captured.append(min_request_interval)
+
+    monkeypatch.setattr("bookery.metadata.http.BookeryHttpClient", _CapturingClient)
+    build_active_providers(use_cache=False)
+    assert captured == [2.0]
 
 
 def test_unknown_provider_is_skipped(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
Completes the remaining scope of #267 (PR #269 shipped the API key half). Hardens Google Books rate-limit handling so a full-library rematch degrades gracefully instead of burning retries.

- **Honor `Retry-After` on 429** (AC#3) — the retry loop now waits the duration the server asks for instead of the blind 1/2/4s backoff, capped at 60s so a hostile/huge value can't hang the CLI. Absent or HTTP-date headers fall back to the existing exponential backoff.
- **Configurable `[matching].min_request_interval`** (AC#4) — surfaces the existing `BookeryHttpClient` request interval as config (default `0.1`, unchanged behavior), applied to every provider's HTTP client. One library-wide interval, not per-provider, since both providers want the same throttle today.

## Changes
- **src/bookery/metadata/http.py**: `_MAX_RETRY_AFTER` cap + `_retry_after()` helper; retry loop prefers the header over backoff.
- **src/bookery/core/config.py**: `MatchingConfig.min_request_interval` field + TOML parse.
- **src/bookery/cli/_match_helpers.py**: thread the configured interval into each provider's `BookeryHttpClient`.
- **README.md**: document `min_request_interval` and the Retry-After behavior.

## Testing
- [x] New unit tests: Retry-After honored / capped / non-numeric fallback / absent fallback; config parse + default; end-to-end wiring into the provider client.
- [x] Full suite: 2422 passed
- [x] `ruff check` clean, pyright 0 errors

## Related Issues
Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)