### PR TITLE
Add list-view UX pass: select-all, per-row action menu, in-dialog delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ uv.lock
 # Bookery runtime
 *.db
 bookery-output/
+
+# Playwright MCP screenshot/snapshot cache
+.playwright-mcp/

--- a/src/bookery/web/routes.py
+++ b/src/bookery/web/routes.py
@@ -760,6 +760,7 @@ def delete_confirm(book_id):
         tag_count=len(tags),
         genre_count=len(genres),
         duplicate_count=duplicate_count,
+        in_dialog=bool(request.args.get("in_dialog")),
     )
 
 

--- a/src/bookery/web/static/style.css
+++ b/src/bookery/web/static/style.css
@@ -1078,6 +1078,88 @@ body:has(input[form="bulk-status-form"]:checked) .bulk-status-actions {
     z-index: 1;
 }
 
+/* Per-row action menu — a plain native <details>, styled locally so it reads
+   as a compact kebab button + popover (Pico's .dropdown is select-shaped and
+   not what we want here). */
+.book-table th.book-row-actions,
+.book-table td.book-row-actions {
+    width: 2.25rem;
+    text-align: right;
+    padding-left: 0;
+}
+.row-actions {
+    position: relative;
+    margin: 0;
+}
+.row-actions > summary {
+    list-style: none;                /* drop the disclosure triangle */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.8rem;
+    height: 1.8rem;
+    border-radius: 5px;
+    color: var(--color-muted);
+    font-size: 1.15rem;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+}
+.row-actions > summary::-webkit-details-marker {
+    display: none;
+}
+.row-actions > summary::after {
+    display: none;                   /* drop Pico's accordion chevron */
+}
+.row-actions > summary:hover,
+.row-actions[open] > summary {
+    background: var(--color-hover);
+    color: var(--color-text);
+}
+/* Popover anchored to the trigger's right edge — the actions column is the
+   table's last column, so a left-anchored menu would spill off-screen. */
+.row-actions > ul {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 20;
+    margin: 0.25rem 0 0;
+    padding: 0.25rem;
+    min-width: 9rem;
+    list-style: none;
+    text-align: left;                /* the table cell is right-aligned */
+    background: #fff;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+.row-actions > ul li {
+    margin: 0;
+    list-style: none;
+}
+.row-actions > ul a {
+    display: block;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    color: var(--color-text);
+    text-decoration: none;
+    white-space: nowrap;
+}
+.row-actions > ul a:hover {
+    background: var(--color-hover);
+}
+.row-actions > ul a.row-action-delete {
+    color: var(--color-destructive);
+}
+
+/* Row-action delete reuses the shared confirm panel inside a plain dialog. */
+#row-dialog {
+    max-width: 32rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 1.25rem;
+}
+
 /* === "Card Catalog" editorial layer (#275) =============================== */
 
 @font-face {

--- a/src/bookery/web/templates/_book_list.html
+++ b/src/bookery/web/templates/_book_list.html
@@ -41,7 +41,11 @@
     <table class="book-table">
         <thead>
             <tr>
-                <th class="book-row-select" aria-label="Select"></th>
+                <th class="book-row-select">
+                    <input type="checkbox"
+                           class="select-all"
+                           aria-label="Select all books on this page">
+                </th>
                 <th class="book-row-cover" aria-label="Cover"></th>
                 <th>{{ sort_link('Title', 'title') }}</th>
                 <th>{{ sort_link('Author', 'author') }}</th>
@@ -50,6 +54,7 @@
                 <th>Publisher</th>
                 <th>{{ sort_link('Added', 'added') }}</th>
                 <th>Enriched</th>
+                <th class="book-row-actions" aria-label="Actions"></th>
             </tr>
         </thead>
         <tbody>
@@ -88,6 +93,24 @@
                 <td>{{ book.metadata.publisher or '' }}</td>
                 <td>{{ book.date_added or '' }}</td>
                 <td>{% if book.metadata_matched_at %}&#10003;{% endif %}</td>
+                <td class="book-row-actions">
+                    {# Native <details> menu, styled locally (not Pico's .dropdown,
+                       which is select-shaped). Edit and Enrich are plain navigations
+                       to their full pages; Delete loads the shared confirm partial
+                       into the page-level #row-dialog. #}
+                    <details class="row-actions">
+                        <summary aria-label="Actions for {{ book.metadata.title }}">&#8942;</summary>
+                        <ul>
+                            <li><a href="{{ url_for('web.edit_form', book_id=book.id, return_to=list_url or none) }}">Edit</a></li>
+                            <li><a href="{{ url_for('web.enrich_form', book_id=book.id, return_to=list_url or none) }}">Enrich</a></li>
+                            <li><a href="#"
+                                   class="row-action-delete"
+                                   hx-get="{{ url_for('web.delete_confirm', book_id=book.id, in_dialog=1) }}"
+                                   hx-target="#row-dialog"
+                                   hx-swap="innerHTML">Delete&hellip;</a></li>
+                        </ul>
+                    </details>
+                </td>
             </tr>
             {% endfor %}
         </tbody>

--- a/src/bookery/web/templates/_delete_confirm.html
+++ b/src/bookery/web/templates/_delete_confirm.html
@@ -43,10 +43,18 @@
                 class="btn btn-destructive"
                 name="keep_file"
                 value="1">Delete row only</button>
+        {% if in_dialog %}
+        {# Loaded into the list page's #row-dialog — no #book-content to swap
+           back to, so Cancel just closes the dialog. #}
+        <button type="button"
+                class="btn btn-secondary"
+                onclick="this.closest('dialog').close()">Cancel</button>
+        {% else %}
         <button type="button"
                 class="btn btn-secondary"
                 hx-get="{{ url_for('web.book_detail', book_id=book.id) }}"
                 hx-target="#book-content"
                 hx-swap="innerHTML">Cancel</button>
+        {% endif %}
     </form>
 </section>

--- a/src/bookery/web/templates/list.html
+++ b/src/bookery/web/templates/list.html
@@ -25,4 +25,20 @@
 <div id="book-list">
     {% include "_book_list.html" %}
 </div>
+
+{# Row-action Delete loads the confirm partial here, then the dialog opens
+   itself on swap. Esc / backdrop close it; the confirm's Cancel button does
+   too (in_dialog mode). On success the POST sends HX-Redirect to /books. #}
+<dialog id="row-dialog" hx-on::after-swap="this.showModal()"></dialog>
+
+<script>
+    // Select-all toggles every row checkbox in the table. Delegated on
+    // document so it survives htmx swaps of #book-list.
+    document.addEventListener("change", function (e) {
+        if (!e.target.matches?.(".select-all")) return;
+        document
+            .querySelectorAll(".book-table input[name='ids']")
+            .forEach(function (cb) { cb.checked = e.target.checked; });
+    });
+</script>
 {% endblock %}

--- a/tests/web/test_delete.py
+++ b/tests/web/test_delete.py
@@ -126,6 +126,17 @@ class TestDeleteConfirmGet:
         response = client.get("/books/999/delete")
         assert response.status_code == 404
 
+    def test_in_dialog_cancel_closes_dialog(self, mock_catalog, client):
+        mock_catalog.get_by_id.return_value = make_book(1)
+        mock_catalog._conn.execute.return_value.fetchone.return_value = (0,)
+
+        html = client.get("/books/1/delete?in_dialog=1").data.decode()
+
+        # Loaded into the list dialog: Cancel closes it rather than swapping
+        # back to a #book-content region that doesn't exist there.
+        assert "dialog').close()" in html
+        assert "#book-content" not in html
+
 
 class TestDeleteConfirmFilePathNone:
     def test_renders_when_no_output_path(self, mock_catalog, client):

--- a/tests/web/test_list_browse.py
+++ b/tests/web/test_list_browse.py
@@ -226,6 +226,45 @@ class TestBooksRoutePagination:
         assert "Showing 1&ndash;1 of 1" in html
 
 
+class TestListRowActions:
+    """Per-row dropdown (Edit/Enrich/Delete) and the select-all control."""
+
+    def test_renders_select_all_checkbox(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        html = client.get("/books").data.decode()
+        assert 'class="select-all"' in html
+
+    def test_row_dropdown_links_to_edit_and_enrich(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(7)], total=1)
+
+        html = client.get("/books").data.decode()
+        assert "/books/7/edit" in html
+        assert "/books/7/enrich" in html
+
+    def test_row_delete_loads_confirm_into_dialog(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(7)], total=1)
+
+        html = client.get("/books").data.decode()
+        assert "/books/7/delete?in_dialog=1" in html
+        assert 'hx-target="#row-dialog"' in html
+
+    def test_full_page_carries_dialog_and_select_all_script(self, mock_catalog, client):
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        html = client.get("/books").data.decode()
+        assert 'id="row-dialog"' in html
+        assert ".select-all" in html  # the toggle script
+
+    def test_partial_swap_omits_dialog_chrome(self, mock_catalog, client):
+        # The dialog + script live in the full-page wrapper, not the swapped
+        # partial — an htmx refresh must not duplicate them.
+        _stub_browse(mock_catalog, books=[make_book(1)], total=1)
+
+        html = client.get("/books", headers={"HX-Request": "true"}).data.decode()
+        assert 'id="row-dialog"' not in html
+
+
 # --- /books route: sortable columns ---
 
 


### PR DESCRIPTION
## Summary
A UX pass on the Library list view, improving both batch selection and per-row actions.

- **Select-all** checkbox in the table header toggles every row's checkbox.
- **Per-row kebab menu** (`⋮`) with quick **Edit · Enrich · Delete…** — actions that previously required opening the detail page first.
- **In-dialog delete** so a row can be deleted in one click without leaving the list.

## Changes
- **templates/_book_list.html**: select-all checkbox in the header; a per-row actions column with a native `<details>` menu (Edit/Enrich link to full pages; Delete loads the confirm partial into the page-level dialog).
- **templates/list.html**: page-level `<dialog id="row-dialog">` (opens itself on htmx swap) + a delegated select-all listener that survives htmx swaps.
- **templates/_delete_confirm.html**: `in_dialog` branch so Cancel closes the dialog instead of swapping into `#book-content` (which only exists on the detail page).
- **routes.py**: `delete_confirm` passes `in_dialog` from the query string.
- **static/style.css**: local styling for the kebab button + popover (deliberately *not* Pico's select-shaped `.dropdown`), right-anchored so the menu stays on screen in the last column; destructive color on Delete.

## Implementation notes
- The contextual bulk-action bar (hidden until a row is selected) already existed via `:has()` and was left as-is.
- No per-row menu on mobile cards — a card is a single `<a>`, so nesting interactive controls would be invalid HTML; the card still taps through to detail.

## Testing
- [x] 407 web tests pass (`uv run pytest tests/web`), including new tests for select-all, the row dropdown links, in-dialog delete, and partial-swap chrome isolation
- [x] ruff lint + format clean; pyright clean
- [x] Manually verified in-browser via Playwright at 1440px: dropdown renders/positions correctly, fits on screen, Delete opens the dialog, Cancel closes it, console clean

https://claude.ai/code/session_01NcntSkXWoXTmPjTaDop5TY