### PR TITLE
Add #256: book-detail collection management + delete modal + web nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ In the web edit form these conversions are gated — when a static collection wi
 hand-picked books gains a rule, or any rule is cleared, the form warns with the
 exact count of books affected and requires a second confirm before writing.
 
+From the web UI (`bookery serve`), reach collections via the **Collections** link
+in the header. A book's detail page has a **Collections** section that lists the
+static collections it belongs to (each with a **Remove**), an **Add to
+collection** picker (static collections only — rule-based membership is derived),
+and a **New collection from this book** link that seeds a rule from the book's
+series or author. Deleting a collection from its detail page asks for
+confirmation first; your books are never deleted.
+
 #### Rule query language
 
 A rule query is a [Lucene](https://lucene.apache.org/)-style expression over a

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -140,6 +140,15 @@ def _format_size(num_bytes: int) -> str:
     return f"{size:.1f} GB"
 
 
+def _static_collections(catalog) -> list[dict[str, object]]:
+    """Static collections only (no query) — the only ones you can add a book to.
+
+    Rule-based membership is derived from the query, so manual add/remove is
+    meaningless for them.
+    """
+    return [c for c in catalog.list_collections() if c["query"] is None]
+
+
 bp = Blueprint(
     "web",
     __name__,
@@ -249,32 +258,23 @@ def book_detail(book_id):
     device_read_state = catalog.get_device_read_state_for_book(book_id)
     queued_for_push = catalog.is_status_queued_for_push(book_id)
 
-    if request.headers.get("HX-Request"):
-        return render_template(
-            "_detail.html",
-            book=book,
-            tags=tags,
-            genres=genres,
-            collections=collections,
-            file_info=file_info,
-            return_to=return_to,
-            book_status=book_status,
-            device_read_state=device_read_state,
-            queued_for_push=queued_for_push,
-        )
-
-    return render_template(
-        "detail.html",
+    context = dict(
         book=book,
         tags=tags,
         genres=genres,
         collections=collections,
+        static_collections=_static_collections(catalog),
         file_info=file_info,
         return_to=return_to,
         book_status=book_status,
         device_read_state=device_read_state,
         queued_for_push=queued_for_push,
     )
+
+    if request.headers.get("HX-Request"):
+        return render_template("_detail.html", **context)
+
+    return render_template("detail.html", **context)
 
 
 @bp.route("/books/bulk-status", methods=["POST"])
@@ -773,6 +773,42 @@ def delete_book(book_id):
     response = make_response("", 200)
     response.headers["HX-Redirect"] = url_for("web.books")
     return response
+
+
+@bp.route("/books/<int:book_id>/add-to-collection", methods=["POST"])
+def book_add_to_collection(book_id):
+    """Add a book to a chosen static collection from its detail page.
+
+    Re-renders the book-detail Collections section (outer-swap). Adding to a
+    rule-based collection is rejected — its membership is derived, not manual.
+    """
+    catalog = current_app.config["CATALOG"]
+    book = catalog.get_by_id(book_id)
+    if book is None:
+        abort(404)
+
+    raw_id = request.form.get("collection_id", "")
+    collection = None
+    if raw_id.isdigit():
+        collection = catalog.get_collection_by_id(int(raw_id))
+
+    if collection is None:
+        flash("Choose a collection to add this book to.", "warning")
+    elif collection["query"] is not None:
+        flash("Rule-based collections fill themselves; pick a manual one.", "error")
+    else:
+        try:
+            catalog.add_books_to_collection(int(raw_id), [book_id])
+            flash(f'Added to "{collection["name"]}".', "success")
+        except ValueError as exc:
+            flash(str(exc), "error")
+
+    return render_template(
+        "_detail_collections.html",
+        book=book,
+        collections=catalog.get_collections_for_book(book_id),
+        static_collections=_static_collections(catalog),
+    )
 
 
 def _hx_redirect(target_url: str) -> Response:
@@ -1321,7 +1357,7 @@ def collection_new_form():
     "New collection from this book" link (PR 5) can seed a starting rule.
     """
     form = {
-        "name": "",
+        "name": request.args.get("name", ""),
         "description": "",
         "query": request.args.get("query", ""),
     }

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1519,6 +1519,18 @@ def collection_update(collection_id):
     return _redirect_after_save(url_for("web.collection_detail", collection_id=collection_id))
 
 
+@bp.route("/collections/<int:collection_id>/delete", methods=["GET"])
+def collection_delete_confirm(collection_id):
+    """Render the delete-confirmation panel (htmx swap into #collection-content)."""
+    catalog = current_app.config["CATALOG"]
+
+    collection = catalog.get_collection_by_id(collection_id)
+    if collection is None:
+        abort(404)
+
+    return render_template("_collection_delete_confirm.html", collection=collection)
+
+
 @bp.route("/collections/<int:collection_id>/delete", methods=["POST"])
 def collection_delete(collection_id):
     """Delete a collection."""

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -1126,6 +1126,10 @@ def collection_add_books(collection_id):
     if collection is None:
         abort(404)
 
+    if collection["query"] is not None:
+        flash("Rule-based collections fill themselves; books can't be added by hand.", "error")
+        return redirect(url_for("web.collection_detail", collection_id=collection_id))
+
     raw_ids = request.form.getlist("book_ids")
     if not raw_ids:
         flash("No books selected.", "warning")

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -362,6 +362,26 @@ header .logo {
     border-bottom: none;
 }
 
+.book-collections .collection-memberships {
+    list-style: none;
+    padding: 0;
+}
+
+.book-collections .collection-memberships li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.25rem;
+}
+
+.book-collections .add-to-collection {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
 .section h3 {
     font-size: 1rem;
     text-transform: uppercase;

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -70,6 +70,21 @@ header .logo {
     text-decoration: none;
 }
 
+.site-nav {
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.site-nav a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.site-nav a:hover {
+    text-decoration: underline;
+}
+
 .page-title {
     font-size: 1.75rem;
     margin: 0 0 1rem;

--- a/src/bookery/web/templates/_collection_delete_confirm.html
+++ b/src/bookery/web/templates/_collection_delete_confirm.html
@@ -1,0 +1,23 @@
+{# ABOUTME: Collection delete-confirmation panel — swapped into #collection-content. #}
+{# ABOUTME: Reassures that book rows/files survive; Cancel is the focused default. #}
+<section class="section delete-confirm" role="dialog" aria-modal="true"
+         aria-labelledby="collection-delete-heading">
+    <h2 id="collection-delete-heading">Delete this collection?</h2>
+
+    <p>
+        Delete &ldquo;{{ collection.name }}&rdquo;? This removes the collection.
+        Your books are not deleted.
+    </p>
+
+    <form action="{{ url_for('web.collection_delete', collection_id=collection.id) }}"
+          method="post"
+          class="delete-actions">
+        <button type="button"
+                class="btn btn-secondary"
+                autofocus
+                hx-get="{{ url_for('web.collection_detail', collection_id=collection.id) }}"
+                hx-target="#collection-content"
+                hx-swap="innerHTML">Cancel</button>
+        <button type="submit" class="btn btn-destructive">Delete collection</button>
+    </form>
+</section>

--- a/src/bookery/web/templates/_collection_detail.html
+++ b/src/bookery/web/templates/_collection_detail.html
@@ -14,6 +14,10 @@
            hx-get="{{ url_for('web.collection_edit_form', collection_id=collection.id) }}"
            hx-target="#collection-content"
            class="btn-secondary">Edit</a>
+        <a href="{{ url_for('web.collection_delete_confirm', collection_id=collection.id) }}"
+           hx-get="{{ url_for('web.collection_delete_confirm', collection_id=collection.id) }}"
+           hx-target="#collection-content"
+           class="btn-destructive">Delete</a>
     </p>
 </header>
 

--- a/src/bookery/web/templates/_detail.html
+++ b/src/bookery/web/templates/_detail.html
@@ -6,5 +6,6 @@
 {% include "_detail_reading.html" %}
 {% include "_detail_publication.html" %}
 {% include "_detail_classification.html" %}
+{% include "_detail_collections.html" %}
 {% include "_detail_file.html" %}
 {% include "_detail_description.html" %}

--- a/src/bookery/web/templates/_detail_collections.html
+++ b/src/bookery/web/templates/_detail_collections.html
@@ -1,0 +1,55 @@
+{# ABOUTME: Book-detail Collections section — membership, add-to-static, quick-create. #}
+{# ABOUTME: Outer-swapped by book_add_to_collection; rule collections are excluded. #}
+{% set seed_query = ('series:"%s"' % book.metadata.series) if book.metadata.series
+   else ('author:"%s"' % (book.metadata.authors[0] if book.metadata.authors else '')) %}
+{% set seed_name = book.metadata.series if book.metadata.series
+   else (book.metadata.authors[0] if book.metadata.authors else '') %}
+<section id="book-collections" class="section book-collections"
+         aria-labelledby="book-collections-heading" aria-live="polite">
+    <h2 id="book-collections-heading">Collections</h2>
+
+    {% if collections %}
+    <ul class="collection-memberships">
+        {% for collection in collections %}
+        <li>
+            <a href="{{ url_for('web.collection_detail', collection_id=collection.id) }}">
+                {{ collection.name }}
+            </a>
+            <form method="POST"
+                  action="{{ url_for('web.collection_remove_book', collection_id=collection.id, book_id=book.id) }}"
+                  hx-post="{{ url_for('web.collection_remove_book', collection_id=collection.id, book_id=book.id) }}"
+                  hx-target="#book-collections"
+                  hx-swap="outerHTML"
+                  class="inline-form">
+                <button type="submit" class="btn-small">Remove</button>
+            </form>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="empty">Not in any collection yet.</p>
+    {% endif %}
+
+    {% if static_collections %}
+    <form method="POST"
+          action="{{ url_for('web.book_add_to_collection', book_id=book.id) }}"
+          hx-post="{{ url_for('web.book_add_to_collection', book_id=book.id) }}"
+          hx-target="#book-collections"
+          hx-swap="outerHTML"
+          class="add-to-collection">
+        <label for="add-collection-select">Add to collection</label>
+        <select id="add-collection-select" name="collection_id">
+            {% for collection in static_collections %}
+            <option value="{{ collection.id }}">{{ collection.name }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit" class="btn-small">Add</button>
+    </form>
+    {% endif %}
+
+    <p class="quick-create">
+        <a href="{{ url_for('web.collection_new_form') }}?query={{ seed_query | urlencode }}{% if seed_name %}&amp;name={{ seed_name | urlencode }}{% endif %}">
+            New collection from this book&hellip;
+        </a>
+    </p>
+</section>

--- a/src/bookery/web/templates/base.html
+++ b/src/bookery/web/templates/base.html
@@ -11,6 +11,10 @@
     <a class="skip-link" href="#main">Skip to main content</a>
     <header>
         <a class="logo" href="{{ url_for('web.books') }}">Bookery</a>
+        <nav class="site-nav" aria-label="Primary">
+            <a href="{{ url_for('web.books') }}">Books</a>
+            <a href="{{ url_for('web.collections_list') }}">Collections</a>
+        </nav>
     </header>
     <main id="main">
         {% with messages = get_flashed_messages(with_categories=True) %}

--- a/tests/e2e/test_collection_web.py
+++ b/tests/e2e/test_collection_web.py
@@ -261,3 +261,69 @@ class TestConversionGateEndToEnd:
         # And the snapshot is genuinely static: removing the book sticks.
         catalog.remove_books_from_collection(cid, [1])
         assert catalog.resolve_collection_member_ids(cid) == []
+
+
+class TestBookDetailMembershipEndToEnd:
+    def test_add_book_to_static_collection_from_its_detail(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        """Adding from the book page persists membership the collection then resolves."""
+        cid = catalog.create_collection("Favorites")
+
+        resp = client.post("/books/1/add-to-collection", data={"collection_id": str(cid)})
+
+        assert resp.status_code == 200
+        assert "Favorites" in resp.data.decode()
+        assert catalog.resolve_collection_member_ids(cid) == [1]
+
+    def test_add_to_rule_collection_from_book_is_rejected(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        """A rule-based collection is excluded from the picker and rejected on POST."""
+        cid = catalog.create_collection("Dune Saga", query="series:Dune")
+
+        detail = client.get("/books/1").data.decode()
+        # The rule collection is not offered as an add target.
+        select = (
+            detail[detail.index("add-collection-select") :]
+            if "add-collection-select" in detail
+            else ""
+        )
+        assert "Dune Saga" not in select
+
+        resp = client.post("/books/1/add-to-collection", data={"collection_id": str(cid)})
+        assert resp.status_code == 200
+        # The guard wrote no static collection_books row: the book's static
+        # memberships still exclude the rule collection.
+        memberships = [c["name"] for c in catalog.get_collections_for_book(1)]
+        assert "Dune Saga" not in memberships
+
+    def test_quick_create_link_seeds_series_query(self, client) -> None:
+        """Dune has a series, so the seed query targets series, with a name prefill."""
+        html_text = client.get("/books/1").data.decode()
+        assert "/collections/new?query=" in html_text
+        assert "series" in html_text and "Dune" in html_text
+
+
+class TestCollectionDeleteModalEndToEnd:
+    def test_confirm_then_delete_removes_collection(self, client, catalog: LibraryCatalog) -> None:
+        cid = catalog.create_collection("Temp")
+
+        confirm = client.get(f"/collections/{cid}/delete").data.decode()
+        assert "Your books are not deleted" in confirm
+        assert 'role="dialog"' in confirm
+
+        resp = client.post(f"/collections/{cid}/delete", follow_redirects=False)
+        assert resp.status_code in (302, 303)
+        assert catalog.get_collection_by_id(cid) is None
+
+    def test_cancel_returns_to_detail_and_keeps_collection(
+        self, client, catalog: LibraryCatalog
+    ) -> None:
+        cid = catalog.create_collection("Keep Me")
+
+        # The confirm panel's Cancel target is the collection detail view.
+        client.get(f"/collections/{cid}/delete")
+        detail = client.get(f"/collections/{cid}").data.decode()
+        assert "Keep Me" in detail
+        assert catalog.get_collection_by_id(cid) is not None

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -60,6 +60,7 @@ def mock_catalog():
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
     catalog.get_collections_for_book.return_value = []
+    catalog.list_collections.return_value = []
     catalog.get_book_statuses.return_value = {}
     catalog.get_book_status.return_value = None
     catalog.get_device_read_state_for_book.return_value = None

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -123,6 +123,7 @@ def mock_catalog():
     catalog.get_tags_for_book.return_value = []
     catalog.get_genres_for_book.return_value = []
     catalog.get_collections_for_book.return_value = []
+    catalog.list_collections.return_value = []
     catalog.get_book_statuses.return_value = {}
     catalog.get_book_status.return_value = None
     catalog.get_device_read_state_for_book.return_value = None

--- a/tests/web/test_book_collections.py
+++ b/tests/web/test_book_collections.py
@@ -91,3 +91,19 @@ class TestAddBookToCollection:
         mock_catalog.get_by_id.return_value = None
         resp = client.post("/books/99/add-to-collection", data={"collection_id": "7"})
         assert resp.status_code == 404
+
+
+class TestCollectionAddBooksGuard:
+    def test_add_books_to_rule_collection_rejected(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            8, "Sci-Fi", query="genre:scifi"
+        )
+
+        resp = client.post(
+            "/collections/8/add-books",
+            data={"book_ids": ["1"]},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code in (302, 303)
+        mock_catalog.add_books_to_collection.assert_not_called()

--- a/tests/web/test_book_collections.py
+++ b/tests/web/test_book_collections.py
@@ -1,0 +1,93 @@
+# ABOUTME: Integration tests for the book-detail Collections section (issue #256).
+# ABOUTME: Covers add-to-static, rule-collection guards, membership list + remove.
+
+import re
+
+from tests.web.conftest import make_book
+
+
+def _collection(cid, name, query=None):
+    return {"id": cid, "name": name, "description": None, "query": query}
+
+
+class TestBookDetailCollectionsSection:
+    def test_detail_shows_collections_section(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_collections_for_book.return_value = []
+        mock_catalog.list_collections.return_value = [_collection(7, "Favorites")]
+
+        html = client.get("/books/1").data.decode()
+
+        assert "Collections" in html
+        assert 'name="collection_id"' in html  # the add-to-collection select
+
+    def test_select_lists_static_excludes_rule(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_collections_for_book.return_value = []
+        mock_catalog.list_collections.return_value = [
+            _collection(7, "Favorites"),
+            _collection(8, "Sci-Fi Rule", query="genre:scifi"),
+        ]
+
+        html = client.get("/books/1").data.decode()
+
+        # The <select> offers the static collection but not the rule-based one.
+        select = re.search(r"<select[^>]*name=\"collection_id\".*?</select>", html, re.DOTALL)
+        assert select, "Add-to-collection select must render"
+        assert "Favorites" in select.group(0)
+        assert "Sci-Fi Rule" not in select.group(0)
+
+    def test_membership_list_shows_remove_form(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_collections_for_book.return_value = [_collection(7, "Favorites")]
+        mock_catalog.list_collections.return_value = [_collection(7, "Favorites")]
+
+        html = client.get("/books/1").data.decode()
+
+        assert "Favorites" in html
+        assert "/collections/7/remove-book/1" in html
+
+    def test_quick_create_link_seeds_author_query(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1, authors=["Frank Herbert"])
+        mock_catalog.get_collections_for_book.return_value = []
+        mock_catalog.list_collections.return_value = []
+
+        html = client.get("/books/1").data.decode()
+
+        assert "/collections/new?query=" in html
+        assert "Frank" in html and "Herbert" in html
+
+
+class TestAddBookToCollection:
+    def test_add_to_static_calls_catalog(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_collection_by_id.return_value = _collection(7, "Favorites")
+        mock_catalog.get_collections_for_book.return_value = [_collection(7, "Favorites")]
+        mock_catalog.list_collections.return_value = [_collection(7, "Favorites")]
+
+        resp = client.post("/books/1/add-to-collection", data={"collection_id": "7"})
+
+        assert resp.status_code == 200
+        mock_catalog.add_books_to_collection.assert_called_once_with(7, [1])
+        # Outer-swap returns the refreshed membership section.
+        assert "Favorites" in resp.data.decode()
+
+    def test_add_to_rule_collection_rejected(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog.get_collection_by_id.return_value = _collection(
+            8, "Sci-Fi", query="genre:scifi"
+        )
+        mock_catalog.get_collections_for_book.return_value = []
+        mock_catalog.list_collections.return_value = [
+            _collection(8, "Sci-Fi", query="genre:scifi")
+        ]
+
+        resp = client.post("/books/1/add-to-collection", data={"collection_id": "8"})
+
+        assert resp.status_code == 200
+        mock_catalog.add_books_to_collection.assert_not_called()
+
+    def test_add_missing_book_404(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = None
+        resp = client.post("/books/99/add-to-collection", data={"collection_id": "7"})
+        assert resp.status_code == 404

--- a/tests/web/test_collection_delete.py
+++ b/tests/web/test_collection_delete.py
@@ -1,0 +1,42 @@
+# ABOUTME: Integration tests for the collection delete-confirmation modal (issue #256).
+# ABOUTME: Covers the confirm GET partial, the detail-page trigger, and confirmed delete.
+
+import re
+
+
+def _collection(cid=1, name="Favorites", query=None):
+    return {"id": cid, "name": name, "description": None, "query": query}
+
+
+class TestCollectionDeleteConfirm:
+    def test_confirm_renders_dialog_with_reassurance(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(1, "Favorites")
+
+        html = client.get("/collections/1/delete").data.decode()
+
+        assert 'role="dialog"' in html
+        assert "aria-modal" in html
+        assert "Favorites" in html
+        assert "Your books are not deleted" in html
+
+    def test_confirm_missing_collection_404(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = None
+        assert client.get("/collections/99/delete").status_code == 404
+
+    def test_detail_page_has_delete_trigger(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(1, "Favorites")
+        mock_catalog.get_collection_books.return_value = []
+
+        html = client.get("/collections/1").data.decode()
+
+        # A Delete control that opens the confirm modal via htmx GET.
+        trigger = re.search(r"hx-get=\"[^\"]*/collections/1/delete\"", html)
+        assert trigger, "Collection detail must expose a Delete trigger"
+
+    def test_confirmed_delete_removes_row_and_redirects(self, mock_catalog, client):
+        mock_catalog.get_collection_by_id.return_value = _collection(1, "Favorites")
+
+        resp = client.post("/collections/1/delete", follow_redirects=False)
+
+        assert resp.status_code in (302, 303)
+        mock_catalog.delete_collection.assert_called_once_with(1)

--- a/tests/web/test_nav.py
+++ b/tests/web/test_nav.py
@@ -1,0 +1,18 @@
+# ABOUTME: Tests for the primary site navigation in the web UI header.
+# ABOUTME: Ensures Books and Collections are reachable from every page's header.
+
+import re
+
+
+class TestSiteNav:
+    def test_books_page_has_collections_nav_link(self, client):
+        html = client.get("/books").data.decode()
+        nav = re.search(r"<nav[^>]*site-nav.*?</nav>", html, re.DOTALL)
+        assert nav, "Header must include the site-nav block"
+        assert 'href="/collections"' in nav.group(0)
+        assert 'href="/books"' in nav.group(0)
+
+    def test_collections_page_has_nav_link(self, mock_catalog, client):
+        mock_catalog.list_collections.return_value = []
+        html = client.get("/collections").data.decode()
+        assert 'href="/collections"' in html


### PR DESCRIPTION
## Summary
Completes the remaining open slice of the Collections epic (#179, slice 5 #238): the web UI can now manage a book's collection membership from its own page, seed a new rule collection from a book, and delete collections safely. Also adds the previously-missing header navigation to reach `/collections` at all.

## Changes
- **`web/templates/base.html` + `static/style.css`**: primary header nav (Books / Collections) — `/collections` had no clickable path before.
- **`web/routes.py`**:
  - `book_detail` now passes static collections to the template (shared `context` dict, dedupes the two render branches).
  - NEW `POST /books/<id>/add-to-collection` — adds to a static collection, re-renders the membership section (outer-swap); rejects rule-based targets.
  - `collection_add_books` guarded against rule-based collections (derived membership can't be hand-edited).
  - `collection_new_form` honors a `?name=` prefill for quick-create.
  - NEW `GET /collections/<id>/delete` — renders a confirmation panel; existing `POST` stays the confirm action.
- **NEW templates**: `_detail_collections.html` (membership list + inline Remove, static-only add picker, quick-create link seeding `series:`/`author:`), `_collection_delete_confirm.html` (`role=dialog`, reassurance copy, Cancel focused).
- **`_detail.html` / `_collection_detail.html`**: include the new section / add the Delete trigger.
- **README**: documents the web collection-management surface.

## Testing
- [x] Unit + integration + e2e: 2441 pass
- [x] New: `tests/web/test_book_collections.py`, `test_collection_delete.py`, `test_nav.py`, plus 6 e2e flows in `tests/e2e/test_collection_web.py`
- [x] ruff lint + format + pyright clean

## Related Issues
Closes #256

Claude-Session: https://claude.ai/code/session_01NcntSkXWoXTmPjTaDop5TY