### PR TITLE
Add #232: note ruff format step in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ intentionally uses `pdfplumber` (MIT) and `pypdf` (BSD-3) instead of
 
 ### Style
 
-- **Ruff** is the linter and formatter. Run `uv run ruff check src/ tests/` before committing.
+- **Ruff** is the linter and formatter. Run `uv run ruff check src/ tests/` and `uv run ruff format src/ tests/` before committing.
 - **Pyright** is the type checker. Run `uv run pyright src/` to check types.
 - Both run automatically on staged files via the pre-commit hook (see Getting Started).
 - Python 3.12+ features are encouraged (type unions with `|`, etc.).


### PR DESCRIPTION
Closes #232.

## What

#232 asked for `ruff format --check` in pre-commit + a clean baseline + a CONTRIBUTING note.

Turns out the tracked `hooks/pre-commit` **already** runs `ruff format --check` on staged files, and `main` is now format-clean (`310 files already formatted`) after the recent ruff-format pass. The only gap was the docs.

This adds the matching local command (`uv run ruff format src/ tests/`) to CONTRIBUTING.md.

## Acceptance
- [x] `ruff format --check src/ tests/` clean on main
- [x] Pre-commit fails on unformatted code (tracked hook)
- [x] CONTRIBUTING.md notes the format step

Note: the drift originally seen came from a stale local `.git/hooks/pre-commit`; `core.hooksPath` should point at the tracked `hooks` dir (per CONTRIBUTING Getting Started).

https://claude.ai/code/session_013E8WzoNJkNgs2GoJQPMFQq